### PR TITLE
ui: Fix formatting for text on Certificate config page

### DIFF
--- a/ui/src/components/SystemCertConfiguration.tsx
+++ b/ui/src/components/SystemCertConfiguration.tsx
@@ -22,11 +22,13 @@ const SystemCertConfiguration = () => {
 
   return (
     <>
-      <h5>
-        By default Operations Center uses an automatically generated self-signed
-        TLS certificate. To replace it with a valid certificate, please provide
-        a replacement PEM-encoded X509 certificate and key.
-      </h5>
+      <div className="form-container">
+        <h6>
+          By default Operations Center uses an automatically generated
+          self-signed TLS certificate. To replace it with a valid certificate,
+          please provide a replacement PEM-encoded X509 certificate and key.
+        </h6>
+      </div>
       <SystemCertForm onSubmit={onSubmit} />
     </>
   );

--- a/ui/src/css/index.css
+++ b/ui/src/css/index.css
@@ -5,6 +5,10 @@ body {
   font-family: 'Inter', sans-serif !important;
 }
 
+h5 {
+  font-family: 'Inter', sans-serif !important;
+}
+
 .detail-table-header {
   color: #00000090;
   padding: 8px 0px;


### PR DESCRIPTION
<img width="600" alt="formatting" src="https://github.com/user-attachments/assets/4806f5fe-ed9f-4619-a44f-a6e66fde1beb" />

Closes: #652 
