### PR TITLE
cli: fix query command path argument handling

### DIFF
--- a/internal/cli/cmds/query.go
+++ b/internal/cli/cmds/query.go
@@ -46,7 +46,7 @@ func (c *CmdQuery) validateArgsAndFlags(cmd *cobra.Command, args []string) error
 }
 
 func (c *CmdQuery) run(cmd *cobra.Command, args []string) error {
-	query, _ := strings.CutSuffix(args[0], "/1.0")
+	query, _ := strings.CutPrefix(args[0], "/1.0")
 
 	resp, err := c.OCClient.DoRequest(cmd.Context(), c.flagRequest, query, nil, bytes.NewBuffer([]byte(c.flagData)))
 	if err != nil {


### PR DESCRIPTION
@masnax I think, this is also wrong in migration-manager, since I initially took the code from there.