### PR TITLE
e2e-tests: use incus wait

### DIFF
--- a/e2e_tests/helpers.go
+++ b/e2e_tests/helpers.go
@@ -303,6 +303,13 @@ func waitAgentRunningWithContext(ctx context.Context, t *testing.T, vm string, a
 		debugCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 
+		respList := runWithContext(debugCtx, t, "incus list")
+		if respList.Success() {
+			t.Logf("incus list (after incus wait error for %q):\n%s", vm, respList.Output())
+		} else {
+			t.Logf("failed to get incus list (after incus wait error for %q): %s", vm, respList.Error())
+		}
+
 		respConsole := runWithContext(debugCtx, t, "incus console %s --show-log", vm)
 		if respConsole.Success() {
 			t.Logf("incus console log for %q:\n%s", vm, respConsole.Output())

--- a/e2e_tests/setup.go
+++ b/e2e_tests/setup.go
@@ -441,7 +441,9 @@ func createIncusOSInstances(t *testing.T, incusOSPreseededISOFilename string) {
 				}
 
 				t.Logf("Waiting for %s to complete installation", name)
-				err = waitAgentRunningWithContext(errgrpctx, t, name)
+				agentWaitCtx, cancel := context.WithTimeout(errgrpctx, strechedTimeout(3*time.Minute))
+				err = waitAgentRunningWithContext(agentWaitCtx, t, name)
+				cancel()
 				if err != nil {
 					return err
 				}
@@ -472,7 +474,9 @@ func createIncusOSInstances(t *testing.T, incusOSPreseededISOFilename string) {
 			}
 
 			t.Logf("Waiting for %s to be ready", name)
-			err = waitAgentRunningWithContext(errgrpctx, t, name)
+			agentWaitCtx, cancel := context.WithTimeout(errgrpctx, strechedTimeout(3*time.Minute))
+			err = waitAgentRunningWithContext(agentWaitCtx, t, name)
+			cancel()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
@stgraber changed to `incus wait`, but this does not fix the issues we observe in the daily tests.