### PR TITLE
Apply Incus preseed certificates

### DIFF
--- a/internal/provisioning/adapter/terraform/templates/resources_certificates.tf.gotmpl
+++ b/internal/provisioning/adapter/terraform/templates/resources_certificates.tf.gotmpl
@@ -1,0 +1,11 @@
+{{- range .IncusPreseed.Certificates -}}
+resource "incus_certificate" "{{ .Name }}" {
+  name        = "{{ .Name }}"
+  description = "{{ .Description }}"
+  restricted  = {{ .Restricted }}
+  projects    = {{ toJson .Projects }}
+  type        = "{{ .Type }}"
+  certificate = "{{ .Certificate }}"
+}
+
+{{ end -}}

--- a/internal/provisioning/adapter/terraform/terraform_test.go
+++ b/internal/provisioning/adapter/terraform/terraform_test.go
@@ -373,6 +373,7 @@ func TestTerraform_GetArchive(t *testing.T) {
 			expectedFilesFound := map[string]bool{
 				"data_cluster.tf":              false,
 				"providers.tf":                 false,
+				"resources_certificates.tf":    false,
 				"resources_networks.tf":        false,
 				"resources_profiles.tf":        false,
 				"resources_projects.tf":        false,


### PR DESCRIPTION
I am not sure, if I have the complete picture for the feature request in #302, but in order to simply pass the certificates, that are present in the application preseed configuration to Incus though Terraform, this should do the trick.

Is there anything that I am missing?

Fixes: #302 