### PR TITLE
devcontainer: Fix docker in devcontainer on trixie

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -76,7 +76,9 @@
   },
 
   "features": {
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    }
   },
 
   "postCreateCommand": "go mod download",


### PR DESCRIPTION
When looking at the issue with the devcontainer again, I found a quick fix, which unblocks the usage of trixie for the devcontainer without the need to refactor the integration tests, which currently use Testcontainers for OpenFGA.

Additionally I created an issue for the (now optional) refactoring of the integration tests: https://github.com/FuturFusion/operations-center/issues/319

Resolves: #309 