### PR TITLE
provisioning/adapter/incus: Fix changed API for incus-os system/security

### DIFF
--- a/internal/provisioning/adapter/incus/client.go
+++ b/internal/provisioning/adapter/incus/client.go
@@ -95,7 +95,7 @@ func (c client) GetOSData(ctx context.Context, server provisioning.Server) (api.
 		return api.OSData{}, fmt.Errorf("Unexpected response metadata while fetching OS network information from %q: %w", server.ConnectionURL, err)
 	}
 
-	resp, _, err = client.RawQuery(http.MethodGet, "/os/1.0/system/encryption", http.NoBody, "")
+	resp, _, err = client.RawQuery(http.MethodGet, "/os/1.0/system/security", http.NoBody, "")
 	if err != nil {
 		return api.OSData{}, fmt.Errorf("Get OS encryption data from %q failed: %w", server.ConnectionURL, err)
 	}

--- a/internal/provisioning/adapter/incus/client_test.go
+++ b/internal/provisioning/adapter/incus/client_test.go
@@ -174,7 +174,7 @@ func TestClient(t *testing.T) {
 }`),
 							},
 						},
-						// GET /os/1.0/system/encryption
+						// GET /os/1.0/system/security
 						{
 							Value: response{
 								statusCode: http.StatusOK,
@@ -190,7 +190,7 @@ func TestClient(t *testing.T) {
 					},
 
 					assertErr: require.NoError,
-					wantPaths: []string{"GET /os/1.0/system/network", "GET /os/1.0/system/encryption"},
+					wantPaths: []string{"GET /os/1.0/system/network", "GET /os/1.0/system/security"},
 					assertResult: func(t *testing.T, res any) {
 						t.Helper()
 						wantResources := api.OSData{
@@ -233,7 +233,7 @@ func TestClient(t *testing.T) {
 }`),
 							},
 						},
-						// GET /os/1.0/system/encryption
+						// GET /os/1.0/system/security
 						{
 							Value: response{
 								statusCode: http.StatusInternalServerError,
@@ -242,7 +242,7 @@ func TestClient(t *testing.T) {
 					},
 
 					assertErr:    require.Error,
-					wantPaths:    []string{"GET /os/1.0/system/network", "GET /os/1.0/system/encryption"},
+					wantPaths:    []string{"GET /os/1.0/system/network", "GET /os/1.0/system/security"},
 					assertResult: noResult,
 				},
 				{
@@ -264,7 +264,7 @@ func TestClient(t *testing.T) {
 }`),
 							},
 						},
-						// GET /os/1.0/system/encryption
+						// GET /os/1.0/system/security
 						{
 							Value: response{
 								statusCode: http.StatusOK,
@@ -276,7 +276,7 @@ func TestClient(t *testing.T) {
 					},
 
 					assertErr:    require.Error,
-					wantPaths:    []string{"GET /os/1.0/system/network", "GET /os/1.0/system/encryption"},
+					wantPaths:    []string{"GET /os/1.0/system/network", "GET /os/1.0/system/security"},
 					assertResult: noResult,
 				},
 				{


### PR DESCRIPTION
Incus OS API for security / encryption API changed in https://github.com/lxc/incus-os/pull/187, in particular the route changed in https://github.com/lxc/incus-os/pull/187/files#diff-cb0a1c3806caba5ab6b4928dca194ec02f1912bebab6adf8385cf5e40bbb3461L57.

CC: @gibmat 