### PR TITLE
Allow empty connection URL only for server type Operations Center

### DIFF
--- a/internal/provisioning/server_model.go
+++ b/internal/provisioning/server_model.go
@@ -72,6 +72,10 @@ func (s Server) Validate() error {
 		return domain.NewValidationErrf(`Invalid server, ":self" is reserved for internal use and not allowed as server name`)
 	}
 
+	if s.Type != api.ServerTypeOperationsCenter && s.ConnectionURL == "" {
+		return domain.NewValidationErrf("Invalid server, connection URL can not be empty for server type %s", s.Type)
+	}
+
 	_, err := url.Parse(s.ConnectionURL)
 	if err != nil {
 		return domain.NewValidationErrf("Invalid server, connection URL is not valid: %v", err)

--- a/internal/provisioning/server_model_test.go
+++ b/internal/provisioning/server_model_test.go
@@ -35,6 +35,22 @@ one
 			assertErr: require.NoError,
 		},
 		{
+			name: "valid - type operations center with empty connection URL",
+			server: provisioning.Server{
+				Name:          "one",
+				Type:          api.ServerTypeOperationsCenter,
+				Cluster:       ptr.To("one"),
+				ConnectionURL: "",
+				Certificate: `-----BEGIN CERTIFICATE-----
+one
+-----END CERTIFICATE-----
+`,
+				Status: api.ServerStatusReady,
+			},
+
+			assertErr: require.NoError,
+		},
+		{
 			name: "error - name empty",
 			server: provisioning.Server{
 				Name:          "", // invalid
@@ -98,6 +114,25 @@ one
 				Type:          api.ServerType("invalid"), // invalid
 				Cluster:       ptr.To("one"),
 				ConnectionURL: "http://one/",
+				Certificate: `-----BEGIN CERTIFICATE-----
+one
+-----END CERTIFICATE-----
+`,
+				Status: api.ServerStatusReady,
+			},
+
+			assertErr: func(tt require.TestingT, err error, a ...any) {
+				var verr domain.ErrValidation
+				require.ErrorAs(tt, err, &verr, a...)
+			},
+		},
+		{
+			name: "error - connection URL empty",
+			server: provisioning.Server{
+				Name:          "one",
+				Type:          api.ServerTypeIncus,
+				Cluster:       ptr.To("one"),
+				ConnectionURL: "", // invalid
 				Certificate: `-----BEGIN CERTIFICATE-----
 one
 -----END CERTIFICATE-----


### PR DESCRIPTION
Followup to the change in https://github.com/FuturFusion/operations-center/commit/e22f6715756c1fe752d5c35330fa30115916c524

@stgraber I don't think, it does make sense to allow empty connection URL in general, since this might cause issues with other part of the system (e.g. polling of registered servers), so I think this should be limited to only server type operations center. This makes sense, since we decided to only allow a single operations center and it is not possible to register an operations center other than through the self register via unix socket.