### PR TITLE
Add linstor to the storage bucket parent filter

### DIFF
--- a/internal/api/api_inventory+filters.go
+++ b/internal/api/api_inventory+filters.go
@@ -47,7 +47,7 @@ func networkPeerWithParentFilter(network incusapi.Network) bool {
 
 func storageBucketWithParentFilter(storagePool incusapi.StoragePool) bool {
 	switch storagePool.Driver {
-	case "ceph", "lvmcluster":
+	case "ceph", "linstor", "lvmcluster":
 		return true
 	}
 


### PR DESCRIPTION
Linstor does not support storage buckets and therefore storage pools of driver type `linstor` need to be skipped during syncing of the storage bucket inventory.

Addressing error:

```none
Dec 05 19:20:24 55e36f75-b144-433d-8f5d-4d04d6a12337 operations-centerd[76152]: time=2025-12-05T19:20:24.818Z level=ERROR msg="<= method GetStorageBuckets returned an error" err="Storage pool driver \"linstor\" does not support buckets"
Dec 05 19:20:24 55e36f75-b144-433d-8f5d-4d04d6a12337 operations-centerd[76152]: time=2025-12-05T19:20:24.818Z level=ERROR msg="<= method SyncCluster returned an error" err="Storage pool driver \"linstor\" does not support buckets"
Dec 05 19:20:24 55e36f75-b144-433d-8f5d-4d04d6a12337 operations-centerd[76152]: time=2025-12-05T19:20:24.818Z level=ERROR msg="<= method ResyncInventory returned an error" err="Failed to resync inventory: Storage pool driver \"linstor\" does not support buckets"
Dec 05 19:20:24 55e36f75-b144-433d-8f5d-4d04d6a12337 operations-centerd[76152]: time=2025-12-05T19:20:24.818Z level=ERROR msg="Inventory update failed" err="Failed to resync inventory: Storage pool driver \"linstor\" does not support buckets"
```
