### PR TITLE
Update terraform configuration to incus terraform provider 1.0.0

### DIFF
--- a/internal/provisioning/adapter/terraform/templates/providers.tf.gotmpl
+++ b/internal/provisioning/adapter/terraform/templates/providers.tf.gotmpl
@@ -4,17 +4,17 @@ terraform {
   required_providers {
     incus = {
       source  = "lxc/incus"
-      version = ">=0.5.1"
+      version = "~>1.0.0"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = ">=3.7.2"
+      version = "~>3.7.2"
     }
 
     null = {
       source  = "hashicorp/null"
-      version = ">=3.2.4"
+      version = "~>3.2.4"
     }
   }
 }
@@ -29,12 +29,11 @@ provider "incus" {
   // This can also be set with the INCUS_ACCEPT_SERVER_CERTIFICATE environment variable.
   accept_remote_certificate = true
 
+  default_remote = "{{ .ClusterName }}"
+
   remote {
     name    = "{{ .ClusterName }}"
-    default = true
-    scheme  = "https"
     address = "{{ .ClusterAddress }}"
-    port    = "{{ .ClusterPort }}"
   }
 }
 

--- a/internal/provisioning/adapter/terraform/terraform.go
+++ b/internal/provisioning/adapter/terraform/terraform.go
@@ -99,11 +99,6 @@ func (t terraform) Init(ctx context.Context, name string, config provisioning.Cl
 		return fmt.Errorf("Failed to parse terraform configuration templates: %w", err)
 	}
 
-	clusterAddress, err := url.Parse(config.ClusterEndpoint.GetConnectionURL())
-	if err != nil {
-		return fmt.Errorf("Failed to parse cluster endpoint connection URL: %w", err)
-	}
-
 	templateFiles, err := templatesFS.ReadDir("templates")
 	if err != nil {
 		return fmt.Errorf("Failed to read templates directory: %w", err)
@@ -134,8 +129,7 @@ func (t terraform) Init(ctx context.Context, name string, config provisioning.Cl
 
 				err = tmpl.ExecuteTemplate(targetFile, templateFile.Name(), map[string]any{
 					"ClusterName":          name,
-					"ClusterAddress":       clusterAddress.Hostname(),
-					"ClusterPort":          clusterAddress.Port(),
+					"ClusterAddress":       config.ClusterEndpoint.GetConnectionURL(),
 					"MeshTunnelInterfaces": meshTunnelInterfaces,
 					"IncusPreseed":         incusPreseed,
 				},

--- a/internal/provisioning/adapter/terraform/testdata/providers.tf
+++ b/internal/provisioning/adapter/terraform/testdata/providers.tf
@@ -4,17 +4,17 @@ terraform {
   required_providers {
     incus = {
       source  = "lxc/incus"
-      version = ">=0.5.1"
+      version = "~>1.0.0"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = ">=3.7.2"
+      version = "~>3.7.2"
     }
 
     null = {
       source  = "hashicorp/null"
-      version = ">=3.2.4"
+      version = "~>3.2.4"
     }
   }
 }
@@ -29,12 +29,11 @@ provider "incus" {
   // This can also be set with the INCUS_ACCEPT_SERVER_CERTIFICATE environment variable.
   accept_remote_certificate = true
 
+  default_remote = "foobar"
+
   remote {
     name    = "foobar"
-    default = true
-    scheme  = "https"
-    address = "127.0.0.1"
-    port    = "8443"
+    address = "https://127.0.0.1:8443"
   }
 }
 


### PR DESCRIPTION
* Adopt provider configuration to the scheme used in v1.0.0.
* Make the provider constraint more strict to prevent breaking updates of the providers.

