### PR TITLE
Unify json and yaml marshalling tags for system config

### DIFF
--- a/internal/api/daemon.go
+++ b/internal/api/daemon.go
@@ -583,7 +583,7 @@ func (d *Daemon) setupBackgroundTasks(
 	}
 
 	var updateSourceOptions []task.EveryOption
-	if config.GetUpdates().SourcePollSkipFirst {
+	if config.SourcePollSkipFirst() {
 		updateSourceOptions = append(updateSourceOptions, task.SkipFirst)
 	}
 

--- a/internal/api/daemon.go
+++ b/internal/api/daemon.go
@@ -571,6 +571,10 @@ func (d *Daemon) setupBackgroundTasks(
 	serverSvc provisioning.ServerService,
 	clusterSvc provisioning.ClusterService,
 ) {
+	if config.IsBackgroundTasksDisabled() {
+		return
+	}
+
 	// Start background task to refresh updates from the sources.
 	refreshUpdatesFromSourcesTask := func(ctx context.Context) {
 		slog.InfoContext(ctx, "Refresh updates triggered")

--- a/internal/config/daemon/config_testing.go
+++ b/internal/config/daemon/config_testing.go
@@ -20,8 +20,6 @@ func InitTest(t *testing.T) {
 	err := yaml.Unmarshal(defaultConfig, &cfg)
 	require.NoError(t, err)
 
-	cfg.Updates.SourcePollSkipFirst = true
-
 	globalConfigInstance = cfg
 }
 

--- a/internal/config/daemon/env.go
+++ b/internal/config/daemon/env.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"os"
+	"strconv"
+)
+
+// SourcePollSkipFirst checks OPERATIONS_CENTER_SOURCE_POLL_SKIP_FIRST env var.
+// If the env var has a value indicating true ("1", "t", "T", "true", "TRUE",
+// "True"), true is returned. False is returned otherwise.
+//
+// If true, the first execution of the task to update the updates from the
+// configured source is skipped. This is mainly useful during development or for
+// integration tests.
+func SourcePollSkipFirst() bool {
+	env := os.Getenv(ApplicationEnvPrefix + "_SOURCE_POLL_SKIP_FIRST")
+
+	value, _ := strconv.ParseBool(env)
+	return value
+}

--- a/internal/config/daemon/env.go
+++ b/internal/config/daemon/env.go
@@ -5,6 +5,19 @@ import (
 	"strconv"
 )
 
+// IsBackgroundTasksDisabled checks OPERATIONS_CENTER_DISABLE_BACKGROUND_TASKS
+// env var. If the env var has a value indicating true ("1", "t", "T", "true",
+// "TRUE", "True"), true is returned. False is returned otherwise.
+//
+// If true, all background tasks are disabled. This is mainly useful during
+// development or for integration tests.
+func IsBackgroundTasksDisabled() bool {
+	env := os.Getenv(ApplicationEnvPrefix + "_DISABLE_BACKGROUND_TASKS")
+
+	value, _ := strconv.ParseBool(env)
+	return value
+}
+
 // SourcePollSkipFirst checks OPERATIONS_CENTER_SOURCE_POLL_SKIP_FIRST env var.
 // If the env var has a value indicating true ("1", "t", "T", "true", "TRUE",
 // "True"), true is returned. False is returned otherwise.

--- a/shared/api/system.go
+++ b/shared/api/system.go
@@ -99,12 +99,6 @@ type SystemUpdatesPut struct {
 	// Source is the URL of the origin, the updates should be fetched from.
 	Source string `json:"source" yaml:"source"`
 
-	// If SourcePollSkipFirst is true, the first execution of the task to update
-	// the updates from the configured source is skipped. This is mainly useful
-	// for development and since it only affects the first execution after the
-	// start of the daemon, this setting is not available thought the JSON API.
-	SourcePollSkipFirst bool `json:"source_skip_first_update" yaml:"source_skip_first_update"`
-
 	// Root CA certificate used to verify the signature of index.sjson.
 	// Example: -----BEGIN CERTIFICATE-----\nMII...\n-----END CERTIFICATE-----
 	SignatureVerificationRootCA string `json:"signature_verification_root_ca" yaml:"signature_verification_root_ca"`

--- a/shared/api/system.go
+++ b/shared/api/system.go
@@ -7,11 +7,11 @@ package api
 type SystemCertificatePost struct {
 	// The new certificate (X509 PEM encoded) for the system (server certificate).
 	// Example: X509 PEM certificate
-	Certificate string `json:"certificate"`
+	Certificate string `json:"certificate" yaml:"certificate"`
 
 	// The new certificate key (X509 PEM encoded) for the system (server key).
 	// Example: X509 PEM certificate key
-	Key string `json:"key"`
+	Key string `json:"key" yaml:"key"`
 }
 
 // SystemNetwork represents the system's network configuration.
@@ -103,7 +103,7 @@ type SystemUpdatesPut struct {
 	// the updates from the configured source is skipped. This is mainly useful
 	// for development and since it only affects the first execution after the
 	// start of the daemon, this setting is not available thought the JSON API.
-	SourcePollSkipFirst bool `json:"-" yaml:"source_skip_first_update"`
+	SourcePollSkipFirst bool `json:"source_skip_first_update" yaml:"source_skip_first_update"`
 
 	// Root CA certificate used to verify the signature of index.sjson.
 	// Example: -----BEGIN CERTIFICATE-----\nMII...\n-----END CERTIFICATE-----


### PR DESCRIPTION
There's a comment about `SourcePollSkipFirst` not being available via the json API, but since seeds can be json or yaml, I think we need to support it.