### PR TITLE
gh actions: Replace DCO check

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -14,13 +14,4 @@ jobs:
     name: Signed-off-by (DCO)
     runs-on: ubuntu-24.04
     steps:
-    - name: Get PR Commits
-      id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@master
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Check that all commits are signed-off
-      uses: tim-actions/dco@master
-      with:
-        commits: ${{ steps.get-pr-commits.outputs.commits }}
+    - uses: KineticCafe/actions-dco@v1


### PR DESCRIPTION
Try to fix "argument list too long" problem.

Executed some test runs with GH action to verify the correct behavior for the new DCO check in #627 .