### PR TITLE
provisioning/adapter/updateserver: Fix fetching of updates with UpstreamChannel

### DIFF
--- a/internal/provisioning/adapter/updateserver/updateserver_test.go
+++ b/internal/provisioning/adapter/updateserver/updateserver_test.go
@@ -34,12 +34,12 @@ func TestUpdateServer_GetLatest(t *testing.T) {
 			statusCode: http.StatusOK,
 			updates: updateserver.UpdatesIndex{
 				Format: "1.0",
-				Updates: []provisioning.Update{
+				Updates: []updateserver.Update{
 					{
-						Version:          "1",
-						UpstreamChannels: []string{"stable", "daily"},
-						Severity:         images.UpdateSeverityNone,
-						PublishedAt:      time.Date(2025, 5, 22, 15, 21, 0, 0, time.UTC),
+						Version:     "1",
+						Channels:    []string{"stable", "daily"},
+						Severity:    images.UpdateSeverityNone,
+						PublishedAt: time.Date(2025, 5, 22, 15, 21, 0, 0, time.UTC),
 					},
 				},
 			},
@@ -62,7 +62,7 @@ func TestUpdateServer_GetLatest(t *testing.T) {
 			statusCode: http.StatusOK,
 			updates: updateserver.UpdatesIndex{
 				Format: "1.0",
-				Updates: []provisioning.Update{
+				Updates: []updateserver.Update{
 					{
 						Version:     "1",
 						Severity:    images.UpdateSeverityNone,


### PR DESCRIPTION
Separate `Update` struct in `UpdateIndex` from `provisioning.Update`.

@stgraber This change is necessary, since the channels information from the image server needs to go into `UpstreamChannels`, but without this change, this is not the case, since the JSON tag on `UpstreamChannels` in the `provisioning.Update` struct is not matching what the image server is presenting (`upstream_channels` != `channels`).
This in the end caused the updated expr-lang filters to never match.