### PR TITLE
environment: Use var dir to determine IncusOS

### DIFF
--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -110,5 +110,5 @@ const IncusOSSocket = "/run/incus-os/unix.socket"
 
 // IsIncusOS checks if the host system is running Incus OS.
 func IsIncusOS() bool {
-	return file.PathExists(IncusOSSocket)
+	return file.PathExists("/var/lib/incus-os/")
 }


### PR DESCRIPTION
@stgraber In https://github.com/lxc/incus/pull/2364/files Incus has been changed to check the var dir in order to determine, if it runs on top of IncusOS. Therefore I prepared the same change also for Operations Center.