### PR TITLE
Database transaction related fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,13 +207,13 @@ doc-linkcheck: doc-setup
 doc-lint:
 	doc/.sphinx/.markdownlint/doc-lint.sh
 
-GO_TEST_RUN ?= 'TestE2E'
+GO_TEST_RUN ?= '^TestE2E'
 
 .PHONY: e2e-test
 e2e-test: bld
 	@echo "go test flags: $(GO_TEST_RUN) (change by running 'make e2e-test GO_TEST_RUN=TestMyTest')"
 	mkdir -p $(OPERATIONS_CENTER_E2E_TEST_TMP_DIR)
-	OPERATIONS_CENTER_E2E_TEST=1 OPERATIONS_CENTER_E2E_TEST_NO_CLEANUP_ON_ERROR=1 OPERATIONS_CENTER_E2E_TEST_TMP_DIR=$(OPERATIONS_CENTER_E2E_TEST_TMP_DIR) $(GO) test ./e2e_tests/ -v -timeout 120m -count 1 -failfast -run $(GO_TEST_RUN) | tee $$OPERATIONS_CENTER_E2E_TEST_TMP_DIR/e2e_tests_$(EXECUTION_DATETIME).log
+	OPERATIONS_CENTER_E2E_TEST=1 OPERATIONS_CENTER_E2E_TEST_NO_CLEANUP_ON_ERROR=1 OPERATIONS_CENTER_E2E_TEST_TMP_DIR=$(OPERATIONS_CENTER_E2E_TEST_TMP_DIR) $(GO) test ./e2e_tests/ -v -timeout 120m -count 1 -failfast -run "$(GO_TEST_RUN)" | tee $$OPERATIONS_CENTER_E2E_TEST_TMP_DIR/e2e_tests_$(EXECUTION_DATETIME).log
 
 .PHONY: e2e-test-cover
 e2e-test-cover: bld-cover
@@ -221,7 +221,7 @@ e2e-test-cover: bld-cover
 	@echo "go test flags: $(GO_TEST_RUN) (change by running 'make e2e-test-cover GO_TEST_RUN=TestMyTest')"
 	mkdir -p $(GOCOVERDIR)
 	OPERATIONS_CENTER_E2E_TEST=0 $(GO) test ./... -cover -coverpkg=./... -v -count 1 -args -test.gocoverdir="$(GOCOVERDIR)" | tee $$OPERATIONS_CENTER_E2E_TEST_TMP_DIR/e2e_tests_$(EXECUTION_DATETIME).log
-	OPERATIONS_CENTER_E2E_GOCOVERDIR=$(GOCOVERDIR) OPERATIONS_CENTER_E2E_TEST=1 OPERATIONS_CENTER_E2E_TEST_TMP_DIR=$(OPERATIONS_CENTER_E2E_TEST_TMP_DIR) $(GO) test ./e2e_tests/ -cover -coverpkg=./... -v -timeout 120m -count 1 -run $(GO_TEST_RUN) -args -test.gocoverdir="$(GOCOVERDIR)" | tee $$OPERATIONS_CENTER_E2E_TEST_TMP_DIR/e2e_tests_$(EXECUTION_DATETIME).log
+	OPERATIONS_CENTER_E2E_GOCOVERDIR=$(GOCOVERDIR) OPERATIONS_CENTER_E2E_TEST=1 OPERATIONS_CENTER_E2E_TEST_TMP_DIR=$(OPERATIONS_CENTER_E2E_TEST_TMP_DIR) $(GO) test ./e2e_tests/ -cover -coverpkg=./... -v -timeout 120m -count 1 -run "$(GO_TEST_RUN)" -args -test.gocoverdir="$(GOCOVERDIR)" | tee $$OPERATIONS_CENTER_E2E_TEST_TMP_DIR/e2e_tests_$(EXECUTION_DATETIME).log
 	@echo ""
 	@echo "================= Coverage Report ================="
 	@$(GO) tool covdata percent -pkg $$($(GO) tool covdata pkglist -i $(GOCOVERDIR) | grep -vE '(middleware|mock|version|lifecycle)$$' | paste -sd,) -i=$(GOCOVERDIR) -o covdata-coverage.out | sed 's/%//' | sort -k3,3nr -k1,1 | column -t
@@ -229,7 +229,7 @@ e2e-test-cover: bld-cover
 
 .PHONY: e2e-test-list
 e2e-test-list:
-	$(GO) test -list 'TestE2E' ./e2e_tests/
+	$(GO) test -list '^TestE2E' ./e2e_tests/
 
 .PHONY: clean-e2e-test
 clean-e2e-test:

--- a/cmd/generate-inventory/tmpl/global/api_inventory.gotmpl
+++ b/cmd/generate-inventory/tmpl/global/api_inventory.gotmpl
@@ -26,6 +26,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 				),
 			),
 		),
+		inventoryServiceMiddleware.InventoryAggregateServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	)
 
 {{ range . }}
@@ -50,6 +60,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			{{- if .HasParentFilter }}
 			inventory.{{ .Name | pascalcase }}WithParentFilter({{ .Name | camelcase }}WithParentFilter),
 			{{- end }}
+		),
+		inventoryServiceMiddleware.{{ .Name | pascalcase }}ServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
 		),
 	)
 

--- a/cmd/generate-inventory/tmpl/service.gotmpl
+++ b/cmd/generate-inventory/tmpl/service.gotmpl
@@ -177,27 +177,32 @@ func (s {{ .Name | camelcase }}Service) GetByUUID(ctx context.Context, id uuid.U
 }
 
 func (s {{ .Name | camelcase }}Service) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	{{ .Name | camelcase }}, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, {{ .Name | camelcase }}.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrieved{{ .Name | pascalcase }}, err := s.{{ .Name | camelcase }}Client.Get{{ .Name | pascalcase }}ByName(ctx, endpoint, {{- if .HasProject }}{{ .Name | camelcase }}.ProjectName, {{ end -}}{{ if .HasParent }}{{ .Name | camelcase }}.{{ .ParentName | pascalcase }}Name, {{ end -}} {{ .Name | camelcase }}.Name {{- range .ExtraAttributes }}, {{ $.Name | camelcase }}.{{ .Name | pascalcase }} {{- end}})
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, {{ .Name | camelcase }}.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete {{ .Name }} %q from cluster %q{{ if .HasParent }}, {{ .ParentName }} %q{{ end }}: %w`, {{ .Name | camelcase }}.UUID.String(), {{ .Name | camelcase }}.Cluster, {{ if .HasParent }}{{ .Name | camelcase }}.{{ .ParentName | pascalcase }}Name, {{ end }}err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		{{ .Name | camelcase }}, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, {{ .Name | camelcase }}.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrieved{{ .Name | pascalcase }}, err := s.{{ .Name | camelcase }}Client.Get{{ .Name | pascalcase }}ByName(ctx, endpoint, {{- if .HasProject }}{{ .Name | camelcase }}.ProjectName, {{ end -}}{{ if .HasParent }}{{ .Name | camelcase }}.{{ .ParentName | pascalcase }}Name, {{ end -}} {{ .Name | camelcase }}.Name {{- range .ExtraAttributes }}, {{ $.Name | camelcase }}.{{ .Name | pascalcase }} {{- end}})
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, {{ .Name | camelcase }}.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete {{ .Name }} %q from cluster %q{{ if .HasParent }}, {{ .ParentName }} %q{{ end }}: %w`, {{ .Name | camelcase }}.UUID.String(), {{ .Name | camelcase }}.Cluster, {{ if .HasParent }}{{ .Name | camelcase }}.{{ .ParentName | pascalcase }}Name, {{ end }}err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/cmd/generate-inventory/tmpl/service_test.gotmpl
+++ b/cmd/generate-inventory/tmpl/service_test.gotmpl
@@ -20,6 +20,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -272,8 +273,7 @@ func Test{{ .Name | pascalcase }}Service_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr     error
 		{{ .Name | camelcase }}ClientGet{{ .Name | pascalcase }}ByName    incusapi.{{ .ObjectType | pascalcase }}
 		{{ .Name | camelcase }}ClientGet{{ .Name | pascalcase }}ByNameErr error
-		repoGetByUUID{{ .Name | pascalcase }} inventory.{{ .Name | pascalcase }}
-		repoGetByUUIDErr    error
+		repoGetByUUID{{ .Name | pascalcase }} []queue.Item[inventory.{{ .Name | pascalcase }}]
 		repoUpdateByUUIDErr error
 		repoDeleteByUUIDErr error
 
@@ -281,16 +281,33 @@ func Test{{ .Name | pascalcase }}Service_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUID{{ .Name | pascalcase }}: inventory.{{ .Name | pascalcase }}{
-				UUID:     uuidgen.FromPattern(t, "1"),
-				Cluster:  "one",
-				Name:     "one",
+			repoGetByUUID{{ .Name | pascalcase }}: []queue.Item[inventory.{{ .Name | pascalcase }}]{
+				{
+					Value: inventory.{{ .Name | pascalcase }}{
+						UUID:     uuidgen.FromPattern(t, "1"),
+						Cluster:  "one",
+						Name:     "one",
 {{- if .HasProject }}
-				ProjectName: "project one",
+						ProjectName: "project one",
 {{- end }}
 {{- if .HasParent }}
-				{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
+						{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
 {{- end }}
+					},
+				},
+				{
+					Value: inventory.{{ .Name | pascalcase }}{
+						UUID:     uuidgen.FromPattern(t, "1"),
+						Cluster:  "one",
+						Name:     "one",
+{{- if .HasProject }}
+						ProjectName: "project one",
+{{- end }}
+{{- if .HasParent }}
+						{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
+{{- end }}
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -325,16 +342,20 @@ func Test{{ .Name | pascalcase }}Service_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - {{ .Name | camelcase }} get by name - not found",
-			repoGetByUUID{{ .Name | pascalcase }}: inventory.{{ .Name | pascalcase }}{
-				UUID:     uuidgen.FromPattern(t, "1"),
-				Cluster:  "one",
-				Name:     "one",
+			repoGetByUUID{{ .Name | pascalcase }}: []queue.Item[inventory.{{ .Name | pascalcase }}]{
+				{
+					Value: inventory.{{ .Name | pascalcase }}{
+						UUID:     uuidgen.FromPattern(t, "1"),
+						Cluster:  "one",
+						Name:     "one",
 {{- if .HasProject }}
-				ProjectName: "project one",
+						ProjectName: "project one",
 {{- end }}
 {{- if .HasParent }}
-				{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
+						{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
 {{- end }}
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -353,13 +374,27 @@ func Test{{ .Name | pascalcase }}Service_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUID{{ .Name | pascalcase }}: inventory.{{ .Name | pascalcase }}{
-				UUID:     uuidgen.FromPattern(t, "1"),
-				Cluster:  "one",
-				Name:     "one",
+			repoGetByUUID{{ .Name | pascalcase }}: []queue.Item[inventory.{{ .Name | pascalcase }}]{
+				{
+					Value: inventory.{{ .Name | pascalcase }}{
+						UUID:     uuidgen.FromPattern(t, "1"),
+						Cluster:  "one",
+						Name:     "one",
 {{- if .HasParent }}
-				{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
+						{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
 {{- end }}
+					},
+				},
+				{
+					Value: inventory.{{ .Name | pascalcase }}{
+						UUID:     uuidgen.FromPattern(t, "1"),
+						Cluster:  "one",
+						Name:     "one",
+{{- if .HasParent }}
+						{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
+{{- end }}
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -390,23 +425,31 @@ func Test{{ .Name | pascalcase }}Service_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:           "error - {{ .Name | camelcase }} get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - {{ .Name | camelcase }} get by UUID - 1st",
+			repoGetByUUID{{ .Name | pascalcase }}: []queue.Item[inventory.{{ .Name | pascalcase }}]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUID{{ .Name | pascalcase }}: inventory.{{ .Name | pascalcase }}{
-				UUID:     uuidgen.FromPattern(t, "1"),
-				Cluster:  "one",
-				Name:     "one",
+			repoGetByUUID{{ .Name | pascalcase }}: []queue.Item[inventory.{{ .Name | pascalcase }}]{
+				{
+					Value: inventory.{{ .Name | pascalcase }}{
+						UUID:     uuidgen.FromPattern(t, "1"),
+						Cluster:  "one",
+						Name:     "one",
 {{- if .HasProject }}
-				ProjectName: "project one",
+						ProjectName: "project one",
 {{- end }}
 {{- if .HasParent }}
-				{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
+						{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
 {{- end }}
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -414,16 +457,20 @@ func Test{{ .Name | pascalcase }}Service_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - {{ .Name | camelcase }} get by name",
-			repoGetByUUID{{ .Name | pascalcase }}: inventory.{{ .Name | pascalcase }}{
-				UUID:     uuidgen.FromPattern(t, "1"),
-				Cluster:  "one",
-				Name:     "one",
+			repoGetByUUID{{ .Name | pascalcase }}: []queue.Item[inventory.{{ .Name | pascalcase }}]{
+				{
+					Value: inventory.{{ .Name | pascalcase }}{
+						UUID:     uuidgen.FromPattern(t, "1"),
+						Cluster:  "one",
+						Name:     "one",
 {{- if .HasProject }}
-				ProjectName: "project one",
+						ProjectName: "project one",
 {{- end }}
 {{- if .HasParent }}
-				{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
+						{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
 {{- end }}
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -438,16 +485,20 @@ func Test{{ .Name | pascalcase }}Service_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - {{ .Name | camelcase }} get by name - not found - delete by uuid",
-			repoGetByUUID{{ .Name | pascalcase }}: inventory.{{ .Name | pascalcase }}{
-				UUID:     uuidgen.FromPattern(t, "1"),
-				Cluster:  "one",
-				Name:     "one",
+			repoGetByUUID{{ .Name | pascalcase }}: []queue.Item[inventory.{{ .Name | pascalcase }}]{
+				{
+					Value: inventory.{{ .Name | pascalcase }}{
+						UUID:     uuidgen.FromPattern(t, "1"),
+						Cluster:  "one",
+						Name:     "one",
 {{- if .HasProject }}
-				ProjectName: "project one",
+						ProjectName: "project one",
 {{- end }}
 {{- if .HasParent }}
-				{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
+						{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
 {{- end }}
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -462,17 +513,64 @@ func Test{{ .Name | pascalcase }}Service_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name: "error - validate",
-			repoGetByUUID{{ .Name | pascalcase }}: inventory.{{ .Name | pascalcase }}{
-				UUID:     uuidgen.FromPattern(t, "1"),
-				Cluster:  "one",
-				Name:     "", // invalid
+			name: "error - {{ .Name | camelcase }} get by UUID - 2nd",
+			repoGetByUUID{{ .Name | pascalcase }}: []queue.Item[inventory.{{ .Name | pascalcase }}]{
+				{
+					Value: inventory.{{ .Name | pascalcase }}{
+						UUID:     uuidgen.FromPattern(t, "1"),
+						Cluster:  "one",
+						Name:     "one",
 {{- if .HasProject }}
-				ProjectName: "project one",
+						ProjectName: "project one",
 {{- end }}
 {{- if .HasParent }}
-				{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
+						{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
 {{- end }}
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL: "https://server-one/",
+					Certificate: "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
+			name: "error - validate",
+			repoGetByUUID{{ .Name | pascalcase }}: []queue.Item[inventory.{{ .Name | pascalcase }}]{
+				{
+					Value: inventory.{{ .Name | pascalcase }}{
+						UUID:     uuidgen.FromPattern(t, "1"),
+						Cluster:  "one",
+						Name:     "", // invalid
+{{- if .HasProject }}
+						ProjectName: "project one",
+{{- end }}
+{{- if .HasParent }}
+						{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
+{{- end }}
+					},
+				},
+				{
+					Value: inventory.{{ .Name | pascalcase }}{
+						UUID:     uuidgen.FromPattern(t, "1"),
+						Cluster:  "one",
+						Name:     "", // invalid
+{{- if .HasProject }}
+						ProjectName: "project one",
+{{- end }}
+{{- if .HasParent }}
+						{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
+{{- end }}
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -510,16 +608,33 @@ func Test{{ .Name | pascalcase }}Service_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUID{{ .Name | pascalcase }}: inventory.{{ .Name | pascalcase }}{
-				UUID:     uuidgen.FromPattern(t, "1"),
-				Cluster:  "one",
-				Name:     "one",
+			repoGetByUUID{{ .Name | pascalcase }}: []queue.Item[inventory.{{ .Name | pascalcase }}]{
+				{
+					Value: inventory.{{ .Name | pascalcase }}{
+						UUID:     uuidgen.FromPattern(t, "1"),
+						Cluster:  "one",
+						Name:     "one",
 {{- if .HasProject }}
-				ProjectName: "project one",
+						ProjectName: "project one",
 {{- end }}
 {{- if .HasParent }}
-				{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
+						{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
 {{- end }}
+					},
+				},
+				{
+					Value: inventory.{{ .Name | pascalcase }}{
+						UUID:     uuidgen.FromPattern(t, "1"),
+						Cluster:  "one",
+						Name:     "one",
+{{- if .HasProject }}
+						ProjectName: "project one",
+{{- end }}
+{{- if .HasParent }}
+						{{ .ParentName | pascalcase }}Name: "{{ .ParentName }}",
+{{- end }}
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -560,7 +675,7 @@ func Test{{ .Name | pascalcase }}Service_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.{{ .Name | pascalcase }}RepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.{{ .Name | pascalcase }}, error) {
-					return tc.repoGetByUUID{{ .Name | pascalcase }}, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUID{{ .Name | pascalcase }})
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, {{ .Name | camelcase }} inventory.{{ .Name | pascalcase }}) (inventory.{{ .Name | pascalcase }}, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), {{ .Name | camelcase }}.LastUpdated)
@@ -580,13 +695,6 @@ func Test{{ .Name | pascalcase }}Service_ResyncByUUID(t *testing.T) {
 
 			{{ .Name | camelcase }}Client := &serverMock.{{ .Name | pascalcase }}ServerClientMock{
 				Get{{ .Name | pascalcase }}ByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, {{- if .HasProject }} projectName string, {{ end -}}{{- if .HasParent }}{{ .ParentName | camelcase }}Name string, {{ end -}} {{ .Name | camelcase }}Name string {{- range .ExtraAttributes }}, {{ $.Name | camelcase }}{{ .Name | pascalcase }} {{ .Type }} {{- end}}) (incusapi.{{ .ObjectType | pascalcase }}, error) {
-					require.Equal(t, tc.repoGetByUUID{{ .Name | pascalcase }}.Name, {{ .Name | camelcase }}Name)
-{{- if .HasProject }}
-				require.Equal(t, tc.repoGetByUUID{{ .Name | pascalcase }}.ProjectName, projectName)
-{{- end }}
-{{- if .HasParent }}
-					require.Equal(t, "{{ .ParentName }}", {{ .ParentName | camelcase }}Name)
-{{- end }}
 					return tc.{{ .Name | camelcase }}ClientGet{{ .Name | pascalcase }}ByName, tc.{{ .Name | camelcase }}ClientGet{{ .Name | pascalcase }}ByNameErr
 				},
 			}
@@ -600,6 +708,8 @@ func Test{{ .Name | pascalcase }}Service_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUID{{ .Name | pascalcase }})
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
+	github.com/fabien-marty/tracerr v0.0.0-20240624051446-7f090eca46ee // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -162,6 +163,7 @@ require (
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	github.com/zitadel/logging v0.7.0 // indirect
 	github.com/zitadel/schema v1.3.2 // indirect
+	github.com/ztrue/tracerr v0.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect
 	go.opentelemetry.io/otel v1.42.0 // indirect
@@ -199,6 +201,7 @@ require (
 	github.com/dsnet/golib/memfile v1.0.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/expr-lang/expr v1.17.8
+	github.com/fabien-marty/slog-helpers v0.0.0-20240624063600-773d61849b89
 	github.com/fvbommel/sortorder v1.1.0
 	github.com/gabriel-vasile/mimetype v1.4.13
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,10 @@ github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
 github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
 github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+github.com/fabien-marty/slog-helpers v0.0.0-20240624063600-773d61849b89 h1:dfxFAMTnLq3jNF8wMK+/oLk3y61BuRjZHJHCMNaGpfQ=
+github.com/fabien-marty/slog-helpers v0.0.0-20240624063600-773d61849b89/go.mod h1:2V/BsRxp1nJU5awq+f92qcG45r932QPSJniELs4uJ5s=
+github.com/fabien-marty/tracerr v0.0.0-20240624051446-7f090eca46ee h1:eiZ6JMlML+keJ69rWBkV5RENVIw66+M2rrz0AXO+1Ns=
+github.com/fabien-marty/tracerr v0.0.0-20240624051446-7f090eca46ee/go.mod h1:eqKGnFoVPY3Ng/iRRYfMxOum60YwQh7ZzYILKbYI7UY=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
@@ -739,6 +743,8 @@ github.com/zitadel/oidc/v3 v3.45.5 h1:CubfcXQiqtysk+FZyIcvj1+1ayvdSV89v5xWu5asrD
 github.com/zitadel/oidc/v3 v3.45.5/go.mod h1:MKHUazeiNX/jxRc6HD/Dv9qhL/wNuzrJAadBEGXiBeE=
 github.com/zitadel/schema v1.3.2 h1:gfJvt7dOMfTmxzhscZ9KkapKo3Nei3B6cAxjav+lyjI=
 github.com/zitadel/schema v1.3.2/go.mod h1:IZmdfF9Wu62Zu6tJJTH3UsArevs3Y4smfJIj3L8fzxw=
+github.com/ztrue/tracerr v0.4.0 h1:vT5PFxwIGs7rCg9ZgJ/y0NmOpJkPCPFK8x0vVIYzd04=
+github.com/ztrue/tracerr v0.4.0/go.mod h1:PaFfYlas0DfmXNpo7Eay4MFhZUONqvXM+T2HyGPpngk=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=

--- a/internal/api/api_inventory_gen.go
+++ b/internal/api/api_inventory_gen.go
@@ -28,6 +28,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 				),
 			),
 		),
+		inventoryServiceMiddleware.InventoryAggregateServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	)
 
 	inventoryImageSvc := inventoryServiceMiddleware.NewImageServiceWithSlog(
@@ -43,6 +53,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			clusterSvc,
 			serverClient,
 		),
+		inventoryServiceMiddleware.ImageServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	)
 
 	inventoryInstanceSvc := inventoryServiceMiddleware.NewInstanceServiceWithSlog(
@@ -57,6 +77,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			),
 			clusterSvc,
 			serverClient,
+		),
+		inventoryServiceMiddleware.InstanceServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
 		),
 	)
 
@@ -74,6 +104,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			serverClient,
 			inventory.NetworkWithSyncFilter(networkWithSyncFilter),
 		),
+		inventoryServiceMiddleware.NetworkServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	)
 
 	inventoryNetworkACLSvc := inventoryServiceMiddleware.NewNetworkACLServiceWithSlog(
@@ -89,6 +129,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			clusterSvc,
 			serverClient,
 		),
+		inventoryServiceMiddleware.NetworkACLServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	)
 
 	inventoryNetworkAddressSetSvc := inventoryServiceMiddleware.NewNetworkAddressSetServiceWithSlog(
@@ -103,6 +153,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			),
 			clusterSvc,
 			serverClient,
+		),
+		inventoryServiceMiddleware.NetworkAddressSetServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
 		),
 	)
 
@@ -121,6 +181,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			serverClient,
 			inventory.NetworkForwardWithParentFilter(networkForwardWithParentFilter),
 		),
+		inventoryServiceMiddleware.NetworkForwardServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	)
 
 	inventoryNetworkIntegrationSvc := inventoryServiceMiddleware.NewNetworkIntegrationServiceWithSlog(
@@ -135,6 +205,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			),
 			clusterSvc,
 			serverClient,
+		),
+		inventoryServiceMiddleware.NetworkIntegrationServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
 		),
 	)
 
@@ -153,6 +233,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			serverClient,
 			inventory.NetworkLoadBalancerWithParentFilter(networkLoadBalancerWithParentFilter),
 		),
+		inventoryServiceMiddleware.NetworkLoadBalancerServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	)
 
 	inventoryNetworkPeerSvc := inventoryServiceMiddleware.NewNetworkPeerServiceWithSlog(
@@ -170,6 +260,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			serverClient,
 			inventory.NetworkPeerWithParentFilter(networkPeerWithParentFilter),
 		),
+		inventoryServiceMiddleware.NetworkPeerServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	)
 
 	inventoryNetworkZoneSvc := inventoryServiceMiddleware.NewNetworkZoneServiceWithSlog(
@@ -184,6 +284,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			),
 			clusterSvc,
 			serverClient,
+		),
+		inventoryServiceMiddleware.NetworkZoneServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
 		),
 	)
 
@@ -200,6 +310,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			clusterSvc,
 			serverClient,
 		),
+		inventoryServiceMiddleware.ProfileServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	)
 
 	inventoryProjectSvc := inventoryServiceMiddleware.NewProjectServiceWithSlog(
@@ -214,6 +334,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			),
 			clusterSvc,
 			serverClient,
+		),
+		inventoryServiceMiddleware.ProjectServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
 		),
 	)
 
@@ -232,6 +362,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			serverClient,
 			inventory.StorageBucketWithParentFilter(storageBucketWithParentFilter),
 		),
+		inventoryServiceMiddleware.StorageBucketServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	)
 
 	inventoryStoragePoolSvc := inventoryServiceMiddleware.NewStoragePoolServiceWithSlog(
@@ -246,6 +386,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			),
 			clusterSvc,
 			serverClient,
+		),
+		inventoryServiceMiddleware.StoragePoolServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
 		),
 	)
 
@@ -263,6 +413,16 @@ func registerInventoryRoutes(db dbdriver.DBTX, clusterSvc provisioning.ClusterSe
 			serverClient,
 			serverClient,
 			inventory.StorageVolumeWithParentFilter(storageVolumeWithParentFilter),
+		),
+		inventoryServiceMiddleware.StorageVolumeServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
 		),
 	)
 

--- a/internal/api/api_provisioning_cluster.go
+++ b/internal/api/api_provisioning_cluster.go
@@ -379,7 +379,7 @@ func (c *clusterHandler) clusterPut(r *http.Request) response.Response {
 	currentCluster.Properties = cluster.Properties
 	currentCluster.Config = cluster.Config
 
-	err = c.service.Update(ctx, *currentCluster)
+	err = c.service.Update(ctx, *currentCluster, true)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed updating cluster %q: %w", name, err))
 	}

--- a/internal/api/daemon.go
+++ b/internal/api/daemon.go
@@ -480,6 +480,16 @@ func (d *Daemon) setupUpdatesService(ctx context.Context, db dbdriver.DBTX) (pro
 
 	return provisioningServiceMiddleware.NewUpdateServiceWithSlog(
 		updateSvcBase,
+		provisioningServiceMiddleware.UpdateServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	), nil
 }
 
@@ -505,6 +515,16 @@ func (d *Daemon) setupTokenService(db dbdriver.DBTX, updateSvc provisioning.Upda
 			updateSvc,
 			channelSvc,
 			imageFlasher,
+		),
+		provisioningServiceMiddleware.TokenServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
 		),
 	)
 }
@@ -570,6 +590,16 @@ func (d *Daemon) setupServerService(db dbdriver.DBTX, tokenSvc provisioning.Toke
 
 	return provisioningServiceMiddleware.NewServerServiceWithSlog(
 		serverSvc,
+		provisioningServiceMiddleware.ServerServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	)
 }
 
@@ -629,6 +659,16 @@ func (d *Daemon) setupClusterService(db dbdriver.DBTX, serverSvc provisioning.Se
 			nil,
 			terraformProvisioner,
 		),
+		provisioningServiceMiddleware.ClusterServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	), nil
 }
 
@@ -638,6 +678,16 @@ func (d *Daemon) setupClusterTemplateService(db dbdriver.DBTX) provisioning.Clus
 			provisioningRepoMiddleware.NewClusterTemplateRepoWithSlog(
 				provisioningSqlite.NewClusterTemplate(db),
 			),
+		),
+		provisioningServiceMiddleware.ClusterTemplateServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
 		),
 	)
 }
@@ -650,12 +700,32 @@ func (d *Daemon) setupChannelService(db dbdriver.DBTX, updateSvc provisioning.Up
 			),
 			updateSvc,
 		),
+		provisioningServiceMiddleware.ChannelServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	)
 }
 
 func (d *Daemon) setupSystemService(serverSvc provisioning.ServerService) system.SystemService {
 	return systemServiceMiddleware.NewSystemServiceWithSlog(
 		system.NewSystemService(d.env, serverSvc),
+		systemServiceMiddleware.SystemServiceWithSlogWithInformativeErrFunc(
+			func(err error) bool {
+				// Treat retryable errors as informational.
+				if domain.IsRetryableError(err) {
+					return true
+				}
+
+				return false
+			},
+		),
 	)
 }
 

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"syscall"
 )
@@ -63,6 +64,13 @@ func IsRetryableError(err error) bool {
 	return errors.As(err, &retryableErr)
 }
 
+// Incus client returns connection errors with "Unable to connect to" prefix
+// see: https://github.com/lxc/incus/blob/07852cf61699581d05649eab55b02bc7aff7e68f/shared/tls/tls.go#L19
+// The original error can not be matched other than string comparison.
+var retryableIncusConnectErrors = regexp.MustCompile(`context deadline exceeded|Unable to connect to:.*\(.*(context cancelled|connection refused).*\)`)
+
+// context deadline exceeded
+
 func RetryableWrapper() func(err error) error {
 	return func(err error) error {
 		// Connection errors are retryable.
@@ -80,6 +88,10 @@ func RetryableWrapper() func(err error) error {
 
 		// Retryable incus errors.
 		if strings.Contains(err.Error(), "no available cowsql leader server found") {
+			return NewRetryableErr(err)
+		}
+
+		if retryableIncusConnectErrors.MatchString(err.Error()) {
 			return NewRetryableErr(err)
 		}
 

--- a/internal/inventory/image_service_gen.go
+++ b/internal/inventory/image_service_gen.go
@@ -148,27 +148,32 @@ func (s imageService) GetByUUID(ctx context.Context, id uuid.UUID) (Image, error
 }
 
 func (s imageService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	image, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, image.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedImage, err := s.imageClient.GetImageByName(ctx, endpoint, image.ProjectName, image.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, image.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete image %q from cluster %q: %w`, image.UUID.String(), image.Cluster, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		image, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, image.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedImage, err := s.imageClient.GetImageByName(ctx, endpoint, image.ProjectName, image.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, image.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete image %q from cluster %q: %w`, image.UUID.String(), image.Cluster, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/image_service_gen_test.go
+++ b/internal/inventory/image_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -269,8 +270,7 @@ func TestImageService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr     error
 		imageClientGetImageByName    incusapi.Image
 		imageClientGetImageByNameErr error
-		repoGetByUUIDImage           inventory.Image
-		repoGetByUUIDErr             error
+		repoGetByUUIDImage           []queue.Item[inventory.Image]
 		repoUpdateByUUIDErr          error
 		repoDeleteByUUIDErr          error
 
@@ -278,11 +278,23 @@ func TestImageService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDImage: inventory.Image{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDImage: []queue.Item[inventory.Image]{
+				{
+					Value: inventory.Image{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.Image{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -300,11 +312,15 @@ func TestImageService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - image get by name - not found",
-			repoGetByUUIDImage: inventory.Image{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDImage: []queue.Item[inventory.Image]{
+				{
+					Value: inventory.Image{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -323,10 +339,21 @@ func TestImageService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDImage: inventory.Image{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDImage: []queue.Item[inventory.Image]{
+				{
+					Value: inventory.Image{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.Image{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -342,18 +369,26 @@ func TestImageService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - image get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - image get by UUID - 1st",
+			repoGetByUUIDImage: []queue.Item[inventory.Image]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDImage: inventory.Image{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDImage: []queue.Item[inventory.Image]{
+				{
+					Value: inventory.Image{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -361,11 +396,15 @@ func TestImageService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - image get by name",
-			repoGetByUUIDImage: inventory.Image{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDImage: []queue.Item[inventory.Image]{
+				{
+					Value: inventory.Image{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -380,11 +419,15 @@ func TestImageService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - image get by name - not found - delete by uuid",
-			repoGetByUUIDImage: inventory.Image{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDImage: []queue.Item[inventory.Image]{
+				{
+					Value: inventory.Image{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -399,12 +442,49 @@ func TestImageService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - image get by UUID - 2nd",
+			repoGetByUUIDImage: []queue.Item[inventory.Image]{
+				{
+					Value: inventory.Image{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDImage: inventory.Image{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "", // invalid
-				ProjectName: "project one",
+			repoGetByUUIDImage: []queue.Item[inventory.Image]{
+				{
+					Value: inventory.Image{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.Image{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -425,11 +505,23 @@ func TestImageService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDImage: inventory.Image{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDImage: []queue.Item[inventory.Image]{
+				{
+					Value: inventory.Image{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.Image{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -453,7 +545,7 @@ func TestImageService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.ImageRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.Image, error) {
-					return tc.repoGetByUUIDImage, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDImage)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, image inventory.Image) (inventory.Image, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), image.LastUpdated)
@@ -473,8 +565,6 @@ func TestImageService_ResyncByUUID(t *testing.T) {
 
 			imageClient := &serverMock.ImageServerClientMock{
 				GetImageByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, projectName string, imageName string) (incusapi.Image, error) {
-					require.Equal(t, tc.repoGetByUUIDImage.Name, imageName)
-					require.Equal(t, tc.repoGetByUUIDImage.ProjectName, projectName)
 					return tc.imageClientGetImageByName, tc.imageClientGetImageByNameErr
 				},
 			}
@@ -488,6 +578,8 @@ func TestImageService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDImage)
 		})
 	}
 }

--- a/internal/inventory/instance_service_gen.go
+++ b/internal/inventory/instance_service_gen.go
@@ -148,27 +148,32 @@ func (s instanceService) GetByUUID(ctx context.Context, id uuid.UUID) (Instance,
 }
 
 func (s instanceService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	instance, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, instance.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedInstance, err := s.instanceClient.GetInstanceByName(ctx, endpoint, instance.ProjectName, instance.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, instance.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete instance %q from cluster %q: %w`, instance.UUID.String(), instance.Cluster, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		instance, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, instance.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedInstance, err := s.instanceClient.GetInstanceByName(ctx, endpoint, instance.ProjectName, instance.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, instance.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete instance %q from cluster %q: %w`, instance.UUID.String(), instance.Cluster, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/instance_service_gen_test.go
+++ b/internal/inventory/instance_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -269,8 +270,7 @@ func TestInstanceService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr           error
 		instanceClientGetInstanceByName    incusapi.InstanceFull
 		instanceClientGetInstanceByNameErr error
-		repoGetByUUIDInstance              inventory.Instance
-		repoGetByUUIDErr                   error
+		repoGetByUUIDInstance              []queue.Item[inventory.Instance]
 		repoUpdateByUUIDErr                error
 		repoDeleteByUUIDErr                error
 
@@ -278,11 +278,23 @@ func TestInstanceService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDInstance: inventory.Instance{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDInstance: []queue.Item[inventory.Instance]{
+				{
+					Value: inventory.Instance{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.Instance{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -303,11 +315,15 @@ func TestInstanceService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - instance get by name - not found",
-			repoGetByUUIDInstance: inventory.Instance{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDInstance: []queue.Item[inventory.Instance]{
+				{
+					Value: inventory.Instance{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -326,10 +342,21 @@ func TestInstanceService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDInstance: inventory.Instance{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDInstance: []queue.Item[inventory.Instance]{
+				{
+					Value: inventory.Instance{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.Instance{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -348,18 +375,26 @@ func TestInstanceService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - instance get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - instance get by UUID - 1st",
+			repoGetByUUIDInstance: []queue.Item[inventory.Instance]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDInstance: inventory.Instance{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDInstance: []queue.Item[inventory.Instance]{
+				{
+					Value: inventory.Instance{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -367,11 +402,15 @@ func TestInstanceService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - instance get by name",
-			repoGetByUUIDInstance: inventory.Instance{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDInstance: []queue.Item[inventory.Instance]{
+				{
+					Value: inventory.Instance{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -386,11 +425,15 @@ func TestInstanceService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - instance get by name - not found - delete by uuid",
-			repoGetByUUIDInstance: inventory.Instance{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDInstance: []queue.Item[inventory.Instance]{
+				{
+					Value: inventory.Instance{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -405,12 +448,49 @@ func TestInstanceService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - instance get by UUID - 2nd",
+			repoGetByUUIDInstance: []queue.Item[inventory.Instance]{
+				{
+					Value: inventory.Instance{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDInstance: inventory.Instance{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "", // invalid
-				ProjectName: "project one",
+			repoGetByUUIDInstance: []queue.Item[inventory.Instance]{
+				{
+					Value: inventory.Instance{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.Instance{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -434,11 +514,23 @@ func TestInstanceService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDInstance: inventory.Instance{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDInstance: []queue.Item[inventory.Instance]{
+				{
+					Value: inventory.Instance{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.Instance{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -465,7 +557,7 @@ func TestInstanceService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.InstanceRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.Instance, error) {
-					return tc.repoGetByUUIDInstance, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDInstance)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, instance inventory.Instance) (inventory.Instance, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), instance.LastUpdated)
@@ -485,8 +577,6 @@ func TestInstanceService_ResyncByUUID(t *testing.T) {
 
 			instanceClient := &serverMock.InstanceServerClientMock{
 				GetInstanceByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, projectName string, instanceName string) (incusapi.InstanceFull, error) {
-					require.Equal(t, tc.repoGetByUUIDInstance.Name, instanceName)
-					require.Equal(t, tc.repoGetByUUIDInstance.ProjectName, projectName)
 					return tc.instanceClientGetInstanceByName, tc.instanceClientGetInstanceByNameErr
 				},
 			}
@@ -500,6 +590,8 @@ func TestInstanceService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDInstance)
 		})
 	}
 }

--- a/internal/inventory/network_acl_service_gen.go
+++ b/internal/inventory/network_acl_service_gen.go
@@ -148,27 +148,32 @@ func (s networkACLService) GetByUUID(ctx context.Context, id uuid.UUID) (Network
 }
 
 func (s networkACLService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	networkACL, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkACL.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedNetworkACL, err := s.networkACLClient.GetNetworkACLByName(ctx, endpoint, networkACL.ProjectName, networkACL.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, networkACL.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete network_acl %q from cluster %q: %w`, networkACL.UUID.String(), networkACL.Cluster, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		networkACL, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkACL.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedNetworkACL, err := s.networkACLClient.GetNetworkACLByName(ctx, endpoint, networkACL.ProjectName, networkACL.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, networkACL.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete network_acl %q from cluster %q: %w`, networkACL.UUID.String(), networkACL.Cluster, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/network_acl_service_gen_test.go
+++ b/internal/inventory/network_acl_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -269,8 +270,7 @@ func TestNetworkACLService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr               error
 		networkACLClientGetNetworkACLByName    incusapi.NetworkACL
 		networkACLClientGetNetworkACLByNameErr error
-		repoGetByUUIDNetworkACL                inventory.NetworkACL
-		repoGetByUUIDErr                       error
+		repoGetByUUIDNetworkACL                []queue.Item[inventory.NetworkACL]
 		repoUpdateByUUIDErr                    error
 		repoDeleteByUUIDErr                    error
 
@@ -278,11 +278,23 @@ func TestNetworkACLService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDNetworkACL: inventory.NetworkACL{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkACL: []queue.Item[inventory.NetworkACL]{
+				{
+					Value: inventory.NetworkACL{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.NetworkACL{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -302,11 +314,15 @@ func TestNetworkACLService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - networkACL get by name - not found",
-			repoGetByUUIDNetworkACL: inventory.NetworkACL{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkACL: []queue.Item[inventory.NetworkACL]{
+				{
+					Value: inventory.NetworkACL{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -325,10 +341,21 @@ func TestNetworkACLService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDNetworkACL: inventory.NetworkACL{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDNetworkACL: []queue.Item[inventory.NetworkACL]{
+				{
+					Value: inventory.NetworkACL{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.NetworkACL{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -346,18 +373,26 @@ func TestNetworkACLService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - networkACL get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - networkACL get by UUID - 1st",
+			repoGetByUUIDNetworkACL: []queue.Item[inventory.NetworkACL]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDNetworkACL: inventory.NetworkACL{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkACL: []queue.Item[inventory.NetworkACL]{
+				{
+					Value: inventory.NetworkACL{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -365,11 +400,15 @@ func TestNetworkACLService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkACL get by name",
-			repoGetByUUIDNetworkACL: inventory.NetworkACL{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkACL: []queue.Item[inventory.NetworkACL]{
+				{
+					Value: inventory.NetworkACL{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -384,11 +423,15 @@ func TestNetworkACLService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkACL get by name - not found - delete by uuid",
-			repoGetByUUIDNetworkACL: inventory.NetworkACL{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkACL: []queue.Item[inventory.NetworkACL]{
+				{
+					Value: inventory.NetworkACL{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -403,12 +446,49 @@ func TestNetworkACLService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - networkACL get by UUID - 2nd",
+			repoGetByUUIDNetworkACL: []queue.Item[inventory.NetworkACL]{
+				{
+					Value: inventory.NetworkACL{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDNetworkACL: inventory.NetworkACL{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "", // invalid
-				ProjectName: "project one",
+			repoGetByUUIDNetworkACL: []queue.Item[inventory.NetworkACL]{
+				{
+					Value: inventory.NetworkACL{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.NetworkACL{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -431,11 +511,23 @@ func TestNetworkACLService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDNetworkACL: inventory.NetworkACL{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkACL: []queue.Item[inventory.NetworkACL]{
+				{
+					Value: inventory.NetworkACL{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.NetworkACL{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -461,7 +553,7 @@ func TestNetworkACLService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.NetworkACLRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.NetworkACL, error) {
-					return tc.repoGetByUUIDNetworkACL, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDNetworkACL)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, networkACL inventory.NetworkACL) (inventory.NetworkACL, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), networkACL.LastUpdated)
@@ -481,8 +573,6 @@ func TestNetworkACLService_ResyncByUUID(t *testing.T) {
 
 			networkACLClient := &serverMock.NetworkACLServerClientMock{
 				GetNetworkACLByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, projectName string, networkACLName string) (incusapi.NetworkACL, error) {
-					require.Equal(t, tc.repoGetByUUIDNetworkACL.Name, networkACLName)
-					require.Equal(t, tc.repoGetByUUIDNetworkACL.ProjectName, projectName)
 					return tc.networkACLClientGetNetworkACLByName, tc.networkACLClientGetNetworkACLByNameErr
 				},
 			}
@@ -496,6 +586,8 @@ func TestNetworkACLService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDNetworkACL)
 		})
 	}
 }

--- a/internal/inventory/network_address_set_service_gen.go
+++ b/internal/inventory/network_address_set_service_gen.go
@@ -148,27 +148,32 @@ func (s networkAddressSetService) GetByUUID(ctx context.Context, id uuid.UUID) (
 }
 
 func (s networkAddressSetService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	networkAddressSet, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkAddressSet.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedNetworkAddressSet, err := s.networkAddressSetClient.GetNetworkAddressSetByName(ctx, endpoint, networkAddressSet.ProjectName, networkAddressSet.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, networkAddressSet.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete network_address_set %q from cluster %q: %w`, networkAddressSet.UUID.String(), networkAddressSet.Cluster, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		networkAddressSet, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkAddressSet.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedNetworkAddressSet, err := s.networkAddressSetClient.GetNetworkAddressSetByName(ctx, endpoint, networkAddressSet.ProjectName, networkAddressSet.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, networkAddressSet.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete network_address_set %q from cluster %q: %w`, networkAddressSet.UUID.String(), networkAddressSet.Cluster, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/network_address_set_service_gen_test.go
+++ b/internal/inventory/network_address_set_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -269,8 +270,7 @@ func TestNetworkAddressSetService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr                             error
 		networkAddressSetClientGetNetworkAddressSetByName    incusapi.NetworkAddressSet
 		networkAddressSetClientGetNetworkAddressSetByNameErr error
-		repoGetByUUIDNetworkAddressSet                       inventory.NetworkAddressSet
-		repoGetByUUIDErr                                     error
+		repoGetByUUIDNetworkAddressSet                       []queue.Item[inventory.NetworkAddressSet]
 		repoUpdateByUUIDErr                                  error
 		repoDeleteByUUIDErr                                  error
 
@@ -278,11 +278,23 @@ func TestNetworkAddressSetService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDNetworkAddressSet: inventory.NetworkAddressSet{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkAddressSet: []queue.Item[inventory.NetworkAddressSet]{
+				{
+					Value: inventory.NetworkAddressSet{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.NetworkAddressSet{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -302,11 +314,15 @@ func TestNetworkAddressSetService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - networkAddressSet get by name - not found",
-			repoGetByUUIDNetworkAddressSet: inventory.NetworkAddressSet{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkAddressSet: []queue.Item[inventory.NetworkAddressSet]{
+				{
+					Value: inventory.NetworkAddressSet{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -325,10 +341,21 @@ func TestNetworkAddressSetService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDNetworkAddressSet: inventory.NetworkAddressSet{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDNetworkAddressSet: []queue.Item[inventory.NetworkAddressSet]{
+				{
+					Value: inventory.NetworkAddressSet{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.NetworkAddressSet{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -346,18 +373,26 @@ func TestNetworkAddressSetService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - networkAddressSet get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - networkAddressSet get by UUID - 1st",
+			repoGetByUUIDNetworkAddressSet: []queue.Item[inventory.NetworkAddressSet]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDNetworkAddressSet: inventory.NetworkAddressSet{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkAddressSet: []queue.Item[inventory.NetworkAddressSet]{
+				{
+					Value: inventory.NetworkAddressSet{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -365,11 +400,15 @@ func TestNetworkAddressSetService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkAddressSet get by name",
-			repoGetByUUIDNetworkAddressSet: inventory.NetworkAddressSet{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkAddressSet: []queue.Item[inventory.NetworkAddressSet]{
+				{
+					Value: inventory.NetworkAddressSet{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -384,11 +423,15 @@ func TestNetworkAddressSetService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkAddressSet get by name - not found - delete by uuid",
-			repoGetByUUIDNetworkAddressSet: inventory.NetworkAddressSet{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkAddressSet: []queue.Item[inventory.NetworkAddressSet]{
+				{
+					Value: inventory.NetworkAddressSet{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -403,12 +446,49 @@ func TestNetworkAddressSetService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - networkAddressSet get by UUID - 2nd",
+			repoGetByUUIDNetworkAddressSet: []queue.Item[inventory.NetworkAddressSet]{
+				{
+					Value: inventory.NetworkAddressSet{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDNetworkAddressSet: inventory.NetworkAddressSet{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "", // invalid
-				ProjectName: "project one",
+			repoGetByUUIDNetworkAddressSet: []queue.Item[inventory.NetworkAddressSet]{
+				{
+					Value: inventory.NetworkAddressSet{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.NetworkAddressSet{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -431,11 +511,23 @@ func TestNetworkAddressSetService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDNetworkAddressSet: inventory.NetworkAddressSet{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkAddressSet: []queue.Item[inventory.NetworkAddressSet]{
+				{
+					Value: inventory.NetworkAddressSet{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.NetworkAddressSet{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -461,7 +553,7 @@ func TestNetworkAddressSetService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.NetworkAddressSetRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.NetworkAddressSet, error) {
-					return tc.repoGetByUUIDNetworkAddressSet, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDNetworkAddressSet)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, networkAddressSet inventory.NetworkAddressSet) (inventory.NetworkAddressSet, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), networkAddressSet.LastUpdated)
@@ -481,8 +573,6 @@ func TestNetworkAddressSetService_ResyncByUUID(t *testing.T) {
 
 			networkAddressSetClient := &serverMock.NetworkAddressSetServerClientMock{
 				GetNetworkAddressSetByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, projectName string, networkAddressSetName string) (incusapi.NetworkAddressSet, error) {
-					require.Equal(t, tc.repoGetByUUIDNetworkAddressSet.Name, networkAddressSetName)
-					require.Equal(t, tc.repoGetByUUIDNetworkAddressSet.ProjectName, projectName)
 					return tc.networkAddressSetClientGetNetworkAddressSetByName, tc.networkAddressSetClientGetNetworkAddressSetByNameErr
 				},
 			}
@@ -496,6 +586,8 @@ func TestNetworkAddressSetService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDNetworkAddressSet)
 		})
 	}
 }

--- a/internal/inventory/network_forward_service_gen.go
+++ b/internal/inventory/network_forward_service_gen.go
@@ -162,27 +162,32 @@ func (s networkForwardService) GetByUUID(ctx context.Context, id uuid.UUID) (Net
 }
 
 func (s networkForwardService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	networkForward, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkForward.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedNetworkForward, err := s.networkForwardClient.GetNetworkForwardByName(ctx, endpoint, networkForward.ProjectName, networkForward.NetworkName, networkForward.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, networkForward.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete network_forward %q from cluster %q, network %q: %w`, networkForward.UUID.String(), networkForward.Cluster, networkForward.NetworkName, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		networkForward, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkForward.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedNetworkForward, err := s.networkForwardClient.GetNetworkForwardByName(ctx, endpoint, networkForward.ProjectName, networkForward.NetworkName, networkForward.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, networkForward.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete network_forward %q from cluster %q, network %q: %w`, networkForward.UUID.String(), networkForward.Cluster, networkForward.NetworkName, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/network_forward_service_gen_test.go
+++ b/internal/inventory/network_forward_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -270,8 +271,7 @@ func TestNetworkForwardService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr                       error
 		networkForwardClientGetNetworkForwardByName    incusapi.NetworkForward
 		networkForwardClientGetNetworkForwardByNameErr error
-		repoGetByUUIDNetworkForward                    inventory.NetworkForward
-		repoGetByUUIDErr                               error
+		repoGetByUUIDNetworkForward                    []queue.Item[inventory.NetworkForward]
 		repoUpdateByUUIDErr                            error
 		repoDeleteByUUIDErr                            error
 
@@ -279,12 +279,25 @@ func TestNetworkForwardService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDNetworkForward: inventory.NetworkForward{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkForward: []queue.Item[inventory.NetworkForward]{
+				{
+					Value: inventory.NetworkForward{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Value: inventory.NetworkForward{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -301,12 +314,16 @@ func TestNetworkForwardService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - networkForward get by name - not found",
-			repoGetByUUIDNetworkForward: inventory.NetworkForward{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkForward: []queue.Item[inventory.NetworkForward]{
+				{
+					Value: inventory.NetworkForward{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -325,11 +342,23 @@ func TestNetworkForwardService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDNetworkForward: inventory.NetworkForward{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkForward: []queue.Item[inventory.NetworkForward]{
+				{
+					Value: inventory.NetworkForward{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Value: inventory.NetworkForward{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -345,19 +374,27 @@ func TestNetworkForwardService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - networkForward get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - networkForward get by UUID - 1st",
+			repoGetByUUIDNetworkForward: []queue.Item[inventory.NetworkForward]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDNetworkForward: inventory.NetworkForward{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkForward: []queue.Item[inventory.NetworkForward]{
+				{
+					Value: inventory.NetworkForward{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -365,12 +402,16 @@ func TestNetworkForwardService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkForward get by name",
-			repoGetByUUIDNetworkForward: inventory.NetworkForward{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkForward: []queue.Item[inventory.NetworkForward]{
+				{
+					Value: inventory.NetworkForward{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -385,12 +426,16 @@ func TestNetworkForwardService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkForward get by name - not found - delete by uuid",
-			repoGetByUUIDNetworkForward: inventory.NetworkForward{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkForward: []queue.Item[inventory.NetworkForward]{
+				{
+					Value: inventory.NetworkForward{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -405,13 +450,52 @@ func TestNetworkForwardService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - networkForward get by UUID - 2nd",
+			repoGetByUUIDNetworkForward: []queue.Item[inventory.NetworkForward]{
+				{
+					Value: inventory.NetworkForward{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDNetworkForward: inventory.NetworkForward{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "", // invalid
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkForward: []queue.Item[inventory.NetworkForward]{
+				{
+					Value: inventory.NetworkForward{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Value: inventory.NetworkForward{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -431,12 +515,25 @@ func TestNetworkForwardService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDNetworkForward: inventory.NetworkForward{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkForward: []queue.Item[inventory.NetworkForward]{
+				{
+					Value: inventory.NetworkForward{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Value: inventory.NetworkForward{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -459,7 +556,7 @@ func TestNetworkForwardService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.NetworkForwardRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.NetworkForward, error) {
-					return tc.repoGetByUUIDNetworkForward, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDNetworkForward)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, networkForward inventory.NetworkForward) (inventory.NetworkForward, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), networkForward.LastUpdated)
@@ -479,9 +576,6 @@ func TestNetworkForwardService_ResyncByUUID(t *testing.T) {
 
 			networkForwardClient := &serverMock.NetworkForwardServerClientMock{
 				GetNetworkForwardByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, projectName string, networkName string, networkForwardName string) (incusapi.NetworkForward, error) {
-					require.Equal(t, tc.repoGetByUUIDNetworkForward.Name, networkForwardName)
-					require.Equal(t, tc.repoGetByUUIDNetworkForward.ProjectName, projectName)
-					require.Equal(t, "network", networkName)
 					return tc.networkForwardClientGetNetworkForwardByName, tc.networkForwardClientGetNetworkForwardByNameErr
 				},
 			}
@@ -495,6 +589,8 @@ func TestNetworkForwardService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDNetworkForward)
 		})
 	}
 }

--- a/internal/inventory/network_integration_service_gen.go
+++ b/internal/inventory/network_integration_service_gen.go
@@ -148,27 +148,32 @@ func (s networkIntegrationService) GetByUUID(ctx context.Context, id uuid.UUID) 
 }
 
 func (s networkIntegrationService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	networkIntegration, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkIntegration.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedNetworkIntegration, err := s.networkIntegrationClient.GetNetworkIntegrationByName(ctx, endpoint, networkIntegration.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, networkIntegration.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete network_integration %q from cluster %q: %w`, networkIntegration.UUID.String(), networkIntegration.Cluster, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		networkIntegration, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkIntegration.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedNetworkIntegration, err := s.networkIntegrationClient.GetNetworkIntegrationByName(ctx, endpoint, networkIntegration.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, networkIntegration.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete network_integration %q from cluster %q: %w`, networkIntegration.UUID.String(), networkIntegration.Cluster, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/network_integration_service_gen_test.go
+++ b/internal/inventory/network_integration_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -268,8 +269,7 @@ func TestNetworkIntegrationService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr                               error
 		networkIntegrationClientGetNetworkIntegrationByName    incusapi.NetworkIntegration
 		networkIntegrationClientGetNetworkIntegrationByNameErr error
-		repoGetByUUIDNetworkIntegration                        inventory.NetworkIntegration
-		repoGetByUUIDErr                                       error
+		repoGetByUUIDNetworkIntegration                        []queue.Item[inventory.NetworkIntegration]
 		repoUpdateByUUIDErr                                    error
 		repoDeleteByUUIDErr                                    error
 
@@ -277,10 +277,21 @@ func TestNetworkIntegrationService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDNetworkIntegration: inventory.NetworkIntegration{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDNetworkIntegration: []queue.Item[inventory.NetworkIntegration]{
+				{
+					Value: inventory.NetworkIntegration{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.NetworkIntegration{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -297,10 +308,14 @@ func TestNetworkIntegrationService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - networkIntegration get by name - not found",
-			repoGetByUUIDNetworkIntegration: inventory.NetworkIntegration{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDNetworkIntegration: []queue.Item[inventory.NetworkIntegration]{
+				{
+					Value: inventory.NetworkIntegration{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -319,10 +334,21 @@ func TestNetworkIntegrationService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDNetworkIntegration: inventory.NetworkIntegration{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDNetworkIntegration: []queue.Item[inventory.NetworkIntegration]{
+				{
+					Value: inventory.NetworkIntegration{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.NetworkIntegration{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -338,17 +364,25 @@ func TestNetworkIntegrationService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - networkIntegration get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - networkIntegration get by UUID - 1st",
+			repoGetByUUIDNetworkIntegration: []queue.Item[inventory.NetworkIntegration]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDNetworkIntegration: inventory.NetworkIntegration{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDNetworkIntegration: []queue.Item[inventory.NetworkIntegration]{
+				{
+					Value: inventory.NetworkIntegration{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -356,10 +390,14 @@ func TestNetworkIntegrationService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkIntegration get by name",
-			repoGetByUUIDNetworkIntegration: inventory.NetworkIntegration{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDNetworkIntegration: []queue.Item[inventory.NetworkIntegration]{
+				{
+					Value: inventory.NetworkIntegration{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -374,10 +412,14 @@ func TestNetworkIntegrationService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkIntegration get by name - not found - delete by uuid",
-			repoGetByUUIDNetworkIntegration: inventory.NetworkIntegration{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDNetworkIntegration: []queue.Item[inventory.NetworkIntegration]{
+				{
+					Value: inventory.NetworkIntegration{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -392,11 +434,46 @@ func TestNetworkIntegrationService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - networkIntegration get by UUID - 2nd",
+			repoGetByUUIDNetworkIntegration: []queue.Item[inventory.NetworkIntegration]{
+				{
+					Value: inventory.NetworkIntegration{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDNetworkIntegration: inventory.NetworkIntegration{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "", // invalid
+			repoGetByUUIDNetworkIntegration: []queue.Item[inventory.NetworkIntegration]{
+				{
+					Value: inventory.NetworkIntegration{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "", // invalid
+					},
+				},
+				{
+					Value: inventory.NetworkIntegration{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "", // invalid
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -416,10 +493,21 @@ func TestNetworkIntegrationService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDNetworkIntegration: inventory.NetworkIntegration{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDNetworkIntegration: []queue.Item[inventory.NetworkIntegration]{
+				{
+					Value: inventory.NetworkIntegration{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.NetworkIntegration{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -442,7 +530,7 @@ func TestNetworkIntegrationService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.NetworkIntegrationRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.NetworkIntegration, error) {
-					return tc.repoGetByUUIDNetworkIntegration, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDNetworkIntegration)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, networkIntegration inventory.NetworkIntegration) (inventory.NetworkIntegration, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), networkIntegration.LastUpdated)
@@ -462,7 +550,6 @@ func TestNetworkIntegrationService_ResyncByUUID(t *testing.T) {
 
 			networkIntegrationClient := &serverMock.NetworkIntegrationServerClientMock{
 				GetNetworkIntegrationByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, networkIntegrationName string) (incusapi.NetworkIntegration, error) {
-					require.Equal(t, tc.repoGetByUUIDNetworkIntegration.Name, networkIntegrationName)
 					return tc.networkIntegrationClientGetNetworkIntegrationByName, tc.networkIntegrationClientGetNetworkIntegrationByNameErr
 				},
 			}
@@ -476,6 +563,8 @@ func TestNetworkIntegrationService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDNetworkIntegration)
 		})
 	}
 }

--- a/internal/inventory/network_load_balancer_service_gen.go
+++ b/internal/inventory/network_load_balancer_service_gen.go
@@ -162,27 +162,32 @@ func (s networkLoadBalancerService) GetByUUID(ctx context.Context, id uuid.UUID)
 }
 
 func (s networkLoadBalancerService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	networkLoadBalancer, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkLoadBalancer.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedNetworkLoadBalancer, err := s.networkLoadBalancerClient.GetNetworkLoadBalancerByName(ctx, endpoint, networkLoadBalancer.ProjectName, networkLoadBalancer.NetworkName, networkLoadBalancer.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, networkLoadBalancer.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete network_load_balancer %q from cluster %q, network %q: %w`, networkLoadBalancer.UUID.String(), networkLoadBalancer.Cluster, networkLoadBalancer.NetworkName, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		networkLoadBalancer, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkLoadBalancer.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedNetworkLoadBalancer, err := s.networkLoadBalancerClient.GetNetworkLoadBalancerByName(ctx, endpoint, networkLoadBalancer.ProjectName, networkLoadBalancer.NetworkName, networkLoadBalancer.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, networkLoadBalancer.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete network_load_balancer %q from cluster %q, network %q: %w`, networkLoadBalancer.UUID.String(), networkLoadBalancer.Cluster, networkLoadBalancer.NetworkName, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/network_load_balancer_service_gen_test.go
+++ b/internal/inventory/network_load_balancer_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -270,8 +271,7 @@ func TestNetworkLoadBalancerService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr                                 error
 		networkLoadBalancerClientGetNetworkLoadBalancerByName    incusapi.NetworkLoadBalancer
 		networkLoadBalancerClientGetNetworkLoadBalancerByNameErr error
-		repoGetByUUIDNetworkLoadBalancer                         inventory.NetworkLoadBalancer
-		repoGetByUUIDErr                                         error
+		repoGetByUUIDNetworkLoadBalancer                         []queue.Item[inventory.NetworkLoadBalancer]
 		repoUpdateByUUIDErr                                      error
 		repoDeleteByUUIDErr                                      error
 
@@ -279,12 +279,25 @@ func TestNetworkLoadBalancerService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDNetworkLoadBalancer: inventory.NetworkLoadBalancer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkLoadBalancer: []queue.Item[inventory.NetworkLoadBalancer]{
+				{
+					Value: inventory.NetworkLoadBalancer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Value: inventory.NetworkLoadBalancer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -301,12 +314,16 @@ func TestNetworkLoadBalancerService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - networkLoadBalancer get by name - not found",
-			repoGetByUUIDNetworkLoadBalancer: inventory.NetworkLoadBalancer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkLoadBalancer: []queue.Item[inventory.NetworkLoadBalancer]{
+				{
+					Value: inventory.NetworkLoadBalancer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -325,11 +342,23 @@ func TestNetworkLoadBalancerService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDNetworkLoadBalancer: inventory.NetworkLoadBalancer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkLoadBalancer: []queue.Item[inventory.NetworkLoadBalancer]{
+				{
+					Value: inventory.NetworkLoadBalancer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Value: inventory.NetworkLoadBalancer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -345,19 +374,27 @@ func TestNetworkLoadBalancerService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - networkLoadBalancer get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - networkLoadBalancer get by UUID - 1st",
+			repoGetByUUIDNetworkLoadBalancer: []queue.Item[inventory.NetworkLoadBalancer]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDNetworkLoadBalancer: inventory.NetworkLoadBalancer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkLoadBalancer: []queue.Item[inventory.NetworkLoadBalancer]{
+				{
+					Value: inventory.NetworkLoadBalancer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -365,12 +402,16 @@ func TestNetworkLoadBalancerService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkLoadBalancer get by name",
-			repoGetByUUIDNetworkLoadBalancer: inventory.NetworkLoadBalancer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkLoadBalancer: []queue.Item[inventory.NetworkLoadBalancer]{
+				{
+					Value: inventory.NetworkLoadBalancer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -385,12 +426,16 @@ func TestNetworkLoadBalancerService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkLoadBalancer get by name - not found - delete by uuid",
-			repoGetByUUIDNetworkLoadBalancer: inventory.NetworkLoadBalancer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkLoadBalancer: []queue.Item[inventory.NetworkLoadBalancer]{
+				{
+					Value: inventory.NetworkLoadBalancer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -405,13 +450,52 @@ func TestNetworkLoadBalancerService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - networkLoadBalancer get by UUID - 2nd",
+			repoGetByUUIDNetworkLoadBalancer: []queue.Item[inventory.NetworkLoadBalancer]{
+				{
+					Value: inventory.NetworkLoadBalancer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDNetworkLoadBalancer: inventory.NetworkLoadBalancer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "", // invalid
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkLoadBalancer: []queue.Item[inventory.NetworkLoadBalancer]{
+				{
+					Value: inventory.NetworkLoadBalancer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Value: inventory.NetworkLoadBalancer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -431,12 +515,25 @@ func TestNetworkLoadBalancerService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDNetworkLoadBalancer: inventory.NetworkLoadBalancer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkLoadBalancer: []queue.Item[inventory.NetworkLoadBalancer]{
+				{
+					Value: inventory.NetworkLoadBalancer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Value: inventory.NetworkLoadBalancer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -459,7 +556,7 @@ func TestNetworkLoadBalancerService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.NetworkLoadBalancerRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.NetworkLoadBalancer, error) {
-					return tc.repoGetByUUIDNetworkLoadBalancer, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDNetworkLoadBalancer)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, networkLoadBalancer inventory.NetworkLoadBalancer) (inventory.NetworkLoadBalancer, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), networkLoadBalancer.LastUpdated)
@@ -479,9 +576,6 @@ func TestNetworkLoadBalancerService_ResyncByUUID(t *testing.T) {
 
 			networkLoadBalancerClient := &serverMock.NetworkLoadBalancerServerClientMock{
 				GetNetworkLoadBalancerByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, projectName string, networkName string, networkLoadBalancerName string) (incusapi.NetworkLoadBalancer, error) {
-					require.Equal(t, tc.repoGetByUUIDNetworkLoadBalancer.Name, networkLoadBalancerName)
-					require.Equal(t, tc.repoGetByUUIDNetworkLoadBalancer.ProjectName, projectName)
-					require.Equal(t, "network", networkName)
 					return tc.networkLoadBalancerClientGetNetworkLoadBalancerByName, tc.networkLoadBalancerClientGetNetworkLoadBalancerByNameErr
 				},
 			}
@@ -495,6 +589,8 @@ func TestNetworkLoadBalancerService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDNetworkLoadBalancer)
 		})
 	}
 }

--- a/internal/inventory/network_peer_service_gen.go
+++ b/internal/inventory/network_peer_service_gen.go
@@ -162,27 +162,32 @@ func (s networkPeerService) GetByUUID(ctx context.Context, id uuid.UUID) (Networ
 }
 
 func (s networkPeerService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	networkPeer, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkPeer.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedNetworkPeer, err := s.networkPeerClient.GetNetworkPeerByName(ctx, endpoint, networkPeer.ProjectName, networkPeer.NetworkName, networkPeer.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, networkPeer.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete network_peer %q from cluster %q, network %q: %w`, networkPeer.UUID.String(), networkPeer.Cluster, networkPeer.NetworkName, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		networkPeer, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkPeer.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedNetworkPeer, err := s.networkPeerClient.GetNetworkPeerByName(ctx, endpoint, networkPeer.ProjectName, networkPeer.NetworkName, networkPeer.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, networkPeer.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete network_peer %q from cluster %q, network %q: %w`, networkPeer.UUID.String(), networkPeer.Cluster, networkPeer.NetworkName, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/network_peer_service_gen_test.go
+++ b/internal/inventory/network_peer_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -270,8 +271,7 @@ func TestNetworkPeerService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr                 error
 		networkPeerClientGetNetworkPeerByName    incusapi.NetworkPeer
 		networkPeerClientGetNetworkPeerByNameErr error
-		repoGetByUUIDNetworkPeer                 inventory.NetworkPeer
-		repoGetByUUIDErr                         error
+		repoGetByUUIDNetworkPeer                 []queue.Item[inventory.NetworkPeer]
 		repoUpdateByUUIDErr                      error
 		repoDeleteByUUIDErr                      error
 
@@ -279,12 +279,25 @@ func TestNetworkPeerService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDNetworkPeer: inventory.NetworkPeer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkPeer: []queue.Item[inventory.NetworkPeer]{
+				{
+					Value: inventory.NetworkPeer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Value: inventory.NetworkPeer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -301,12 +314,16 @@ func TestNetworkPeerService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - networkPeer get by name - not found",
-			repoGetByUUIDNetworkPeer: inventory.NetworkPeer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkPeer: []queue.Item[inventory.NetworkPeer]{
+				{
+					Value: inventory.NetworkPeer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -325,11 +342,23 @@ func TestNetworkPeerService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDNetworkPeer: inventory.NetworkPeer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkPeer: []queue.Item[inventory.NetworkPeer]{
+				{
+					Value: inventory.NetworkPeer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Value: inventory.NetworkPeer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -345,19 +374,27 @@ func TestNetworkPeerService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - networkPeer get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - networkPeer get by UUID - 1st",
+			repoGetByUUIDNetworkPeer: []queue.Item[inventory.NetworkPeer]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDNetworkPeer: inventory.NetworkPeer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkPeer: []queue.Item[inventory.NetworkPeer]{
+				{
+					Value: inventory.NetworkPeer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -365,12 +402,16 @@ func TestNetworkPeerService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkPeer get by name",
-			repoGetByUUIDNetworkPeer: inventory.NetworkPeer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkPeer: []queue.Item[inventory.NetworkPeer]{
+				{
+					Value: inventory.NetworkPeer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -385,12 +426,16 @@ func TestNetworkPeerService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkPeer get by name - not found - delete by uuid",
-			repoGetByUUIDNetworkPeer: inventory.NetworkPeer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkPeer: []queue.Item[inventory.NetworkPeer]{
+				{
+					Value: inventory.NetworkPeer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -405,13 +450,52 @@ func TestNetworkPeerService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - networkPeer get by UUID - 2nd",
+			repoGetByUUIDNetworkPeer: []queue.Item[inventory.NetworkPeer]{
+				{
+					Value: inventory.NetworkPeer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDNetworkPeer: inventory.NetworkPeer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "", // invalid
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkPeer: []queue.Item[inventory.NetworkPeer]{
+				{
+					Value: inventory.NetworkPeer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Value: inventory.NetworkPeer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -431,12 +515,25 @@ func TestNetworkPeerService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDNetworkPeer: inventory.NetworkPeer{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
-				NetworkName: "network",
+			repoGetByUUIDNetworkPeer: []queue.Item[inventory.NetworkPeer]{
+				{
+					Value: inventory.NetworkPeer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
+				{
+					Value: inventory.NetworkPeer{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+						NetworkName: "network",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -459,7 +556,7 @@ func TestNetworkPeerService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.NetworkPeerRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.NetworkPeer, error) {
-					return tc.repoGetByUUIDNetworkPeer, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDNetworkPeer)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, networkPeer inventory.NetworkPeer) (inventory.NetworkPeer, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), networkPeer.LastUpdated)
@@ -479,9 +576,6 @@ func TestNetworkPeerService_ResyncByUUID(t *testing.T) {
 
 			networkPeerClient := &serverMock.NetworkPeerServerClientMock{
 				GetNetworkPeerByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, projectName string, networkName string, networkPeerName string) (incusapi.NetworkPeer, error) {
-					require.Equal(t, tc.repoGetByUUIDNetworkPeer.Name, networkPeerName)
-					require.Equal(t, tc.repoGetByUUIDNetworkPeer.ProjectName, projectName)
-					require.Equal(t, "network", networkName)
 					return tc.networkPeerClientGetNetworkPeerByName, tc.networkPeerClientGetNetworkPeerByNameErr
 				},
 			}
@@ -495,6 +589,8 @@ func TestNetworkPeerService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDNetworkPeer)
 		})
 	}
 }

--- a/internal/inventory/network_service_gen.go
+++ b/internal/inventory/network_service_gen.go
@@ -148,27 +148,32 @@ func (s networkService) GetByUUID(ctx context.Context, id uuid.UUID) (Network, e
 }
 
 func (s networkService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	network, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, network.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedNetwork, err := s.networkClient.GetNetworkByName(ctx, endpoint, network.ProjectName, network.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, network.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete network %q from cluster %q: %w`, network.UUID.String(), network.Cluster, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		network, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, network.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedNetwork, err := s.networkClient.GetNetworkByName(ctx, endpoint, network.ProjectName, network.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, network.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete network %q from cluster %q: %w`, network.UUID.String(), network.Cluster, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/network_service_gen_test.go
+++ b/internal/inventory/network_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -269,8 +270,7 @@ func TestNetworkService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr         error
 		networkClientGetNetworkByName    incusapi.Network
 		networkClientGetNetworkByNameErr error
-		repoGetByUUIDNetwork             inventory.Network
-		repoGetByUUIDErr                 error
+		repoGetByUUIDNetwork             []queue.Item[inventory.Network]
 		repoUpdateByUUIDErr              error
 		repoDeleteByUUIDErr              error
 
@@ -278,11 +278,23 @@ func TestNetworkService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDNetwork: inventory.Network{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetwork: []queue.Item[inventory.Network]{
+				{
+					Value: inventory.Network{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.Network{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -300,11 +312,15 @@ func TestNetworkService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - network get by name - not found",
-			repoGetByUUIDNetwork: inventory.Network{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetwork: []queue.Item[inventory.Network]{
+				{
+					Value: inventory.Network{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -323,10 +339,21 @@ func TestNetworkService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDNetwork: inventory.Network{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDNetwork: []queue.Item[inventory.Network]{
+				{
+					Value: inventory.Network{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.Network{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -342,18 +369,26 @@ func TestNetworkService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - network get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - network get by UUID - 1st",
+			repoGetByUUIDNetwork: []queue.Item[inventory.Network]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDNetwork: inventory.Network{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetwork: []queue.Item[inventory.Network]{
+				{
+					Value: inventory.Network{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -361,11 +396,15 @@ func TestNetworkService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - network get by name",
-			repoGetByUUIDNetwork: inventory.Network{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetwork: []queue.Item[inventory.Network]{
+				{
+					Value: inventory.Network{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -380,11 +419,15 @@ func TestNetworkService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - network get by name - not found - delete by uuid",
-			repoGetByUUIDNetwork: inventory.Network{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetwork: []queue.Item[inventory.Network]{
+				{
+					Value: inventory.Network{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -399,12 +442,49 @@ func TestNetworkService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - network get by UUID - 2nd",
+			repoGetByUUIDNetwork: []queue.Item[inventory.Network]{
+				{
+					Value: inventory.Network{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDNetwork: inventory.Network{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "", // invalid
-				ProjectName: "project one",
+			repoGetByUUIDNetwork: []queue.Item[inventory.Network]{
+				{
+					Value: inventory.Network{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.Network{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -425,11 +505,23 @@ func TestNetworkService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDNetwork: inventory.Network{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetwork: []queue.Item[inventory.Network]{
+				{
+					Value: inventory.Network{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.Network{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -453,7 +545,7 @@ func TestNetworkService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.NetworkRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.Network, error) {
-					return tc.repoGetByUUIDNetwork, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDNetwork)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, network inventory.Network) (inventory.Network, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), network.LastUpdated)
@@ -473,8 +565,6 @@ func TestNetworkService_ResyncByUUID(t *testing.T) {
 
 			networkClient := &serverMock.NetworkServerClientMock{
 				GetNetworkByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, projectName string, networkName string) (incusapi.Network, error) {
-					require.Equal(t, tc.repoGetByUUIDNetwork.Name, networkName)
-					require.Equal(t, tc.repoGetByUUIDNetwork.ProjectName, projectName)
 					return tc.networkClientGetNetworkByName, tc.networkClientGetNetworkByNameErr
 				},
 			}
@@ -488,6 +578,8 @@ func TestNetworkService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDNetwork)
 		})
 	}
 }

--- a/internal/inventory/network_zone_service_gen.go
+++ b/internal/inventory/network_zone_service_gen.go
@@ -148,27 +148,32 @@ func (s networkZoneService) GetByUUID(ctx context.Context, id uuid.UUID) (Networ
 }
 
 func (s networkZoneService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	networkZone, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkZone.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedNetworkZone, err := s.networkZoneClient.GetNetworkZoneByName(ctx, endpoint, networkZone.ProjectName, networkZone.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, networkZone.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete network_zone %q from cluster %q: %w`, networkZone.UUID.String(), networkZone.Cluster, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		networkZone, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, networkZone.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedNetworkZone, err := s.networkZoneClient.GetNetworkZoneByName(ctx, endpoint, networkZone.ProjectName, networkZone.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, networkZone.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete network_zone %q from cluster %q: %w`, networkZone.UUID.String(), networkZone.Cluster, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/network_zone_service_gen_test.go
+++ b/internal/inventory/network_zone_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -269,8 +270,7 @@ func TestNetworkZoneService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr                 error
 		networkZoneClientGetNetworkZoneByName    incusapi.NetworkZone
 		networkZoneClientGetNetworkZoneByNameErr error
-		repoGetByUUIDNetworkZone                 inventory.NetworkZone
-		repoGetByUUIDErr                         error
+		repoGetByUUIDNetworkZone                 []queue.Item[inventory.NetworkZone]
 		repoUpdateByUUIDErr                      error
 		repoDeleteByUUIDErr                      error
 
@@ -278,11 +278,23 @@ func TestNetworkZoneService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDNetworkZone: inventory.NetworkZone{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkZone: []queue.Item[inventory.NetworkZone]{
+				{
+					Value: inventory.NetworkZone{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.NetworkZone{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -300,11 +312,15 @@ func TestNetworkZoneService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - networkZone get by name - not found",
-			repoGetByUUIDNetworkZone: inventory.NetworkZone{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkZone: []queue.Item[inventory.NetworkZone]{
+				{
+					Value: inventory.NetworkZone{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -323,10 +339,21 @@ func TestNetworkZoneService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDNetworkZone: inventory.NetworkZone{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDNetworkZone: []queue.Item[inventory.NetworkZone]{
+				{
+					Value: inventory.NetworkZone{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.NetworkZone{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -342,18 +369,26 @@ func TestNetworkZoneService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - networkZone get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - networkZone get by UUID - 1st",
+			repoGetByUUIDNetworkZone: []queue.Item[inventory.NetworkZone]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDNetworkZone: inventory.NetworkZone{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkZone: []queue.Item[inventory.NetworkZone]{
+				{
+					Value: inventory.NetworkZone{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -361,11 +396,15 @@ func TestNetworkZoneService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkZone get by name",
-			repoGetByUUIDNetworkZone: inventory.NetworkZone{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkZone: []queue.Item[inventory.NetworkZone]{
+				{
+					Value: inventory.NetworkZone{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -380,11 +419,15 @@ func TestNetworkZoneService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - networkZone get by name - not found - delete by uuid",
-			repoGetByUUIDNetworkZone: inventory.NetworkZone{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkZone: []queue.Item[inventory.NetworkZone]{
+				{
+					Value: inventory.NetworkZone{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -399,12 +442,49 @@ func TestNetworkZoneService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - networkZone get by UUID - 2nd",
+			repoGetByUUIDNetworkZone: []queue.Item[inventory.NetworkZone]{
+				{
+					Value: inventory.NetworkZone{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDNetworkZone: inventory.NetworkZone{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "", // invalid
-				ProjectName: "project one",
+			repoGetByUUIDNetworkZone: []queue.Item[inventory.NetworkZone]{
+				{
+					Value: inventory.NetworkZone{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.NetworkZone{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -425,11 +505,23 @@ func TestNetworkZoneService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDNetworkZone: inventory.NetworkZone{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDNetworkZone: []queue.Item[inventory.NetworkZone]{
+				{
+					Value: inventory.NetworkZone{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.NetworkZone{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -453,7 +545,7 @@ func TestNetworkZoneService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.NetworkZoneRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.NetworkZone, error) {
-					return tc.repoGetByUUIDNetworkZone, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDNetworkZone)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, networkZone inventory.NetworkZone) (inventory.NetworkZone, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), networkZone.LastUpdated)
@@ -473,8 +565,6 @@ func TestNetworkZoneService_ResyncByUUID(t *testing.T) {
 
 			networkZoneClient := &serverMock.NetworkZoneServerClientMock{
 				GetNetworkZoneByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, projectName string, networkZoneName string) (incusapi.NetworkZone, error) {
-					require.Equal(t, tc.repoGetByUUIDNetworkZone.Name, networkZoneName)
-					require.Equal(t, tc.repoGetByUUIDNetworkZone.ProjectName, projectName)
 					return tc.networkZoneClientGetNetworkZoneByName, tc.networkZoneClientGetNetworkZoneByNameErr
 				},
 			}
@@ -488,6 +578,8 @@ func TestNetworkZoneService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDNetworkZone)
 		})
 	}
 }

--- a/internal/inventory/profile_service_gen.go
+++ b/internal/inventory/profile_service_gen.go
@@ -148,27 +148,32 @@ func (s profileService) GetByUUID(ctx context.Context, id uuid.UUID) (Profile, e
 }
 
 func (s profileService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	profile, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, profile.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedProfile, err := s.profileClient.GetProfileByName(ctx, endpoint, profile.ProjectName, profile.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, profile.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete profile %q from cluster %q: %w`, profile.UUID.String(), profile.Cluster, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		profile, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, profile.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedProfile, err := s.profileClient.GetProfileByName(ctx, endpoint, profile.ProjectName, profile.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, profile.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete profile %q from cluster %q: %w`, profile.UUID.String(), profile.Cluster, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/profile_service_gen_test.go
+++ b/internal/inventory/profile_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -269,8 +270,7 @@ func TestProfileService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr         error
 		profileClientGetProfileByName    incusapi.Profile
 		profileClientGetProfileByNameErr error
-		repoGetByUUIDProfile             inventory.Profile
-		repoGetByUUIDErr                 error
+		repoGetByUUIDProfile             []queue.Item[inventory.Profile]
 		repoUpdateByUUIDErr              error
 		repoDeleteByUUIDErr              error
 
@@ -278,11 +278,23 @@ func TestProfileService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDProfile: inventory.Profile{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDProfile: []queue.Item[inventory.Profile]{
+				{
+					Value: inventory.Profile{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.Profile{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -300,11 +312,15 @@ func TestProfileService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - profile get by name - not found",
-			repoGetByUUIDProfile: inventory.Profile{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDProfile: []queue.Item[inventory.Profile]{
+				{
+					Value: inventory.Profile{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -323,10 +339,21 @@ func TestProfileService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDProfile: inventory.Profile{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDProfile: []queue.Item[inventory.Profile]{
+				{
+					Value: inventory.Profile{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.Profile{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -342,18 +369,26 @@ func TestProfileService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - profile get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - profile get by UUID - 1st",
+			repoGetByUUIDProfile: []queue.Item[inventory.Profile]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDProfile: inventory.Profile{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDProfile: []queue.Item[inventory.Profile]{
+				{
+					Value: inventory.Profile{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -361,11 +396,15 @@ func TestProfileService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - profile get by name",
-			repoGetByUUIDProfile: inventory.Profile{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDProfile: []queue.Item[inventory.Profile]{
+				{
+					Value: inventory.Profile{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -380,11 +419,15 @@ func TestProfileService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - profile get by name - not found - delete by uuid",
-			repoGetByUUIDProfile: inventory.Profile{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDProfile: []queue.Item[inventory.Profile]{
+				{
+					Value: inventory.Profile{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -399,12 +442,49 @@ func TestProfileService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - profile get by UUID - 2nd",
+			repoGetByUUIDProfile: []queue.Item[inventory.Profile]{
+				{
+					Value: inventory.Profile{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDProfile: inventory.Profile{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "", // invalid
-				ProjectName: "project one",
+			repoGetByUUIDProfile: []queue.Item[inventory.Profile]{
+				{
+					Value: inventory.Profile{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.Profile{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "", // invalid
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -425,11 +505,23 @@ func TestProfileService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDProfile: inventory.Profile{
-				UUID:        uuidgen.FromPattern(t, "1"),
-				Cluster:     "one",
-				Name:        "one",
-				ProjectName: "project one",
+			repoGetByUUIDProfile: []queue.Item[inventory.Profile]{
+				{
+					Value: inventory.Profile{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
+				{
+					Value: inventory.Profile{
+						UUID:        uuidgen.FromPattern(t, "1"),
+						Cluster:     "one",
+						Name:        "one",
+						ProjectName: "project one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -453,7 +545,7 @@ func TestProfileService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.ProfileRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.Profile, error) {
-					return tc.repoGetByUUIDProfile, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDProfile)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, profile inventory.Profile) (inventory.Profile, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), profile.LastUpdated)
@@ -473,8 +565,6 @@ func TestProfileService_ResyncByUUID(t *testing.T) {
 
 			profileClient := &serverMock.ProfileServerClientMock{
 				GetProfileByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, projectName string, profileName string) (incusapi.Profile, error) {
-					require.Equal(t, tc.repoGetByUUIDProfile.Name, profileName)
-					require.Equal(t, tc.repoGetByUUIDProfile.ProjectName, projectName)
 					return tc.profileClientGetProfileByName, tc.profileClientGetProfileByNameErr
 				},
 			}
@@ -488,6 +578,8 @@ func TestProfileService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDProfile)
 		})
 	}
 }

--- a/internal/inventory/project_service_gen.go
+++ b/internal/inventory/project_service_gen.go
@@ -148,27 +148,32 @@ func (s projectService) GetByUUID(ctx context.Context, id uuid.UUID) (Project, e
 }
 
 func (s projectService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	project, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, project.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedProject, err := s.projectClient.GetProjectByName(ctx, endpoint, project.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, project.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete project %q from cluster %q: %w`, project.UUID.String(), project.Cluster, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		project, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, project.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedProject, err := s.projectClient.GetProjectByName(ctx, endpoint, project.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, project.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete project %q from cluster %q: %w`, project.UUID.String(), project.Cluster, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/project_service_gen_test.go
+++ b/internal/inventory/project_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -268,8 +269,7 @@ func TestProjectService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr         error
 		projectClientGetProjectByName    incusapi.Project
 		projectClientGetProjectByNameErr error
-		repoGetByUUIDProject             inventory.Project
-		repoGetByUUIDErr                 error
+		repoGetByUUIDProject             []queue.Item[inventory.Project]
 		repoUpdateByUUIDErr              error
 		repoDeleteByUUIDErr              error
 
@@ -277,10 +277,21 @@ func TestProjectService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDProject: inventory.Project{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDProject: []queue.Item[inventory.Project]{
+				{
+					Value: inventory.Project{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.Project{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -297,10 +308,14 @@ func TestProjectService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - project get by name - not found",
-			repoGetByUUIDProject: inventory.Project{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDProject: []queue.Item[inventory.Project]{
+				{
+					Value: inventory.Project{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -319,10 +334,21 @@ func TestProjectService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDProject: inventory.Project{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDProject: []queue.Item[inventory.Project]{
+				{
+					Value: inventory.Project{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.Project{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -338,17 +364,25 @@ func TestProjectService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - project get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - project get by UUID - 1st",
+			repoGetByUUIDProject: []queue.Item[inventory.Project]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDProject: inventory.Project{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDProject: []queue.Item[inventory.Project]{
+				{
+					Value: inventory.Project{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -356,10 +390,14 @@ func TestProjectService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - project get by name",
-			repoGetByUUIDProject: inventory.Project{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDProject: []queue.Item[inventory.Project]{
+				{
+					Value: inventory.Project{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -374,10 +412,14 @@ func TestProjectService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - project get by name - not found - delete by uuid",
-			repoGetByUUIDProject: inventory.Project{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDProject: []queue.Item[inventory.Project]{
+				{
+					Value: inventory.Project{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -392,11 +434,46 @@ func TestProjectService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - project get by UUID - 2nd",
+			repoGetByUUIDProject: []queue.Item[inventory.Project]{
+				{
+					Value: inventory.Project{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDProject: inventory.Project{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "", // invalid
+			repoGetByUUIDProject: []queue.Item[inventory.Project]{
+				{
+					Value: inventory.Project{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "", // invalid
+					},
+				},
+				{
+					Value: inventory.Project{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "", // invalid
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -416,10 +493,21 @@ func TestProjectService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDProject: inventory.Project{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDProject: []queue.Item[inventory.Project]{
+				{
+					Value: inventory.Project{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.Project{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -442,7 +530,7 @@ func TestProjectService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.ProjectRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.Project, error) {
-					return tc.repoGetByUUIDProject, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDProject)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, project inventory.Project) (inventory.Project, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), project.LastUpdated)
@@ -462,7 +550,6 @@ func TestProjectService_ResyncByUUID(t *testing.T) {
 
 			projectClient := &serverMock.ProjectServerClientMock{
 				GetProjectByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, projectName string) (incusapi.Project, error) {
-					require.Equal(t, tc.repoGetByUUIDProject.Name, projectName)
 					return tc.projectClientGetProjectByName, tc.projectClientGetProjectByNameErr
 				},
 			}
@@ -476,6 +563,8 @@ func TestProjectService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDProject)
 		})
 	}
 }

--- a/internal/inventory/server/incus/client.go
+++ b/internal/inventory/server/incus/client.go
@@ -3,6 +3,7 @@ package incus
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 
@@ -10,6 +11,8 @@ import (
 
 	"github.com/FuturFusion/operations-center/internal/inventory"
 	"github.com/FuturFusion/operations-center/internal/provisioning"
+	"github.com/FuturFusion/operations-center/internal/sql/transaction"
+	"github.com/FuturFusion/operations-center/internal/util/logger"
 )
 
 type serverClient struct {
@@ -53,6 +56,10 @@ func New(clientCert string, clientKey string, opts ...Option) inventory.ServerCl
 }
 
 func (s serverClient) getClient(ctx context.Context, endpoint provisioning.Endpoint) (incus.InstanceServer, error) {
+	if transaction.IsActive(ctx) {
+		slog.WarnContext(ctx, "Incus API call inside of a transaction", logger.AddStacktrace())
+	}
+
 	serverName, err := endpoint.GetServerName()
 	if err != nil {
 		return nil, err

--- a/internal/inventory/server/incus/client_test.go
+++ b/internal/inventory/server/incus/client_test.go
@@ -1,6 +1,7 @@
 package incus_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -19,6 +20,9 @@ import (
 	"github.com/FuturFusion/operations-center/internal/inventory"
 	"github.com/FuturFusion/operations-center/internal/inventory/server/incus"
 	"github.com/FuturFusion/operations-center/internal/provisioning"
+	"github.com/FuturFusion/operations-center/internal/sql/transaction"
+	"github.com/FuturFusion/operations-center/internal/util/logger"
+	"github.com/FuturFusion/operations-center/internal/util/testing/log"
 	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 )
 
@@ -253,6 +257,58 @@ func TestClient_HasExtension(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestClient_in_transaction(t *testing.T) {
+	// Setup
+	caPool, certPEM, keyPEM := setupCerts(t)
+
+	logBuf := &bytes.Buffer{}
+	err := logger.InitLogger(logBuf, "", false, false, false)
+	require.NoError(t, err)
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(
+			[]byte(`{
+  "metadata": {
+    "api_extensions": [
+      "foobar"
+    ]
+  }
+}`),
+		)
+	}))
+	server.TLS = &tls.Config{
+		NextProtos: []string{"h2", "http/1.1"},
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  caPool,
+	}
+
+	server.StartTLS()
+	defer server.Close()
+
+	client := incus.New(certPEM, keyPEM)
+
+	serverCert := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: server.Certificate().Raw,
+	})
+
+	target := provisioning.Server{
+		ConnectionURL: server.URL,
+		Certificate:   string(serverCert),
+	}
+
+	// Run test
+	err = transaction.Do(t.Context(), func(ctx context.Context) error {
+		_ = client.HasExtension(ctx, target, "foobar")
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Assert
+	log.Contains("Incus API call inside of a transaction")(t, logBuf)
 }
 
 func endpointGetClientErr(t *testing.T, method methodTestSet, caPool *x509.CertPool, certPEM string) {

--- a/internal/inventory/storage_bucket_service_gen.go
+++ b/internal/inventory/storage_bucket_service_gen.go
@@ -163,27 +163,32 @@ func (s storageBucketService) GetByUUID(ctx context.Context, id uuid.UUID) (Stor
 }
 
 func (s storageBucketService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	storageBucket, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, storageBucket.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedStorageBucket, err := s.storageBucketClient.GetStorageBucketByName(ctx, endpoint, storageBucket.ProjectName, storageBucket.StoragePoolName, storageBucket.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, storageBucket.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete storage_bucket %q from cluster %q, storage_pool %q: %w`, storageBucket.UUID.String(), storageBucket.Cluster, storageBucket.StoragePoolName, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		storageBucket, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, storageBucket.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedStorageBucket, err := s.storageBucketClient.GetStorageBucketByName(ctx, endpoint, storageBucket.ProjectName, storageBucket.StoragePoolName, storageBucket.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, storageBucket.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete storage_bucket %q from cluster %q, storage_pool %q: %w`, storageBucket.UUID.String(), storageBucket.Cluster, storageBucket.StoragePoolName, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/storage_bucket_service_gen_test.go
+++ b/internal/inventory/storage_bucket_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -270,8 +271,7 @@ func TestStorageBucketService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr                     error
 		storageBucketClientGetStorageBucketByName    incusapi.StorageBucketFull
 		storageBucketClientGetStorageBucketByNameErr error
-		repoGetByUUIDStorageBucket                   inventory.StorageBucket
-		repoGetByUUIDErr                             error
+		repoGetByUUIDStorageBucket                   []queue.Item[inventory.StorageBucket]
 		repoUpdateByUUIDErr                          error
 		repoDeleteByUUIDErr                          error
 
@@ -279,12 +279,25 @@ func TestStorageBucketService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDStorageBucket: inventory.StorageBucket{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageBucket: []queue.Item[inventory.StorageBucket]{
+				{
+					Value: inventory.StorageBucket{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
+				{
+					Value: inventory.StorageBucket{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -305,12 +318,16 @@ func TestStorageBucketService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - storageBucket get by name - not found",
-			repoGetByUUIDStorageBucket: inventory.StorageBucket{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageBucket: []queue.Item[inventory.StorageBucket]{
+				{
+					Value: inventory.StorageBucket{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -329,11 +346,23 @@ func TestStorageBucketService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDStorageBucket: inventory.StorageBucket{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageBucket: []queue.Item[inventory.StorageBucket]{
+				{
+					Value: inventory.StorageBucket{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						StoragePoolName: "storage_pool",
+					},
+				},
+				{
+					Value: inventory.StorageBucket{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -352,19 +381,27 @@ func TestStorageBucketService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - storageBucket get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - storageBucket get by UUID - 1st",
+			repoGetByUUIDStorageBucket: []queue.Item[inventory.StorageBucket]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDStorageBucket: inventory.StorageBucket{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageBucket: []queue.Item[inventory.StorageBucket]{
+				{
+					Value: inventory.StorageBucket{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -372,12 +409,16 @@ func TestStorageBucketService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - storageBucket get by name",
-			repoGetByUUIDStorageBucket: inventory.StorageBucket{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageBucket: []queue.Item[inventory.StorageBucket]{
+				{
+					Value: inventory.StorageBucket{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -392,12 +433,16 @@ func TestStorageBucketService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - storageBucket get by name - not found - delete by uuid",
-			repoGetByUUIDStorageBucket: inventory.StorageBucket{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageBucket: []queue.Item[inventory.StorageBucket]{
+				{
+					Value: inventory.StorageBucket{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -412,13 +457,52 @@ func TestStorageBucketService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - storageBucket get by UUID - 2nd",
+			repoGetByUUIDStorageBucket: []queue.Item[inventory.StorageBucket]{
+				{
+					Value: inventory.StorageBucket{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDStorageBucket: inventory.StorageBucket{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "", // invalid
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageBucket: []queue.Item[inventory.StorageBucket]{
+				{
+					Value: inventory.StorageBucket{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "", // invalid
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
+				{
+					Value: inventory.StorageBucket{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "", // invalid
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -442,12 +526,25 @@ func TestStorageBucketService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDStorageBucket: inventory.StorageBucket{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageBucket: []queue.Item[inventory.StorageBucket]{
+				{
+					Value: inventory.StorageBucket{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
+				{
+					Value: inventory.StorageBucket{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -474,7 +571,7 @@ func TestStorageBucketService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.StorageBucketRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.StorageBucket, error) {
-					return tc.repoGetByUUIDStorageBucket, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDStorageBucket)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, storageBucket inventory.StorageBucket) (inventory.StorageBucket, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), storageBucket.LastUpdated)
@@ -494,9 +591,6 @@ func TestStorageBucketService_ResyncByUUID(t *testing.T) {
 
 			storageBucketClient := &serverMock.StorageBucketServerClientMock{
 				GetStorageBucketByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, projectName string, storagePoolName string, storageBucketName string) (incusapi.StorageBucketFull, error) {
-					require.Equal(t, tc.repoGetByUUIDStorageBucket.Name, storageBucketName)
-					require.Equal(t, tc.repoGetByUUIDStorageBucket.ProjectName, projectName)
-					require.Equal(t, "storage_pool", storagePoolName)
 					return tc.storageBucketClientGetStorageBucketByName, tc.storageBucketClientGetStorageBucketByNameErr
 				},
 			}
@@ -510,6 +604,8 @@ func TestStorageBucketService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDStorageBucket)
 		})
 	}
 }

--- a/internal/inventory/storage_pool_service_gen.go
+++ b/internal/inventory/storage_pool_service_gen.go
@@ -148,27 +148,32 @@ func (s storagePoolService) GetByUUID(ctx context.Context, id uuid.UUID) (Storag
 }
 
 func (s storagePoolService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	storagePool, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, storagePool.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedStoragePool, err := s.storagePoolClient.GetStoragePoolByName(ctx, endpoint, storagePool.Name)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, storagePool.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete storage_pool %q from cluster %q: %w`, storagePool.UUID.String(), storagePool.Cluster, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		storagePool, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, storagePool.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedStoragePool, err := s.storagePoolClient.GetStoragePoolByName(ctx, endpoint, storagePool.Name)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, storagePool.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete storage_pool %q from cluster %q: %w`, storagePool.UUID.String(), storagePool.Cluster, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/storage_pool_service_gen_test.go
+++ b/internal/inventory/storage_pool_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -268,8 +269,7 @@ func TestStoragePoolService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr                 error
 		storagePoolClientGetStoragePoolByName    incusapi.StoragePool
 		storagePoolClientGetStoragePoolByNameErr error
-		repoGetByUUIDStoragePool                 inventory.StoragePool
-		repoGetByUUIDErr                         error
+		repoGetByUUIDStoragePool                 []queue.Item[inventory.StoragePool]
 		repoUpdateByUUIDErr                      error
 		repoDeleteByUUIDErr                      error
 
@@ -277,10 +277,21 @@ func TestStoragePoolService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDStoragePool: inventory.StoragePool{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDStoragePool: []queue.Item[inventory.StoragePool]{
+				{
+					Value: inventory.StoragePool{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.StoragePool{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -297,10 +308,14 @@ func TestStoragePoolService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - storagePool get by name - not found",
-			repoGetByUUIDStoragePool: inventory.StoragePool{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDStoragePool: []queue.Item[inventory.StoragePool]{
+				{
+					Value: inventory.StoragePool{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -319,10 +334,21 @@ func TestStoragePoolService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDStoragePool: inventory.StoragePool{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDStoragePool: []queue.Item[inventory.StoragePool]{
+				{
+					Value: inventory.StoragePool{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.StoragePool{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -338,17 +364,25 @@ func TestStoragePoolService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - storagePool get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - storagePool get by UUID - 1st",
+			repoGetByUUIDStoragePool: []queue.Item[inventory.StoragePool]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDStoragePool: inventory.StoragePool{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDStoragePool: []queue.Item[inventory.StoragePool]{
+				{
+					Value: inventory.StoragePool{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -356,10 +390,14 @@ func TestStoragePoolService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - storagePool get by name",
-			repoGetByUUIDStoragePool: inventory.StoragePool{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDStoragePool: []queue.Item[inventory.StoragePool]{
+				{
+					Value: inventory.StoragePool{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -374,10 +412,14 @@ func TestStoragePoolService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - storagePool get by name - not found - delete by uuid",
-			repoGetByUUIDStoragePool: inventory.StoragePool{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDStoragePool: []queue.Item[inventory.StoragePool]{
+				{
+					Value: inventory.StoragePool{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -392,11 +434,46 @@ func TestStoragePoolService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - storagePool get by UUID - 2nd",
+			repoGetByUUIDStoragePool: []queue.Item[inventory.StoragePool]{
+				{
+					Value: inventory.StoragePool{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDStoragePool: inventory.StoragePool{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "", // invalid
+			repoGetByUUIDStoragePool: []queue.Item[inventory.StoragePool]{
+				{
+					Value: inventory.StoragePool{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "", // invalid
+					},
+				},
+				{
+					Value: inventory.StoragePool{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "", // invalid
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -416,10 +493,21 @@ func TestStoragePoolService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDStoragePool: inventory.StoragePool{
-				UUID:    uuidgen.FromPattern(t, "1"),
-				Cluster: "one",
-				Name:    "one",
+			repoGetByUUIDStoragePool: []queue.Item[inventory.StoragePool]{
+				{
+					Value: inventory.StoragePool{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
+				{
+					Value: inventory.StoragePool{
+						UUID:    uuidgen.FromPattern(t, "1"),
+						Cluster: "one",
+						Name:    "one",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -442,7 +530,7 @@ func TestStoragePoolService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.StoragePoolRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.StoragePool, error) {
-					return tc.repoGetByUUIDStoragePool, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDStoragePool)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, storagePool inventory.StoragePool) (inventory.StoragePool, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), storagePool.LastUpdated)
@@ -462,7 +550,6 @@ func TestStoragePoolService_ResyncByUUID(t *testing.T) {
 
 			storagePoolClient := &serverMock.StoragePoolServerClientMock{
 				GetStoragePoolByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, storagePoolName string) (incusapi.StoragePool, error) {
-					require.Equal(t, tc.repoGetByUUIDStoragePool.Name, storagePoolName)
 					return tc.storagePoolClientGetStoragePoolByName, tc.storagePoolClientGetStoragePoolByNameErr
 				},
 			}
@@ -476,6 +563,8 @@ func TestStoragePoolService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDStoragePool)
 		})
 	}
 }

--- a/internal/inventory/storage_volume_service_gen.go
+++ b/internal/inventory/storage_volume_service_gen.go
@@ -163,27 +163,32 @@ func (s storageVolumeService) GetByUUID(ctx context.Context, id uuid.UUID) (Stor
 }
 
 func (s storageVolumeService) ResyncByUUID(ctx context.Context, id uuid.UUID) error {
-	err := transaction.Do(ctx, func(ctx context.Context) error {
+	storageVolume, err := s.repo.GetByUUID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := s.clusterSvc.GetEndpoint(ctx, storageVolume.Cluster)
+	if err != nil {
+		return err
+	}
+
+	retrievedStorageVolume, err := s.storageVolumeClient.GetStorageVolumeByName(ctx, endpoint, storageVolume.ProjectName, storageVolume.StoragePoolName, storageVolume.Name, storageVolume.Type)
+	if errors.Is(err, domain.ErrNotFound) {
+		err = s.repo.DeleteByUUID(ctx, storageVolume.UUID)
+		if err != nil {
+			return fmt.Errorf(`Failed to delete storage_volume %q from cluster %q, storage_pool %q: %w`, storageVolume.UUID.String(), storageVolume.Cluster, storageVolume.StoragePoolName, err)
+		}
+
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	err = transaction.Do(ctx, func(ctx context.Context) error {
 		storageVolume, err := s.repo.GetByUUID(ctx, id)
-		if err != nil {
-			return err
-		}
-
-		endpoint, err := s.clusterSvc.GetEndpoint(ctx, storageVolume.Cluster)
-		if err != nil {
-			return err
-		}
-
-		retrievedStorageVolume, err := s.storageVolumeClient.GetStorageVolumeByName(ctx, endpoint, storageVolume.ProjectName, storageVolume.StoragePoolName, storageVolume.Name, storageVolume.Type)
-		if errors.Is(err, domain.ErrNotFound) {
-			err = s.repo.DeleteByUUID(ctx, storageVolume.UUID)
-			if err != nil {
-				return fmt.Errorf(`Failed to delete storage_volume %q from cluster %q, storage_pool %q: %w`, storageVolume.UUID.String(), storageVolume.Cluster, storageVolume.StoragePoolName, err)
-			}
-
-			return nil
-		}
-
 		if err != nil {
 			return err
 		}

--- a/internal/inventory/storage_volume_service_gen_test.go
+++ b/internal/inventory/storage_volume_service_gen_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/log"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
 
@@ -270,8 +271,7 @@ func TestStorageVolumeService_ResyncByUUID(t *testing.T) {
 		clusterSvcGetEndpointErr                     error
 		storageVolumeClientGetStorageVolumeByName    incusapi.StorageVolumeFull
 		storageVolumeClientGetStorageVolumeByNameErr error
-		repoGetByUUIDStorageVolume                   inventory.StorageVolume
-		repoGetByUUIDErr                             error
+		repoGetByUUIDStorageVolume                   []queue.Item[inventory.StorageVolume]
 		repoUpdateByUUIDErr                          error
 		repoDeleteByUUIDErr                          error
 
@@ -279,12 +279,25 @@ func TestStorageVolumeService_ResyncByUUID(t *testing.T) {
 	}{
 		{
 			name: "success",
-			repoGetByUUIDStorageVolume: inventory.StorageVolume{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageVolume: []queue.Item[inventory.StorageVolume]{
+				{
+					Value: inventory.StorageVolume{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
+				{
+					Value: inventory.StorageVolume{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -305,12 +318,16 @@ func TestStorageVolumeService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "success - storageVolume get by name - not found",
-			repoGetByUUIDStorageVolume: inventory.StorageVolume{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageVolume: []queue.Item[inventory.StorageVolume]{
+				{
+					Value: inventory.StorageVolume{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -329,11 +346,23 @@ func TestStorageVolumeService_ResyncByUUID(t *testing.T) {
 		// See: https://github.com/FuturFusion/operations-center/pull/527/changes#r2664538461
 		{
 			name: "success - missing project",
-			repoGetByUUIDStorageVolume: inventory.StorageVolume{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageVolume: []queue.Item[inventory.StorageVolume]{
+				{
+					Value: inventory.StorageVolume{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						StoragePoolName: "storage_pool",
+					},
+				},
+				{
+					Value: inventory.StorageVolume{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -352,19 +381,27 @@ func TestStorageVolumeService_ResyncByUUID(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
-			name:             "error - storageVolume get by UUID",
-			repoGetByUUIDErr: boom.Error,
+			name: "error - storageVolume get by UUID - 1st",
+			repoGetByUUIDStorageVolume: []queue.Item[inventory.StorageVolume]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
 		},
 		{
 			name: "error - cluster get by ID",
-			repoGetByUUIDStorageVolume: inventory.StorageVolume{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageVolume: []queue.Item[inventory.StorageVolume]{
+				{
+					Value: inventory.StorageVolume{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpointErr: boom.Error,
 
@@ -372,12 +409,16 @@ func TestStorageVolumeService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - storageVolume get by name",
-			repoGetByUUIDStorageVolume: inventory.StorageVolume{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageVolume: []queue.Item[inventory.StorageVolume]{
+				{
+					Value: inventory.StorageVolume{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -392,12 +433,16 @@ func TestStorageVolumeService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - storageVolume get by name - not found - delete by uuid",
-			repoGetByUUIDStorageVolume: inventory.StorageVolume{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageVolume: []queue.Item[inventory.StorageVolume]{
+				{
+					Value: inventory.StorageVolume{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -412,13 +457,52 @@ func TestStorageVolumeService_ResyncByUUID(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
+			name: "error - storageVolume get by UUID - 2nd",
+			repoGetByUUIDStorageVolume: []queue.Item[inventory.StorageVolume]{
+				{
+					Value: inventory.StorageVolume{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
+				{
+					ConnectionURL:      "https://server-one/",
+					Certificate:        "cert",
+					ClusterCertificate: ptr.To("cluster-cert"),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
 			name: "error - validate",
-			repoGetByUUIDStorageVolume: inventory.StorageVolume{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "", // invalid
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageVolume: []queue.Item[inventory.StorageVolume]{
+				{
+					Value: inventory.StorageVolume{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "", // invalid
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
+				{
+					Value: inventory.StorageVolume{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "", // invalid
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -442,12 +526,25 @@ func TestStorageVolumeService_ResyncByUUID(t *testing.T) {
 		},
 		{
 			name: "error - update by UUID",
-			repoGetByUUIDStorageVolume: inventory.StorageVolume{
-				UUID:            uuidgen.FromPattern(t, "1"),
-				Cluster:         "one",
-				Name:            "one",
-				ProjectName:     "project one",
-				StoragePoolName: "storage_pool",
+			repoGetByUUIDStorageVolume: []queue.Item[inventory.StorageVolume]{
+				{
+					Value: inventory.StorageVolume{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
+				{
+					Value: inventory.StorageVolume{
+						UUID:            uuidgen.FromPattern(t, "1"),
+						Cluster:         "one",
+						Name:            "one",
+						ProjectName:     "project one",
+						StoragePoolName: "storage_pool",
+					},
+				},
 			},
 			clusterSvcGetEndpoint: provisioning.ClusterEndpoint{
 				{
@@ -474,7 +571,7 @@ func TestStorageVolumeService_ResyncByUUID(t *testing.T) {
 			// Setup
 			repo := &repoMock.StorageVolumeRepoMock{
 				GetByUUIDFunc: func(ctx context.Context, id uuid.UUID) (inventory.StorageVolume, error) {
-					return tc.repoGetByUUIDStorageVolume, tc.repoGetByUUIDErr
+					return queue.Pop(t, &tc.repoGetByUUIDStorageVolume)
 				},
 				UpdateByUUIDFunc: func(ctx context.Context, storageVolume inventory.StorageVolume) (inventory.StorageVolume, error) {
 					require.Equal(t, time.Date(2025, 2, 26, 8, 54, 35, 123, time.UTC), storageVolume.LastUpdated)
@@ -494,9 +591,6 @@ func TestStorageVolumeService_ResyncByUUID(t *testing.T) {
 
 			storageVolumeClient := &serverMock.StorageVolumeServerClientMock{
 				GetStorageVolumeByNameFunc: func(ctx context.Context, endpoint provisioning.Endpoint, projectName string, storagePoolName string, storageVolumeName string, storageVolumeType string) (incusapi.StorageVolumeFull, error) {
-					require.Equal(t, tc.repoGetByUUIDStorageVolume.Name, storageVolumeName)
-					require.Equal(t, tc.repoGetByUUIDStorageVolume.ProjectName, projectName)
-					require.Equal(t, "storage_pool", storagePoolName)
 					return tc.storageVolumeClientGetStorageVolumeByName, tc.storageVolumeClientGetStorageVolumeByNameErr
 				},
 			}
@@ -510,6 +604,8 @@ func TestStorageVolumeService_ResyncByUUID(t *testing.T) {
 
 			// Assert
 			tc.assertErr(t, err)
+
+			require.Empty(t, tc.repoGetByUUIDStorageVolume)
 		})
 	}
 }

--- a/internal/provisioning/adapter/incus/client.go
+++ b/internal/provisioning/adapter/incus/client.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/FuturFusion/operations-center/internal/domain"
 	"github.com/FuturFusion/operations-center/internal/provisioning"
+	"github.com/FuturFusion/operations-center/internal/sql/transaction"
 	"github.com/FuturFusion/operations-center/internal/util/logger"
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/shared/api"
@@ -54,6 +55,10 @@ func New(clientCert string, clientKey string) client {
 }
 
 func (c client) getClient(ctx context.Context, endpoint provisioning.Endpoint) (incus.InstanceServer, error) {
+	if transaction.IsActive(ctx) {
+		slog.WarnContext(ctx, "Incus API call inside of a transaction", logger.AddStacktrace())
+	}
+
 	serverName, err := endpoint.GetServerName()
 	if err != nil {
 		return nil, err

--- a/internal/provisioning/adapter/incus/client_internal_test.go
+++ b/internal/provisioning/adapter/incus/client_internal_test.go
@@ -1,6 +1,7 @@
 package incus
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -23,7 +24,10 @@ import (
 
 	"github.com/FuturFusion/operations-center/internal/domain"
 	"github.com/FuturFusion/operations-center/internal/provisioning"
+	"github.com/FuturFusion/operations-center/internal/sql/transaction"
+	"github.com/FuturFusion/operations-center/internal/util/logger"
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
+	"github.com/FuturFusion/operations-center/internal/util/testing/log"
 )
 
 func TestClient_ClusterEndpointWithCA(t *testing.T) {
@@ -471,4 +475,22 @@ func Test_firstNonEmpty(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func Test_getClient(t *testing.T) {
+	logBuf := &bytes.Buffer{}
+	err := logger.InitLogger(logBuf, "", false, false, false)
+	require.NoError(t, err)
+
+	err = transaction.Do(t.Context(), func(ctx context.Context) error {
+		_, err := New("", "").getClient(ctx, provisioning.Server{
+			Name: "name",
+		})
+		require.NoError(t, err)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	log.Contains("Incus API call inside of a transaction")(t, logBuf)
 }

--- a/internal/provisioning/cluster_ports.go
+++ b/internal/provisioning/cluster_ports.go
@@ -19,7 +19,7 @@ type ClusterService interface {
 	GetAllNames(ctx context.Context) ([]string, error)
 	GetAllNamesWithFilter(ctx context.Context, filter ClusterFilter) ([]string, error)
 	GetByName(ctx context.Context, name string) (*Cluster, error)
-	Update(ctx context.Context, cluster Cluster) error
+	Update(ctx context.Context, cluster Cluster, updateServers bool) error
 	Rename(ctx context.Context, oldName string, newName string) error
 	DeleteByName(ctx context.Context, name string, force bool) error
 	DeleteAndFactoryResetByName(ctx context.Context, name string, tokenID *uuid.UUID, tokenSeedName *string) error

--- a/internal/provisioning/cluster_service.go
+++ b/internal/provisioning/cluster_service.go
@@ -393,6 +393,7 @@ func (s clusterService) Create(ctx context.Context, newCluster Cluster) (_ Clust
 
 		// Update Server records in the repo.
 		for _, server := range servers {
+			// FIXME: triggers API call within a transaction!!
 			err = s.serverSvc.Update(ctx, server, true, true)
 			if err != nil {
 				return err
@@ -752,6 +753,7 @@ func (s clusterService) Update(ctx context.Context, newCluster Cluster, updateSe
 
 		for _, server := range servers {
 			server.Channel = newCluster.Channel
+			// FIXME: triggers API call within a transaction!!
 			err = s.serverSvc.Update(ctx, server, true, true)
 			if err != nil {
 				return fmt.Errorf("Failed to update member %q of cluster %q: %w", server.Name, newCluster.Name, err)

--- a/internal/provisioning/cluster_service.go
+++ b/internal/provisioning/cluster_service.go
@@ -1268,11 +1268,8 @@ func (s clusterService) executeRollingUpdate(ctx context.Context, cluster Cluste
 	}
 
 	if emitLifecycleSignal {
-		go func() {
-			lifecycle.ServerLifecycleSignal.Emit(ctx, lifecycle.ServerLifecycleMessage{
-				Cluster: &cluster.Name,
-			})
-		}()
+		// Use last server as the triggering server, since it was most likely the last one that was updated.
+		servers[len(servers)-1].signalLifecycleEvent()
 	}
 
 	return nil

--- a/internal/provisioning/cluster_service.go
+++ b/internal/provisioning/cluster_service.go
@@ -1124,11 +1124,22 @@ func (s clusterService) ClusterUpdateControlLoop(ctx context.Context, clusterNam
 
 	var errs []error
 	for _, cluster := range clusters {
-		if cluster.UpdateStatus.InProgressStatus.Error != "" {
-			return nil
-		}
-
 		err := func() error {
+			log := slog.With(slog.String("cluster", cluster.Name))
+			log.InfoContext(ctx,
+				"Cluster rolling update control loop started",
+				slog.String("in_progress_status", string(cluster.UpdateStatus.InProgressStatus.InProgress)),
+			)
+			defer log.InfoContext(ctx, "Cluster rolling update control loop end")
+
+			if cluster.UpdateStatus.InProgressStatus.Error != "" {
+				log.ErrorContext(ctx,
+					"Cluster rolling update control loop in progress status error",
+					slog.String("err", cluster.UpdateStatus.InProgressStatus.Error),
+				)
+				return nil
+			}
+
 			// Refresh all status information for all servers.
 			err := s.serverSvc.PollServers(ctx, ServerFilter{
 				Cluster: &cluster.Name,
@@ -1177,6 +1188,8 @@ func (s clusterService) ClusterUpdateControlLoop(ctx context.Context, clusterNam
 }
 
 func (s clusterService) executeRollingUpdate(ctx context.Context, cluster Cluster, servers Servers) error {
+	log := slog.With(slog.String("cluster", cluster.Name))
+
 	// Trigger update on each server, applications get updated immediately,
 	// OS is prepared for update on next reboot.
 	// Also verify, that none of the servers is still updating or has pending
@@ -1186,11 +1199,11 @@ func (s clusterService) executeRollingUpdate(ctx context.Context, cluster Cluste
 			continue
 		}
 
-		// To get a consistent debug log, print the current state before triggering the next action, since
+		// To get a consistent log, print the current state before triggering the next action, since
 		// it will likely update the state.
 		updateState := clusterUpdateState(cluster.UpdateStatus.InProgressStatus, servers)
 		if updateState != "" {
-			slog.DebugContext(ctx, "rolling update next step", slog.String("cluster_update_state", updateState))
+			log.InfoContext(ctx, "Cluster rolling update next step", slog.String("cluster_update_state", updateState))
 		}
 
 		if server.StatusDetail == api.ServerStatusDetailReadyUpdating {
@@ -1223,6 +1236,8 @@ func (s clusterService) executeRollingUpdate(ctx context.Context, cluster Cluste
 		// Update servers one by one, so we have to wait.
 		return nil
 	}
+
+	log.InfoContext(ctx, "Cluster rolling update, all servers are updated")
 
 	// All servers are updated, update the clusters update status
 	var emitLifecycleSignal bool
@@ -1264,6 +1279,8 @@ func (s clusterService) executeRollingUpdate(ctx context.Context, cluster Cluste
 }
 
 func (s clusterService) executeRollingRestartNextStep(ctx context.Context, cluster Cluster, servers Servers) error {
+	log := slog.With(slog.String("cluster", cluster.Name))
+
 	// Calculate, if we are done based on the current state of all servers and the desired target state and
 	// calculate next action if we are not done yet.
 	var err error
@@ -1368,11 +1385,11 @@ func (s clusterService) executeRollingRestartNextStep(ctx context.Context, clust
 		}
 	}
 
-	// To get a consistent debug log, print the current state before triggering the next action, since
+	// To get a consistent log, print the current state before triggering the next action, since
 	// it will likely update the state.
 	updateState := clusterUpdateState(cluster.UpdateStatus.InProgressStatus, servers)
 	if updateState != "" {
-		slog.DebugContext(ctx, "rolling update next step", slog.String("cluster_update_state", updateState))
+		log.InfoContext(ctx, "Cluster rolling update next step", slog.String("cluster_update_state", updateState))
 	}
 
 	done := nextAction == nil
@@ -2307,7 +2324,7 @@ func (s clusterService) startLifecycleEventHandler(ctx context.Context, clusterN
 			for {
 				select {
 				case event := <-events:
-					slog.InfoContext(ctx, "lifecycle event", slog.String("event", event.LifecycleEventAction), slog.String("cluster", clusterName), slog.Any("action", event.Operation), slog.Any("resource_type", event.ResourceType), slog.String("source", event.Source.String()))
+					slog.InfoContext(ctx, "Lifecycle event", slog.String("event", event.LifecycleEventAction), slog.String("cluster", clusterName), slog.Any("action", event.Operation), slog.Any("resource_type", event.ResourceType), slog.String("source", event.Source.String()))
 
 					inventorySyncer, ok := s.inventorySyncers[event.ResourceType]
 					if !ok {

--- a/internal/provisioning/cluster_service.go
+++ b/internal/provisioning/cluster_service.go
@@ -726,7 +726,7 @@ func (s clusterService) getClusterUpdateStatus(ctx context.Context, name string,
 	return nil
 }
 
-func (s clusterService) Update(ctx context.Context, newCluster Cluster) error {
+func (s clusterService) Update(ctx context.Context, newCluster Cluster, updateServers bool) error {
 	err := newCluster.Validate()
 	if err != nil {
 		return err
@@ -736,6 +736,10 @@ func (s clusterService) Update(ctx context.Context, newCluster Cluster) error {
 		err = s.repo.Update(ctx, newCluster)
 		if err != nil {
 			return err
+		}
+
+		if !updateServers {
+			return nil
 		}
 
 		// Get servers of cluster and update "channel" to same value as cluster.
@@ -1029,7 +1033,7 @@ func (s clusterService) LaunchClusterUpdate(ctx context.Context, name string, re
 		cluster.UpdateStatus.InProgressStatus.Error = ""
 		cluster.UpdateStatus.InProgressStatus.LastUpdated = s.now()
 
-		err = s.Update(ctx, *cluster)
+		err = s.Update(ctx, *cluster, false)
 		if err != nil {
 			return fmt.Errorf("Failed to update cluster %q: %w", name, err)
 		}
@@ -1053,7 +1057,7 @@ func (s clusterService) LaunchClusterUpdate(ctx context.Context, name string, re
 		cluster.UpdateStatus.InProgressStatus.EvacuatedBefore = nil
 		cluster.UpdateStatus.InProgressStatus.LastUpdated = s.now()
 
-		err = s.Update(ctx, *cluster)
+		err = s.Update(ctx, *cluster, false)
 		if err != nil {
 			slog.ErrorContext(ctx, "Failed to revert cluster update status", logger.Err(err), slog.String("cluster", cluster.Name))
 		}

--- a/internal/provisioning/cluster_service_test.go
+++ b/internal/provisioning/cluster_service_test.go
@@ -3855,6 +3855,7 @@ func TestClusterService_GetByName(t *testing.T) {
 func TestClusterService_Update(t *testing.T) {
 	tests := []struct {
 		name                         string
+		argUpdateServers             bool
 		cluster                      provisioning.Cluster
 		repoUpdateErr                error
 		serverSvcGetAllWithFilter    []provisioning.Server
@@ -3864,7 +3865,8 @@ func TestClusterService_Update(t *testing.T) {
 		assertErr require.ErrorAssertionFunc
 	}{
 		{
-			name: "success",
+			name:             "success",
+			argUpdateServers: true,
 			cluster: provisioning.Cluster{
 				Name:          "one",
 				ConnectionURL: "http://one/",
@@ -3877,6 +3879,17 @@ func TestClusterService_Update(t *testing.T) {
 				{
 					Name: "two",
 				},
+			},
+
+			assertErr: require.NoError,
+		},
+		{
+			name:             "success - without servers update",
+			argUpdateServers: false,
+			cluster: provisioning.Cluster{
+				Name:          "one",
+				ConnectionURL: "http://one/",
+				Channel:       "stable",
 			},
 
 			assertErr: require.NoError,
@@ -3907,7 +3920,8 @@ func TestClusterService_Update(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name: "error - serverSvc.GetAllNamesWithFilter",
+			name:             "error - serverSvc.GetAllNamesWithFilter",
+			argUpdateServers: true,
 			cluster: provisioning.Cluster{
 				Name:          "one",
 				ServerNames:   []string{"server1", "server3"},
@@ -3919,7 +3933,8 @@ func TestClusterService_Update(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name: "error - serverSvc.GetAllNamesWithFilter",
+			name:             "error - serverSvc.GetAllNamesWithFilter",
+			argUpdateServers: true,
 			cluster: provisioning.Cluster{
 				Name:          "one",
 				ServerNames:   []string{"server1", "server3"},
@@ -3961,7 +3976,7 @@ func TestClusterService_Update(t *testing.T) {
 			clusterSvc := provisioning.NewClusterService(repo, nil, nil, serverSvc, nil, nil, nil)
 
 			// Run test
-			err := clusterSvc.Update(context.Background(), tc.cluster)
+			err := clusterSvc.Update(context.Background(), tc.cluster, tc.argUpdateServers)
 
 			// Assert
 			tc.assertErr(t, err)
@@ -4819,8 +4834,6 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 						},
 					},
 				},
-				// Update
-				{},
 				// GetAllWithFilter, needs update
 				{
 					Value: provisioning.Servers{
@@ -4908,8 +4921,6 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 						},
 					},
 				},
-				// Update
-				{},
 				// GetAllWithFilter, needs update
 				{
 					Value: provisioning.Servers{
@@ -4991,8 +5002,6 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 						},
 					},
 				},
-				// Update
-				{},
 				// GetAllWithFilter, needs update
 				{
 					Value: provisioning.Servers{
@@ -5084,6 +5093,7 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 					Value: api.ClusterUpdateInProgressStatus{
 						InProgress: api.ClusterUpdateInProgressApplyUpdate,
 					},
+					Err: boom.Error,
 				},
 			},
 			serverSvcGetAllWithFilter: []queue.Item[provisioning.Servers]{
@@ -5108,10 +5118,6 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 							},
 						},
 					},
-				},
-				// Update
-				{
-					Err: boom.Error,
 				},
 			},
 
@@ -5167,10 +5173,6 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 						},
 					},
 				},
-				// Update
-				{},
-				// Update reverter
-				{},
 			},
 			serverSvcPollServers: boom.Error,
 
@@ -5201,6 +5203,7 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 					Value: api.ClusterUpdateInProgressStatus{
 						InProgress: api.ClusterUpdateInProgressInactive,
 					},
+					Err: boom.Error,
 				},
 			},
 			serverSvcGetAllWithFilter: []queue.Item[provisioning.Servers]{
@@ -5225,12 +5228,6 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 							},
 						},
 					},
-				},
-				// Update
-				{},
-				// Update reverter
-				{
-					Err: boom.Error,
 				},
 			},
 			serverSvcPollServers: boom.Error,
@@ -5287,14 +5284,10 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 						},
 					},
 				},
-				// Update
-				{},
 				// GetAllWithFilter, needs update
 				{
 					Value: nil, // No servers found.
 				},
-				// Update reverter
-				{},
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -5351,14 +5344,10 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 						},
 					},
 				},
-				// Update
-				{},
 				// GetAllWithFilter, needs update
 				{
 					Err: boom.Error,
 				},
-				// Update reverter
-				{},
 			},
 
 			assertErr: boom.ErrorIs,
@@ -5413,8 +5402,6 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 						},
 					},
 				},
-				// Update
-				{},
 				// GetAllWithFilter, needs update
 				{
 					Value: provisioning.Servers{
@@ -5435,8 +5422,6 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 						},
 					},
 				},
-				// Update reverter
-				{},
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -5495,8 +5480,6 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 						},
 					},
 				},
-				// Update
-				{},
 				// GetAllWithFilter, needs update
 				{
 					Value: provisioning.Servers{
@@ -5519,8 +5502,6 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 						},
 					},
 				},
-				// Update reverter
-				{},
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -5585,8 +5566,6 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 						},
 					},
 				},
-				// Update
-				{},
 				// GetAllWithFilter
 				{
 					Value: provisioning.Servers{
@@ -5608,8 +5587,6 @@ func TestClusterService_LaunchClusterUpdate(t *testing.T) {
 						},
 					},
 				},
-				// Update reverter
-				{},
 			},
 
 			assertErr: boom.ErrorIs,

--- a/internal/provisioning/middleware/cluster_service_prometheus_gen.go
+++ b/internal/provisioning/middleware/cluster_service_prometheus_gen.go
@@ -482,7 +482,7 @@ func (_d ClusterServiceWithPrometheus) StartLifecycleEventsMonitor(ctx context.C
 }
 
 // Update implements provisioning.ClusterService.
-func (_d ClusterServiceWithPrometheus) Update(ctx context.Context, cluster provisioning.Cluster) (err error) {
+func (_d ClusterServiceWithPrometheus) Update(ctx context.Context, cluster provisioning.Cluster, updateServers bool) (err error) {
 	_since := time.Now()
 	defer func() {
 		result := "ok"
@@ -492,7 +492,7 @@ func (_d ClusterServiceWithPrometheus) Update(ctx context.Context, cluster provi
 
 		clusterServiceDurationSummaryVec.WithLabelValues(_d.instanceName, "Update", result).Observe(time.Since(_since).Seconds())
 	}()
-	return _d.base.Update(ctx, cluster)
+	return _d.base.Update(ctx, cluster, updateServers)
 }
 
 // UpdateCertificate implements provisioning.ClusterService.

--- a/internal/provisioning/middleware/cluster_service_slog_gen.go
+++ b/internal/provisioning/middleware/cluster_service_slog_gen.go
@@ -1134,12 +1134,13 @@ func (_d ClusterServiceWithSlog) StartLifecycleEventsMonitor(ctx context.Context
 }
 
 // Update implements provisioning.ClusterService.
-func (_d ClusterServiceWithSlog) Update(ctx context.Context, cluster provisioning.Cluster) (err error) {
+func (_d ClusterServiceWithSlog) Update(ctx context.Context, cluster provisioning.Cluster, updateServers bool) (err error) {
 	log := slog.With()
 	if slog.Default().Enabled(ctx, logger.LevelTrace) {
 		log = log.With(
 			slog.Any("ctx", ctx),
 			slog.Any("cluster", cluster),
+			slog.Bool("updateServers", updateServers),
 		)
 	}
 	log.DebugContext(ctx, "=> calling Update")
@@ -1164,7 +1165,7 @@ func (_d ClusterServiceWithSlog) Update(ctx context.Context, cluster provisionin
 			log.DebugContext(ctx, "<= method Update finished")
 		}
 	}()
-	return _d._base.Update(ctx, cluster)
+	return _d._base.Update(ctx, cluster, updateServers)
 }
 
 // UpdateCertificate implements provisioning.ClusterService.

--- a/internal/provisioning/mock/cluster_service_mock_gen.go
+++ b/internal/provisioning/mock/cluster_service_mock_gen.go
@@ -121,7 +121,7 @@ var _ provisioning.ClusterService = &ClusterServiceMock{}
 //			StartLifecycleEventsMonitorFunc: func(ctx context.Context) error {
 //				panic("mock out the StartLifecycleEventsMonitor method")
 //			},
-//			UpdateFunc: func(ctx context.Context, cluster provisioning.Cluster) error {
+//			UpdateFunc: func(ctx context.Context, cluster provisioning.Cluster, updateServers bool) error {
 //				panic("mock out the Update method")
 //			},
 //			UpdateCertificateFunc: func(ctx context.Context, name string, certificatePEM string, keyPEM string) error {
@@ -237,7 +237,7 @@ type ClusterServiceMock struct {
 	StartLifecycleEventsMonitorFunc func(ctx context.Context) error
 
 	// UpdateFunc mocks the Update method.
-	UpdateFunc func(ctx context.Context, cluster provisioning.Cluster) error
+	UpdateFunc func(ctx context.Context, cluster provisioning.Cluster, updateServers bool) error
 
 	// UpdateCertificateFunc mocks the UpdateCertificate method.
 	UpdateCertificateFunc func(ctx context.Context, name string, certificatePEM string, keyPEM string) error
@@ -512,6 +512,8 @@ type ClusterServiceMock struct {
 			Ctx context.Context
 			// Cluster is the cluster argument value.
 			Cluster provisioning.Cluster
+			// UpdateServers is the updateServers argument value.
+			UpdateServers bool
 		}
 		// UpdateCertificate holds details about calls to the UpdateCertificate method.
 		UpdateCertificate []struct {
@@ -1798,21 +1800,23 @@ func (mock *ClusterServiceMock) StartLifecycleEventsMonitorCalls() []struct {
 }
 
 // Update calls UpdateFunc.
-func (mock *ClusterServiceMock) Update(ctx context.Context, cluster provisioning.Cluster) error {
+func (mock *ClusterServiceMock) Update(ctx context.Context, cluster provisioning.Cluster, updateServers bool) error {
 	if mock.UpdateFunc == nil {
 		panic("ClusterServiceMock.UpdateFunc: method is nil but ClusterService.Update was just called")
 	}
 	callInfo := struct {
-		Ctx     context.Context
-		Cluster provisioning.Cluster
+		Ctx           context.Context
+		Cluster       provisioning.Cluster
+		UpdateServers bool
 	}{
-		Ctx:     ctx,
-		Cluster: cluster,
+		Ctx:           ctx,
+		Cluster:       cluster,
+		UpdateServers: updateServers,
 	}
 	mock.lockUpdate.Lock()
 	mock.calls.Update = append(mock.calls.Update, callInfo)
 	mock.lockUpdate.Unlock()
-	return mock.UpdateFunc(ctx, cluster)
+	return mock.UpdateFunc(ctx, cluster, updateServers)
 }
 
 // UpdateCalls gets all the calls that were made to Update.
@@ -1820,12 +1824,14 @@ func (mock *ClusterServiceMock) Update(ctx context.Context, cluster provisioning
 //
 //	len(mockedClusterService.UpdateCalls())
 func (mock *ClusterServiceMock) UpdateCalls() []struct {
-	Ctx     context.Context
-	Cluster provisioning.Cluster
+	Ctx           context.Context
+	Cluster       provisioning.Cluster
+	UpdateServers bool
 } {
 	var calls []struct {
-		Ctx     context.Context
-		Cluster provisioning.Cluster
+		Ctx           context.Context
+		Cluster       provisioning.Cluster
+		UpdateServers bool
 	}
 	mock.lockUpdate.RLock()
 	calls = mock.calls.Update

--- a/internal/provisioning/server_model.go
+++ b/internal/provisioning/server_model.go
@@ -139,13 +139,22 @@ func (s Server) UpdateState() api.ServerUpdateState {
 	}.UpdateState()
 }
 
-func (s Server) signalLifecycleEvent(ctx context.Context) {
+var signalLifecycleEventDelay = 3 * time.Second
+
+func (s Server) signalLifecycleEvent() {
 	go func() {
+		// Defer lifecycle signal a bit, let the triggering event complete first.
+		time.Sleep(signalLifecycleEventDelay)
+
+		// Use a detached context in order to make sure, no existing DB transaction is inherited.
+		ctx := context.Background()
+
 		slm := lifecycle.ServerLifecycleMessage{
 			Server:            s.Name,
 			Cluster:           s.Cluster,
 			ServerUpdateState: s.UpdateState(),
 		}
+
 		err := lifecycle.ServerLifecycleSignal.TryEmit(ctx, slm)
 		if err != nil {
 			slog.ErrorContext(ctx, "Signal lifecycle event failed", logger.Err(err), slog.Any("server_lifecycle_message", slm))

--- a/internal/provisioning/server_model.go
+++ b/internal/provisioning/server_model.go
@@ -3,6 +3,7 @@ package provisioning
 import (
 	"context"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -74,6 +75,15 @@ func (s Server) GetServerName() (string, error) {
 
 func (s Server) GetName() string {
 	return s.Name
+}
+
+func (s Server) Clone() Server {
+	var server Server
+
+	b, _ := json.Marshal(s)
+	_ = json.Unmarshal(b, &server)
+
+	return server
 }
 
 func (s Server) Validate() error {
@@ -232,6 +242,7 @@ type operation int
 const (
 	operationNone operation = iota
 	operationEvacuation
+	operationReboot
 	operationRestore
 )
 

--- a/internal/provisioning/server_model_internal_test.go
+++ b/internal/provisioning/server_model_internal_test.go
@@ -36,6 +36,12 @@ func TestServer_signalLifecycleEvent(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			oldSignalLifecycleEventDelay := signalLifecycleEventDelay
+			signalLifecycleEventDelay = 0
+			defer func() {
+				signalLifecycleEventDelay = oldSignalLifecycleEventDelay
+			}()
+
 			lifecycle.ServerLifecycleSignal.AddListenerWithErr(func(_ context.Context, _ lifecycle.ServerLifecycleMessage) error {
 				return tc.lifecycleServerLifecycleSignalErr
 			}, "TestServer_signalLifecycleEvent")
@@ -49,7 +55,7 @@ func TestServer_signalLifecycleEvent(t *testing.T) {
 
 			server := Server{}
 
-			server.signalLifecycleEvent(t.Context())
+			server.signalLifecycleEvent()
 
 			tc.assertLog(t, logBuf)
 		})

--- a/internal/provisioning/server_service.go
+++ b/internal/provisioning/server_service.go
@@ -1148,7 +1148,9 @@ func (s *serverService) UpdateSystemByName(ctx context.Context, name string, upd
 		// Forcefully set channel and update frequency on server before triggering update.
 		err = s.UpdateSystemUpdate(ctx, name, incusosapi.SystemUpdate{
 			Config: incusosapi.SystemUpdateConfig{
-				Channel: server.Channel,
+				AutoReboot:     false,
+				Channel:        server.Channel,
+				CheckFrequency: "never",
 			},
 		})
 		if err != nil {

--- a/internal/provisioning/server_service.go
+++ b/internal/provisioning/server_service.go
@@ -629,10 +629,12 @@ func (s *serverService) UpdateSystemUpdate(ctx context.Context, name string, upd
 		return fmt.Errorf("Failed to update the update config for %q: %w", server.Name, err)
 	}
 
-	err = s.PollServer(ctx, *server, true)
-	if err != nil {
-		slog.WarnContext(ctx, "Server poll after changing the update configuration failed (non-critical), fixed by the next successful server poll interval", logger.Err(err), slog.String("name", server.Name), slog.String("url", server.ConnectionURL))
-	}
+	go func() {
+		err := s.PollServer(ctx, *server, true)
+		if err != nil {
+			slog.WarnContext(ctx, "Server poll after changing the update configuration failed (non-critical), fixed by the next successful server poll interval", logger.Err(err), slog.String("name", server.Name), slog.String("url", server.ConnectionURL))
+		}
+	}()
 
 	return nil
 }

--- a/internal/provisioning/server_service.go
+++ b/internal/provisioning/server_service.go
@@ -1026,6 +1026,7 @@ func (s *serverService) PoweroffSystemByName(ctx context.Context, name string, f
 			return fmt.Errorf("Failed to update server %q: %w", name, err)
 		}
 
+		// FIXME: triggers API call within a transaction!!
 		err = s.client.Poweroff(ctx, *server)
 		if err != nil {
 			return fmt.Errorf("Failed to poweroff server %q by name: %w", name, err)
@@ -1223,6 +1224,7 @@ func (s *serverService) UpdateSystemByName(ctx context.Context, name string, upd
 		}
 
 		// Forcefully set channel and update frequency on server before triggering update.
+		// FIXME: triggers API call within a transaction!!
 		err = s.UpdateSystemUpdate(ctx, name, incusosapi.SystemUpdate{
 			Config: incusosapi.SystemUpdateConfig{
 				AutoReboot:     false,
@@ -1235,6 +1237,7 @@ func (s *serverService) UpdateSystemByName(ctx context.Context, name string, upd
 		}
 
 		if updateRequest.OS.TriggerUpdate {
+			// FIXME: triggers API call within a transaction!!
 			err = s.client.UpdateOS(ctx, *server)
 			if err != nil {
 				return fmt.Errorf("Failed to update the OS of server %q by name: %w", name, err)

--- a/internal/provisioning/server_service.go
+++ b/internal/provisioning/server_service.go
@@ -630,6 +630,9 @@ func (s *serverService) UpdateSystemUpdate(ctx context.Context, name string, upd
 	}
 
 	go func() {
+		// Use a detached context in order to make sure, no existing DB transaction is inherited.
+		ctx := context.Background()
+
 		err := s.PollServer(ctx, *server, true)
 		if err != nil {
 			slog.WarnContext(ctx, "Server poll after changing the update configuration failed (non-critical), fixed by the next successful server poll interval", logger.Err(err), slog.String("name", server.Name), slog.String("url", server.ConnectionURL))
@@ -965,7 +968,7 @@ func (s *serverService) EvacuateSystemByName(ctx context.Context, name string, c
 
 	reverter.Success()
 
-	server.signalLifecycleEvent(ctx)
+	server.signalLifecycleEvent()
 
 	return nil
 }
@@ -1006,7 +1009,7 @@ func (s *serverService) PoweroffSystemByName(ctx context.Context, name string, f
 		return err
 	}
 
-	server.signalLifecycleEvent(ctx)
+	server.signalLifecycleEvent()
 
 	return nil
 }
@@ -1047,7 +1050,7 @@ func (s *serverService) RebootSystemByName(ctx context.Context, name string, for
 		return err
 	}
 
-	server.signalLifecycleEvent(ctx)
+	server.signalLifecycleEvent()
 
 	return nil
 }
@@ -1124,7 +1127,7 @@ func (s *serverService) RestoreSystemByName(ctx context.Context, name string, cl
 
 	reverter.Success()
 
-	server.signalLifecycleEvent(ctx)
+	server.signalLifecycleEvent()
 
 	return nil
 }
@@ -1186,7 +1189,7 @@ func (s *serverService) UpdateSystemByName(ctx context.Context, name string, upd
 		return err
 	}
 
-	server.signalLifecycleEvent(ctx)
+	server.signalLifecycleEvent()
 
 	return nil
 }
@@ -1316,7 +1319,7 @@ func (s *serverService) handleMaintenanceUpdate(ctx context.Context, server *Ser
 		return fmt.Errorf("Failed to update servers in maintenance state: %w", err)
 	}
 
-	server.signalLifecycleEvent(ctx)
+	server.signalLifecycleEvent()
 
 	return nil
 }
@@ -1434,7 +1437,7 @@ func (s *serverService) PollServer(ctx context.Context, server Server, updateSer
 			}
 
 			if signalLifecycle {
-				updateServer.signalLifecycleEvent(ctx)
+				updateServer.signalLifecycleEvent()
 			}
 
 			return nil
@@ -1533,7 +1536,7 @@ func (s *serverService) PollServer(ctx context.Context, server Server, updateSer
 	}
 
 	if signalLifecycle {
-		server.signalLifecycleEvent(ctx)
+		server.signalLifecycleEvent()
 	}
 
 	return nil

--- a/internal/provisioning/server_service.go
+++ b/internal/provisioning/server_service.go
@@ -1359,6 +1359,10 @@ func (s *serverService) GetChangelogByName(ctx context.Context, name string) (ap
 func (s *serverService) PollServer(ctx context.Context, server Server, updateServerConfiguration bool) error {
 	log := slog.With(slog.String("name", server.Name), slog.String("url", server.ConnectionURL))
 
+	if transaction.IsActive(ctx) {
+		log.WarnContext(ctx, "serverService.PollServer is called inside of a DB transaction", slog.Bool("update_server_configuration", updateServerConfiguration), logger.AddStacktrace())
+	}
+
 	var err error
 	signalLifecycle := false
 

--- a/internal/provisioning/server_service.go
+++ b/internal/provisioning/server_service.go
@@ -1600,7 +1600,7 @@ func (s *serverService) connectionTestWithCertificateUpdate(ctx context.Context,
 
 					cluster.Certificate = nil
 
-					retryErr = s.clusterSvc.Update(ctx, *cluster)
+					retryErr = s.clusterSvc.Update(ctx, *cluster, false)
 					if retryErr != nil {
 						return fmt.Errorf("Failed to update cluster's certificate for server %q: %w", server.Name, retryErr)
 					}

--- a/internal/provisioning/server_service.go
+++ b/internal/provisioning/server_service.go
@@ -895,6 +895,8 @@ func (s *serverService) PollServers(ctx context.Context, serverFilter ServerFilt
 }
 
 func (s *serverService) EvacuateSystemByName(ctx context.Context, name string, clusterUpdate bool, force bool) error {
+	slog.InfoContext(ctx, "Evacuation initiated", slog.String("server", name), slog.Bool("force", force))
+
 	reverter := revert.New()
 	defer reverter.Fail()
 
@@ -969,6 +971,8 @@ func (s *serverService) EvacuateSystemByName(ctx context.Context, name string, c
 }
 
 func (s *serverService) PoweroffSystemByName(ctx context.Context, name string, force bool) error {
+	slog.InfoContext(ctx, "Poweroff initiated", slog.String("server", name), slog.Bool("force", force))
+
 	var server *Server
 
 	err := transaction.Do(ctx, func(ctx context.Context) error {
@@ -1008,6 +1012,8 @@ func (s *serverService) PoweroffSystemByName(ctx context.Context, name string, f
 }
 
 func (s *serverService) RebootSystemByName(ctx context.Context, name string, force bool) error {
+	slog.InfoContext(ctx, "Reboot initiated", slog.String("server", name), slog.Bool("force", force))
+
 	var server *Server
 
 	err := transaction.Do(ctx, func(ctx context.Context) error {
@@ -1047,6 +1053,8 @@ func (s *serverService) RebootSystemByName(ctx context.Context, name string, for
 }
 
 func (s *serverService) RestoreSystemByName(ctx context.Context, name string, clusterUpdate bool, force bool, restoreModeSkip bool) error {
+	slog.InfoContext(ctx, "Restore initiated", slog.String("server", name), slog.Bool("force", force))
+
 	reverter := revert.New()
 	defer reverter.Fail()
 
@@ -1122,6 +1130,8 @@ func (s *serverService) RestoreSystemByName(ctx context.Context, name string, cl
 }
 
 func (s *serverService) UpdateSystemByName(ctx context.Context, name string, updateRequest api.ServerUpdatePost, force bool) error {
+	slog.InfoContext(ctx, "System update initiated", slog.String("server", name), slog.Bool("force", force))
+
 	var server *Server
 
 	err := transaction.Do(ctx, func(ctx context.Context) error {

--- a/internal/provisioning/server_service.go
+++ b/internal/provisioning/server_service.go
@@ -407,16 +407,19 @@ func (s *serverService) Update(ctx context.Context, server Server, force bool, u
 		return fmt.Errorf("Failed to validate server for update: %w", err)
 	}
 
-	return transaction.Do(ctx, func(ctx context.Context) error {
-		if !force {
-			currentServer, err := s.repo.GetByName(ctx, server.Name)
-			if err != nil {
-				return fmt.Errorf("Failed to get server %q for update: %w", server.Name, err)
-			}
+	reverter := revert.New()
+	defer reverter.Fail()
 
-			if currentServer.Cluster != nil && currentServer.Channel != server.Channel {
-				return fmt.Errorf("Update of channel not allowed for clustered server %q: %w", server.Name, domain.ErrOperationNotPermitted)
-			}
+	var previousServer *Server
+	err = transaction.Do(ctx, func(ctx context.Context) error {
+		var err error
+		previousServer, err = s.repo.GetByName(ctx, server.Name)
+		if err != nil {
+			return fmt.Errorf("Failed to get server %q for update: %w", server.Name, err)
+		}
+
+		if !force && previousServer.Cluster != nil && previousServer.Channel != server.Channel {
+			return fmt.Errorf("Update of channel not allowed for clustered server %q: %w", server.Name, domain.ErrOperationNotPermitted)
 		}
 
 		err = s.repo.Update(ctx, server)
@@ -424,23 +427,38 @@ func (s *serverService) Update(ctx context.Context, server Server, force bool, u
 			return fmt.Errorf("Failed to update server %q: %w", server.Name, err)
 		}
 
-		if !updateSystem {
-			return nil
-		}
-
-		err = s.UpdateSystemUpdate(ctx, server.Name, incusosapi.SystemUpdate{
-			Config: incusosapi.SystemUpdateConfig{
-				AutoReboot:     false,
-				Channel:        server.Channel,
-				CheckFrequency: "never",
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("Failed to update system update configuration for server %q: %w", server.Name, err)
-		}
-
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	if !updateSystem {
+		reverter.Success()
+		return nil
+	}
+
+	reverter.Add(func() {
+		err := s.repo.Update(ctx, *previousServer)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed restore previous server state after failed to update system update config", slog.String("server", server.Name), logger.Err(err))
+		}
+	})
+
+	err = s.UpdateSystemUpdate(ctx, server.Name, incusosapi.SystemUpdate{
+		Config: incusosapi.SystemUpdateConfig{
+			AutoReboot:     false,
+			Channel:        server.Channel,
+			CheckFrequency: "never",
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to update system update configuration for server %q: %w", server.Name, err)
+	}
+
+	reverter.Success()
+
+	return nil
 }
 
 func (s *serverService) UpdateSystemNetwork(ctx context.Context, name string, systemNetwork ServerSystemNetwork) (err error) {
@@ -927,6 +945,7 @@ func (s *serverService) EvacuateSystemByName(ctx context.Context, name string, c
 	}
 
 	var server *Server
+	var previousServer Server
 	err := transaction.Do(ctx, func(ctx context.Context) error {
 		var err error
 
@@ -934,6 +953,8 @@ func (s *serverService) EvacuateSystemByName(ctx context.Context, name string, c
 		if err != nil {
 			return fmt.Errorf("Failed to get server %q by name: %w", name, err)
 		}
+
+		previousServer = server.Clone()
 
 		if server.Type != api.ServerTypeIncus {
 			return fmt.Errorf("Server %q is not of type %q: %w", name, api.ServerTypeIncus, domain.ErrOperationNotPermitted)
@@ -955,15 +976,22 @@ func (s *serverService) EvacuateSystemByName(ctx context.Context, name string, c
 			return fmt.Errorf("Failed put server %q in evacuating: %w", name, err)
 		}
 
-		err = s.client.Evacuate(ctx, *server, callback)
-		if err != nil {
-			return fmt.Errorf("Failed to evacuate server %q by name: %w", name, err)
-		}
-
 		return nil
 	})
 	if err != nil {
 		return err
+	}
+
+	reverter.Add(func() {
+		err := s.repo.Update(ctx, previousServer)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed restore previous server state after failed to trigger evacuation", slog.String("server", name), logger.Err(err))
+		}
+	})
+
+	err = s.client.Evacuate(ctx, *server, callback)
+	if err != nil {
+		return fmt.Errorf("Failed to evacuate server %q by name: %w", name, err)
 	}
 
 	reverter.Success()
@@ -1017,7 +1045,20 @@ func (s *serverService) PoweroffSystemByName(ctx context.Context, name string, f
 func (s *serverService) RebootSystemByName(ctx context.Context, name string, force bool) error {
 	slog.InfoContext(ctx, "Reboot initiated", slog.String("server", name), slog.Bool("force", force))
 
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	reverter.Add(func() {
+		s.volatileServerStates.reset(name, operationEvacuation)
+	})
+
+	_, ok := s.volatileServerStates.start(name, operationReboot)
+	if !ok {
+		return domain.NewRetryableErr(fmt.Errorf("server operation in flight"))
+	}
+
 	var server *Server
+	var previousServer Server
 
 	err := transaction.Do(ctx, func(ctx context.Context) error {
 		var err error
@@ -1026,6 +1067,8 @@ func (s *serverService) RebootSystemByName(ctx context.Context, name string, for
 		if err != nil {
 			return fmt.Errorf("Failed to get server %q by name: %w", name, err)
 		}
+
+		previousServer = server.Clone()
 
 		if !force && !s.clusterSvc.IsInstanceLifecycleOperationPermitted(ctx, ptr.From(server.Cluster)) {
 			return fmt.Errorf("Lifecycle operation for server %q currently not permitted: %w", name, domain.ErrOperationNotPermitted)
@@ -1039,16 +1082,25 @@ func (s *serverService) RebootSystemByName(ctx context.Context, name string, for
 			return fmt.Errorf("Failed to update server %q: %w", name, err)
 		}
 
-		err = s.client.Reboot(ctx, *server)
-		if err != nil {
-			return fmt.Errorf("Failed to reboot server %q by name: %w", name, err)
-		}
-
 		return nil
 	})
 	if err != nil {
 		return err
 	}
+
+	reverter.Add(func() {
+		err := s.repo.Update(ctx, previousServer)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed restore previous server state after failed to trigger reboot", slog.String("server", name), logger.Err(err))
+		}
+	})
+
+	err = s.client.Reboot(ctx, *server)
+	if err != nil {
+		return fmt.Errorf("Failed to reboot server %q by name: %w", name, err)
+	}
+
+	reverter.Success()
 
 	server.signalLifecycleEvent()
 
@@ -1085,6 +1137,7 @@ func (s *serverService) RestoreSystemByName(ctx context.Context, name string, cl
 	}
 
 	var server *Server
+	var previousServer Server
 
 	err := transaction.Do(ctx, func(ctx context.Context) error {
 		var err error
@@ -1093,6 +1146,8 @@ func (s *serverService) RestoreSystemByName(ctx context.Context, name string, cl
 		if err != nil {
 			return fmt.Errorf("Failed to get server %q by name: %w", name, err)
 		}
+
+		previousServer = server.Clone()
 
 		if server.Type != api.ServerTypeIncus {
 			return fmt.Errorf("Server %q is not of type %q: %w", name, api.ServerTypeIncus, domain.ErrOperationNotPermitted)
@@ -1114,15 +1169,22 @@ func (s *serverService) RestoreSystemByName(ctx context.Context, name string, cl
 			return fmt.Errorf("Failed put server %q in restoring: %w", name, err)
 		}
 
-		err = s.client.Restore(ctx, *server, restoreModeSkip, callback)
-		if err != nil {
-			return fmt.Errorf("Failed to restore server %q by name: %w", name, err)
-		}
-
 		return nil
 	})
 	if err != nil {
 		return err
+	}
+
+	reverter.Add(func() {
+		err := s.repo.Update(ctx, previousServer)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed restore previous server state after failed to trigger restore", slog.String("server", name), logger.Err(err))
+		}
+	})
+
+	err = s.client.Restore(ctx, *server, restoreModeSkip, callback)
+	if err != nil {
+		return fmt.Errorf("Failed to restore server %q by name: %w", name, err)
 	}
 
 	reverter.Success()
@@ -1407,6 +1469,8 @@ func (s *serverService) PollServer(ctx context.Context, server Server, updateSer
 				case api.ServerStatusReady:
 					log.WarnContext(ctx, "Server connection test failed")
 
+					s.volatileServerStates.reset(server.Name, operationReboot)
+
 					updateServer.Status = api.ServerStatusOffline
 					updateServer.StatusDetail = api.ServerStatusDetailOfflineUnresponsive
 					err = s.repo.Update(ctx, *updateServer)
@@ -1502,6 +1566,7 @@ func (s *serverService) PollServer(ctx context.Context, server Server, updateSer
 		// Clear status detail, if previous state was not ready, e.g. because
 		// of reboot or reconfiguration.
 		if server.Status != api.ServerStatusReady {
+			s.volatileServerStates.reset(server.Name, operationReboot)
 			server.StatusDetail = api.ServerStatusDetailNone
 			signalLifecycle = true
 		}

--- a/internal/provisioning/server_service_test.go
+++ b/internal/provisioning/server_service_test.go
@@ -27,6 +27,7 @@ import (
 	adapterMock "github.com/FuturFusion/operations-center/internal/provisioning/adapter/mock"
 	svcMock "github.com/FuturFusion/operations-center/internal/provisioning/mock"
 	repoMock "github.com/FuturFusion/operations-center/internal/provisioning/repo/mock"
+	"github.com/FuturFusion/operations-center/internal/sql/transaction"
 	"github.com/FuturFusion/operations-center/internal/util/logger"
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
@@ -3949,6 +3950,45 @@ func TestServerService_PollServer(t *testing.T) {
 			tc.assertLog(t, logBuf)
 		})
 	}
+}
+
+func TestServerService_PollServer_in_transaction(t *testing.T) {
+	// Setup
+	logBuf := &bytes.Buffer{}
+	err := logger.InitLogger(logBuf, "", false, true, false)
+	require.NoError(t, err)
+
+	repo := &repoMock.ServerRepoMock{
+		GetByNameFunc: func(ctx context.Context, name string) (*provisioning.Server, error) {
+			return &provisioning.Server{
+				Name:   "one",
+				Status: api.ServerStatusPending,
+			}, nil
+		},
+		UpdateFunc: func(ctx context.Context, server provisioning.Server) error {
+			return nil
+		},
+	}
+
+	client := &adapterMock.ServerClientPortMock{
+		PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
+			return nil
+		},
+	}
+
+	serverSvc := provisioning.NewServerService(repo, client, nil, nil, nil, nil, tls.Certificate{})
+
+	// Run test
+	err = transaction.Do(t.Context(), func(ctx context.Context) error {
+		return serverSvc.PollServer(ctx, provisioning.Server{
+			Name:   "one",
+			Status: api.ServerStatusPending,
+		}, false)
+	})
+
+	// Assert
+	require.NoError(t, err)
+	log.Contains("serverService.PollServer is called inside of a DB transaction")(t, logBuf)
 }
 
 func TestServerService_ResyncByName(t *testing.T) {

--- a/internal/provisioning/server_service_test.go
+++ b/internal/provisioning/server_service_test.go
@@ -3508,7 +3508,7 @@ foobar
 				GetByNameFunc: func(ctx context.Context, name string) (*provisioning.Cluster, error) {
 					return tc.clusterSvcGetByName, tc.clusterSvcGetByNameErr
 				},
-				UpdateFunc: func(ctx context.Context, cluster provisioning.Cluster) error {
+				UpdateFunc: func(ctx context.Context, cluster provisioning.Cluster, updateServers bool) error {
 					return tc.clusterSvcUpdateErr
 				},
 			}

--- a/internal/provisioning/server_service_test.go
+++ b/internal/provisioning/server_service_test.go
@@ -1095,14 +1095,14 @@ func TestServerService_Update(t *testing.T) {
 	fixedDate := time.Date(2025, 3, 12, 10, 57, 43, 0, time.UTC)
 
 	tests := []struct {
-		name                string
-		argForce            bool
-		server              provisioning.Server
-		repoUpdateErr       error
-		repoGetByNameServer *provisioning.Server
-		repoGetByNameErr    error
+		name           string
+		argForce       bool
+		server         provisioning.Server
+		repoUpdateErrs queue.Errs
+		repoGetByName  []queue.Item[*provisioning.Server]
 
 		assertErr require.ErrorAssertionFunc
+		assertLog log.MatcherFunc
 	}{
 		{
 			name: "success",
@@ -1118,12 +1118,29 @@ one
 				Status:  api.ServerStatusReady,
 				Channel: "stable",
 			},
-			repoGetByNameServer: &provisioning.Server{
-				Name:    "one",
-				Channel: "stable",
+			repoGetByName: []queue.Item[*provisioning.Server]{
+				{
+					Value: &provisioning.Server{
+						Name:    "one",
+						Channel: "stable",
+					},
+				},
+				{
+					Value: &provisioning.Server{
+						Name:    "one",
+						Channel: "stable",
+					},
+				},
+				{
+					Value: &provisioning.Server{
+						Name:    "one",
+						Channel: "stable",
+					},
+				},
 			},
 
 			assertErr: require.NoError,
+			assertLog: log.Empty,
 		},
 		{
 			name: "error - validation",
@@ -1144,6 +1161,7 @@ one
 				var verr domain.ErrValidation
 				require.ErrorAs(tt, err, &verr, a...)
 			},
+			assertLog: log.Empty,
 		},
 		{
 			name:     "error - repo.GetByName - without force",
@@ -1160,9 +1178,14 @@ one
 				Status:  api.ServerStatusReady,
 				Channel: "stable",
 			},
-			repoGetByNameErr: boom.Error,
+			repoGetByName: []queue.Item[*provisioning.Server]{
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
+			assertLog: log.Empty,
 		},
 		{
 			name:     "error - channel update for clustered server",
@@ -1179,16 +1202,21 @@ one
 				Status:  api.ServerStatusReady,
 				Channel: "stable",
 			},
-			repoGetByNameServer: &provisioning.Server{
-				Name:    "one",
-				Cluster: ptr.To("one"),
-				Channel: "testing",
+			repoGetByName: []queue.Item[*provisioning.Server]{
+				{
+					Value: &provisioning.Server{
+						Name:    "one",
+						Cluster: ptr.To("one"),
+						Channel: "testing",
+					},
+				},
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
 				require.ErrorIs(tt, err, domain.ErrOperationNotPermitted)
 				require.ErrorContains(tt, err, `Update of channel not allowed for clustered server "one"`)
 			},
+			assertLog: log.Empty,
 		},
 		{
 			name: "error - repo.UpdateByID",
@@ -1204,13 +1232,20 @@ one
 				Status:  api.ServerStatusReady,
 				Channel: "stable",
 			},
-			repoGetByNameServer: &provisioning.Server{
-				Name:    "one",
-				Channel: "stable",
+			repoGetByName: []queue.Item[*provisioning.Server]{
+				{
+					Value: &provisioning.Server{
+						Name:    "one",
+						Channel: "stable",
+					},
+				},
 			},
-			repoUpdateErr: boom.Error,
+			repoUpdateErrs: queue.Errs{
+				boom.Error,
+			},
 
 			assertErr: boom.ErrorIs,
+			assertLog: log.Empty,
 		},
 		{
 			name:     "error - repo.GetByName - force", // UpdateSystemUpdate
@@ -1227,21 +1262,70 @@ one
 				Status:  api.ServerStatusReady,
 				Channel: "stable",
 			},
-			repoGetByNameErr: boom.Error,
+			repoGetByName: []queue.Item[*provisioning.Server]{
+				{
+					Value: &provisioning.Server{
+						Name:    "one",
+						Channel: "stable",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
 
 			assertErr: boom.ErrorIs,
+			assertLog: log.Empty,
+		},
+		{
+			name:     "error - repo.GetByName - force - revert error", // UpdateSystemUpdate
+			argForce: true,
+			server: provisioning.Server{
+				Name:          "one",
+				Type:          api.ServerTypeIncus,
+				Cluster:       ptr.To("one"),
+				ConnectionURL: "http://one/",
+				Certificate: `-----BEGIN CERTIFICATE-----
+one
+-----END CERTIFICATE-----
+`,
+				Status:  api.ServerStatusReady,
+				Channel: "stable",
+			},
+			repoGetByName: []queue.Item[*provisioning.Server]{
+				{
+					Value: &provisioning.Server{
+						Name:    "one",
+						Channel: "stable",
+					},
+				},
+				{
+					Err: boom.Error,
+				},
+			},
+			repoUpdateErrs: queue.Errs{
+				nil,
+				boom.Error,
+			},
+
+			assertErr: boom.ErrorIs,
+			assertLog: log.Contains("Failed restore previous server state after failed to update system update config"),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
+			logBuf := &bytes.Buffer{}
+			err := logger.InitLogger(logBuf, "", false, true, true)
+			require.NoError(t, err)
+
 			repo := &repoMock.ServerRepoMock{
 				UpdateFunc: func(ctx context.Context, in provisioning.Server) error {
-					return tc.repoUpdateErr
+					return tc.repoUpdateErrs.PopOrNil(t)
 				},
 				GetByNameFunc: func(ctx context.Context, name string) (*provisioning.Server, error) {
-					return tc.repoGetByNameServer, tc.repoGetByNameErr
+					return queue.Pop(t, &tc.repoGetByName)
 				},
 			}
 
@@ -1271,10 +1355,14 @@ one
 			)
 
 			// Run test
-			err := serverSvc.Update(t.Context(), tc.server, tc.argForce, true)
+			err = serverSvc.Update(t.Context(), tc.server, tc.argForce, true)
 
 			// Assert
 			tc.assertErr(t, err)
+			tc.assertLog(t, logBuf)
+
+			// require.Empty(t, tc.repoGetByName)
+			require.Empty(t, tc.repoUpdateErrs)
 		})
 	}
 }
@@ -2450,7 +2538,7 @@ func TestServerService_SelfUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
 			logBuf := &bytes.Buffer{}
-			err := logger.InitLogger(logBuf, "", false, true, false)
+			err := logger.InitLogger(logBuf, "", false, true, true)
 			require.NoError(t, err)
 
 			repo := &repoMock.ServerRepoMock{
@@ -3481,7 +3569,7 @@ foobar
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
 			logBuf := &bytes.Buffer{}
-			err := logger.InitLogger(logBuf, "", false, true, false)
+			err := logger.InitLogger(logBuf, "", false, true, true)
 			require.NoError(t, err)
 
 			repo := &repoMock.ServerRepoMock{
@@ -3900,7 +3988,7 @@ func TestServerService_PollServer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
 			logBuf := &bytes.Buffer{}
-			err := logger.InitLogger(logBuf, "", false, true, false)
+			err := logger.InitLogger(logBuf, "", false, true, true)
 			require.NoError(t, err)
 
 			repo := &repoMock.ServerRepoMock{
@@ -3955,7 +4043,7 @@ func TestServerService_PollServer(t *testing.T) {
 func TestServerService_PollServer_in_transaction(t *testing.T) {
 	// Setup
 	logBuf := &bytes.Buffer{}
-	err := logger.InitLogger(logBuf, "", false, true, false)
+	err := logger.InitLogger(logBuf, "", false, true, true)
 	require.NoError(t, err)
 
 	repo := &repoMock.ServerRepoMock{
@@ -4586,13 +4674,14 @@ func TestServerService_EvacuateSystemByName(t *testing.T) {
 		argForce                                        bool
 		repoGetByName                                   provisioning.Server
 		repoGetByNameErr                                error
-		repoUpdateErr                                   error
+		repoUpdateErrs                                  queue.Errs
 		clientEvacuateErr                               error
 		clusterSvcIsInstanceLifecycleOperationPermitted bool
 		doCallback                                      func(f func(err error))
 		initVolatileServerState                         func(serverSvc provisioning.ServerService)
 
 		assertErr require.ErrorAssertionFunc
+		assertLog log.MatcherFunc
 	}{
 		{
 			name: "success - lifecycle operation permitted",
@@ -4614,6 +4703,7 @@ func TestServerService_EvacuateSystemByName(t *testing.T) {
 			clusterSvcIsInstanceLifecycleOperationPermitted: true,
 
 			assertErr: require.NoError,
+			assertLog: log.Noop,
 		},
 		{
 			name:             "success - cluster update",
@@ -4635,6 +4725,7 @@ func TestServerService_EvacuateSystemByName(t *testing.T) {
 			},
 
 			assertErr: require.NoError,
+			assertLog: log.Noop,
 		},
 		{
 			name:     "success - force",
@@ -4656,6 +4747,7 @@ func TestServerService_EvacuateSystemByName(t *testing.T) {
 			},
 
 			assertErr: require.NoError,
+			assertLog: log.Noop,
 		},
 		{
 			name:             "success - cluster update - operation in flight",
@@ -4683,6 +4775,7 @@ func TestServerService_EvacuateSystemByName(t *testing.T) {
 				require.True(tt, domain.IsRetryableError(err))
 				require.ErrorContains(tt, err, "server operation in flight")
 			},
+			assertLog: log.Noop,
 		},
 		{
 			name:             "success - cluster update - attempt limit reached",
@@ -4712,12 +4805,14 @@ func TestServerService_EvacuateSystemByName(t *testing.T) {
 				require.ErrorIs(tt, err, domain.ErrTerminal)
 				require.ErrorContains(tt, err, "Failed to evacuate system in 3 attempts")
 			},
+			assertLog: log.Noop,
 		},
 		{
 			name:             "error - repo.GetByName",
 			repoGetByNameErr: boom.Error,
 
 			assertErr: boom.ErrorIs,
+			assertLog: log.Noop,
 		},
 		{
 			name: "error - not type incus",
@@ -4730,6 +4825,7 @@ func TestServerService_EvacuateSystemByName(t *testing.T) {
 			assertErr: func(tt require.TestingT, err error, a ...any) {
 				require.ErrorIs(tt, err, domain.ErrOperationNotPermitted)
 			},
+			assertLog: log.Noop,
 		},
 		{
 			name: "error - cluster lifecycle operation not permitted",
@@ -4751,6 +4847,7 @@ func TestServerService_EvacuateSystemByName(t *testing.T) {
 				require.ErrorIs(tt, err, domain.ErrOperationNotPermitted)
 				require.ErrorContains(tt, err, "Lifecycle operation for server")
 			},
+			assertLog: log.Noop,
 		},
 		{
 			name: "error - repo.Update",
@@ -4766,10 +4863,13 @@ func TestServerService_EvacuateSystemByName(t *testing.T) {
 					},
 				},
 			},
+			repoUpdateErrs: queue.Errs{
+				boom.Error,
+			},
 			clusterSvcIsInstanceLifecycleOperationPermitted: true,
-			repoUpdateErr: boom.Error,
 
 			assertErr: boom.ErrorIs,
+			assertLog: log.Noop,
 		},
 		{
 			name: "error - client.Evacuate",
@@ -4792,20 +4892,50 @@ func TestServerService_EvacuateSystemByName(t *testing.T) {
 			},
 
 			assertErr: boom.ErrorIs,
+			assertLog: log.Noop,
+		},
+		{
+			name: "error - client.Evacuate - reverter error",
+			repoGetByName: provisioning.Server{
+				Name:   "one",
+				Status: api.ServerStatusReady,
+				Type:   api.ServerTypeIncus,
+				VersionData: api.ServerVersionData{
+					Applications: []api.ApplicationVersionData{
+						{
+							Name: "incus",
+						},
+					},
+				},
+			},
+			clusterSvcIsInstanceLifecycleOperationPermitted: true,
+			repoUpdateErrs: queue.Errs{
+				nil,
+				boom.Error,
+			},
+			clientEvacuateErr: boom.Error,
+			doCallback: func(f func(err error)) {
+				f(nil)
+			},
+
+			assertErr: boom.ErrorIs,
+			assertLog: log.Contains("Failed restore previous server state after failed to trigger evacuation server=one err=boom!"),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
+			logBuf := &bytes.Buffer{}
+			err := logger.InitLogger(logBuf, "", false, true, true)
+			require.NoError(t, err)
+
 			repo := &repoMock.ServerRepoMock{
 				GetByNameFunc: func(ctx context.Context, name string) (*provisioning.Server, error) {
 					return &tc.repoGetByName, tc.repoGetByNameErr
 				},
 				UpdateFunc: func(ctx context.Context, server provisioning.Server) error {
-					server.VersionData.Compute(nil)
-					require.Equal(t, api.InMaintenanceEvacuating, *server.VersionData.InMaintenance)
-					return tc.repoUpdateErr
+					return tc.repoUpdateErrs.PopOrNil(t)
 				},
 			}
 
@@ -4835,10 +4965,13 @@ func TestServerService_EvacuateSystemByName(t *testing.T) {
 			}
 
 			// Run test
-			err := serverSvc.EvacuateSystemByName(t.Context(), "one", tc.argClusterUpdate, tc.argForce)
+			err = serverSvc.EvacuateSystemByName(t.Context(), "one", tc.argClusterUpdate, tc.argForce)
 
 			// Assert
 			tc.assertErr(t, err)
+			tc.assertLog(t, logBuf)
+
+			require.Empty(t, tc.repoUpdateErrs)
 		})
 	}
 }
@@ -4987,11 +5120,13 @@ func TestServerService_RebootSystemByName(t *testing.T) {
 		argForce                                        bool
 		repoGetByName                                   provisioning.Server
 		repoGetByNameErr                                error
-		repoUpdateErr                                   error
+		repoUpdateErrs                                  queue.Errs
 		clientRebootErr                                 error
 		clusterSvcIsInstanceLifecycleOperationPermitted bool
+		initVolatileServerState                         func(serverSvc provisioning.ServerService)
 
 		assertErr require.ErrorAssertionFunc
+		assertLog log.MatcherFunc
 	}{
 		{
 			name: "success - lifecycle operation permitted",
@@ -5006,6 +5141,7 @@ func TestServerService_RebootSystemByName(t *testing.T) {
 			clusterSvcIsInstanceLifecycleOperationPermitted: true,
 
 			assertErr: require.NoError,
+			assertLog: log.Noop,
 		},
 		{
 			name:     "success - force",
@@ -5020,12 +5156,35 @@ func TestServerService_RebootSystemByName(t *testing.T) {
 			},
 
 			assertErr: require.NoError,
+			assertLog: log.Noop,
+		},
+		{
+			name:     "success - operation in flight",
+			argForce: true,
+			repoGetByName: provisioning.Server{
+				Name:          "operations-center",
+				Type:          api.ServerTypeOperationsCenter,
+				Channel:       "stable",
+				ConnectionURL: "https://one/",
+				Certificate:   "certificate",
+				Status:        api.ServerStatusReady,
+			},
+			initVolatileServerState: func(serverSvc provisioning.ServerService) {
+				_ = serverSvc.RebootSystemByName(context.Background(), "one", true)
+			},
+
+			assertErr: func(tt require.TestingT, err error, a ...any) {
+				require.True(tt, domain.IsRetryableError(err))
+				require.ErrorContains(tt, err, "server operation in flight")
+			},
+			assertLog: log.Noop,
 		},
 		{
 			name:             "error - repo.GetByName",
 			repoGetByNameErr: boom.Error,
 
 			assertErr: boom.ErrorIs,
+			assertLog: log.Noop,
 		},
 		{
 			name: "error - cluster lifecycle operation not permitted",
@@ -5043,6 +5202,7 @@ func TestServerService_RebootSystemByName(t *testing.T) {
 				require.ErrorIs(tt, err, domain.ErrOperationNotPermitted)
 				require.ErrorContains(tt, err, "Lifecycle operation for server")
 			},
+			assertLog: log.Noop,
 		},
 		{
 			name: "error - repo.Update",
@@ -5055,9 +5215,12 @@ func TestServerService_RebootSystemByName(t *testing.T) {
 				Status:        api.ServerStatusReady,
 			},
 			clusterSvcIsInstanceLifecycleOperationPermitted: true,
-			repoUpdateErr: boom.Error,
+			repoUpdateErrs: queue.Errs{
+				boom.Error,
+			},
 
 			assertErr: boom.ErrorIs,
+			assertLog: log.Noop,
 		},
 		{
 			name: "error - client.Reboot",
@@ -5073,20 +5236,43 @@ func TestServerService_RebootSystemByName(t *testing.T) {
 			clientRebootErr: boom.Error,
 
 			assertErr: boom.ErrorIs,
+			assertLog: log.Noop,
+		},
+		{
+			name: "error - client.Reboot and reverter error",
+			repoGetByName: provisioning.Server{
+				Name:          "operations-center",
+				Type:          api.ServerTypeOperationsCenter,
+				Channel:       "stable",
+				ConnectionURL: "https://one/",
+				Certificate:   "certificate",
+				Status:        api.ServerStatusReady,
+			},
+			clusterSvcIsInstanceLifecycleOperationPermitted: true,
+			repoUpdateErrs: queue.Errs{
+				nil,
+				boom.Error,
+			},
+			clientRebootErr: boom.Error,
+
+			assertErr: boom.ErrorIs,
+			assertLog: log.Match("Failed restore previous server state after failed to trigger reboot server=one err=boom!"),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
+			logBuf := &bytes.Buffer{}
+			err := logger.InitLogger(logBuf, "", false, true, true)
+			require.NoError(t, err)
+
 			repo := &repoMock.ServerRepoMock{
 				GetByNameFunc: func(ctx context.Context, name string) (*provisioning.Server, error) {
 					return &tc.repoGetByName, tc.repoGetByNameErr
 				},
 				UpdateFunc: func(ctx context.Context, server provisioning.Server) error {
-					require.Equal(t, api.ServerStatusOffline, server.Status)
-					require.Equal(t, api.ServerStatusDetailOfflineRebooting, server.StatusDetail)
-					return tc.repoUpdateErr
+					return tc.repoUpdateErrs.PopOrNil(t)
 				},
 			}
 
@@ -5110,11 +5296,17 @@ func TestServerService_RebootSystemByName(t *testing.T) {
 
 			serverSvc := provisioning.NewServerService(repo, client, nil, clusterSvc, nil, updateSvc, tls.Certificate{})
 
+			if tc.initVolatileServerState != nil {
+				tc.initVolatileServerState(serverSvc)
+			}
+
 			// Run test
-			err := serverSvc.RebootSystemByName(t.Context(), "one", tc.argForce)
+			err = serverSvc.RebootSystemByName(t.Context(), "one", tc.argForce)
 
 			// Assert
 			tc.assertErr(t, err)
+			tc.assertLog(t, logBuf)
+			require.Empty(t, tc.repoUpdateErrs)
 		})
 	}
 }
@@ -5127,13 +5319,14 @@ func TestServerService_RestoreSystemByName(t *testing.T) {
 		argRestoreModeSkip                              bool
 		repoGetByName                                   provisioning.Server
 		repoGetByNameErr                                error
-		repoUpdateErr                                   error
+		repoUpdateErrs                                  queue.Errs
 		clientRestoreErr                                error
 		clusterSvcIsInstanceLifecycleOperationPermitted bool
 		doCallback                                      func(f func(err error))
 		initVolatileServerState                         func(serverSvc provisioning.ServerService)
 
 		assertErr require.ErrorAssertionFunc
+		assertLog log.MatcherFunc
 	}{
 		{
 			name: "success - lifecycle operation permitted",
@@ -5155,6 +5348,7 @@ func TestServerService_RestoreSystemByName(t *testing.T) {
 			},
 
 			assertErr: require.NoError,
+			assertLog: log.Noop,
 		},
 		{
 			name:             "success - cluster update",
@@ -5176,6 +5370,7 @@ func TestServerService_RestoreSystemByName(t *testing.T) {
 			},
 
 			assertErr: require.NoError,
+			assertLog: log.Noop,
 		},
 		{
 			name:     "success - force",
@@ -5197,6 +5392,7 @@ func TestServerService_RestoreSystemByName(t *testing.T) {
 			},
 
 			assertErr: require.NoError,
+			assertLog: log.Noop,
 		},
 		{
 			name:             "success - cluster update - operation in flight",
@@ -5224,6 +5420,7 @@ func TestServerService_RestoreSystemByName(t *testing.T) {
 				require.True(tt, domain.IsRetryableError(err))
 				require.ErrorContains(tt, err, "server operation in flight")
 			},
+			assertLog: log.Noop,
 		},
 		{
 			name:             "success - cluster update - attempt limit reached",
@@ -5253,12 +5450,14 @@ func TestServerService_RestoreSystemByName(t *testing.T) {
 				require.ErrorIs(tt, err, domain.ErrTerminal)
 				require.ErrorContains(tt, err, "Failed to restore system in 3 attempts")
 			},
+			assertLog: log.Noop,
 		},
 		{
 			name:             "error - repo.GetByName",
 			repoGetByNameErr: boom.Error,
 
 			assertErr: boom.ErrorIs,
+			assertLog: log.Noop,
 		},
 		{
 			name: "error - not type incus",
@@ -5271,6 +5470,7 @@ func TestServerService_RestoreSystemByName(t *testing.T) {
 			assertErr: func(tt require.TestingT, err error, a ...any) {
 				require.ErrorIs(tt, err, domain.ErrOperationNotPermitted)
 			},
+			assertLog: log.Noop,
 		},
 		{
 			name: "error - cluster lifecycle operation not permitted",
@@ -5292,9 +5492,10 @@ func TestServerService_RestoreSystemByName(t *testing.T) {
 				require.ErrorIs(tt, err, domain.ErrOperationNotPermitted)
 				require.ErrorContains(tt, err, "Lifecycle operation for server")
 			},
+			assertLog: log.Noop,
 		},
 		{
-			name: "error - client.Restore",
+			name: "error - repo.Update",
 			repoGetByName: provisioning.Server{
 				Name:   "one",
 				Status: api.ServerStatusReady,
@@ -5308,9 +5509,12 @@ func TestServerService_RestoreSystemByName(t *testing.T) {
 				},
 			},
 			clusterSvcIsInstanceLifecycleOperationPermitted: true,
-			repoUpdateErr: boom.Error,
+			repoUpdateErrs: queue.Errs{
+				boom.Error,
+			},
 
 			assertErr: boom.ErrorIs,
+			assertLog: log.Noop,
 		},
 		{
 			name: "error - client.Restore",
@@ -5333,20 +5537,50 @@ func TestServerService_RestoreSystemByName(t *testing.T) {
 			},
 
 			assertErr: boom.ErrorIs,
+			assertLog: log.Noop,
+		},
+		{
+			name: "error - client.Restore and reverter error",
+			repoGetByName: provisioning.Server{
+				Name:   "one",
+				Status: api.ServerStatusReady,
+				Type:   api.ServerTypeIncus,
+				VersionData: api.ServerVersionData{
+					Applications: []api.ApplicationVersionData{
+						{
+							Name: "incus",
+						},
+					},
+				},
+			},
+			clusterSvcIsInstanceLifecycleOperationPermitted: true,
+			repoUpdateErrs: queue.Errs{
+				nil,
+				boom.Error,
+			},
+			clientRestoreErr: boom.Error,
+			doCallback: func(f func(err error)) {
+				f(nil)
+			},
+
+			assertErr: boom.ErrorIs,
+			assertLog: log.Match("Failed restore previous server state after failed to trigger restore server=one err=boom!"),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
+			logBuf := &bytes.Buffer{}
+			err := logger.InitLogger(logBuf, "", false, true, true)
+			require.NoError(t, err)
+
 			repo := &repoMock.ServerRepoMock{
 				GetByNameFunc: func(ctx context.Context, name string) (*provisioning.Server, error) {
 					return &tc.repoGetByName, tc.repoGetByNameErr
 				},
 				UpdateFunc: func(ctx context.Context, server provisioning.Server) error {
-					server.VersionData.Compute(nil)
-					require.Equal(t, api.InMaintenanceRestoring, *server.VersionData.InMaintenance)
-					return tc.repoUpdateErr
+					return tc.repoUpdateErrs.PopOrNil(t)
 				},
 			}
 
@@ -5376,10 +5610,12 @@ func TestServerService_RestoreSystemByName(t *testing.T) {
 			}
 
 			// Run test
-			err := serverSvc.RestoreSystemByName(t.Context(), "one", tc.argClusterUpdate, tc.argForce, tc.argRestoreModeSkip)
+			err = serverSvc.RestoreSystemByName(t.Context(), "one", tc.argClusterUpdate, tc.argForce, tc.argRestoreModeSkip)
 
 			// Assert
 			tc.assertErr(t, err)
+			tc.assertLog(t, logBuf)
+			require.Empty(t, tc.repoUpdateErrs)
 		})
 	}
 }

--- a/internal/sql/transaction/context.go
+++ b/internal/sql/transaction/context.go
@@ -123,9 +123,13 @@ func GetDBTX(ctx context.Context, db DBTX) DBTX {
 	return db
 }
 
-func Begin(ctx context.Context) (context.Context, transaction) {
+func IsActive(ctx context.Context) bool {
 	existingTC := ctx.Value(tcKey{})
-	if existingTC != nil {
+	return existingTC != nil
+}
+
+func Begin(ctx context.Context) (context.Context, transaction) {
+	if IsActive(ctx) {
 		return ctx, &noopTransactionContainer{}
 	}
 

--- a/internal/sql/transaction/context_test.go
+++ b/internal/sql/transaction/context_test.go
@@ -31,7 +31,7 @@ func TestForceTx_inStartedTransacationRollback(t *testing.T) {
 		db: dbWithTransaction,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Get dummies from empty db, no dummies expected.
 	dummies, err := dummySvc.getAll(ctx)
@@ -63,7 +63,7 @@ func TestForceTx_inStartedTransacationRollback(t *testing.T) {
 
 	// Query dummies with fresh context, expect to not get any dummies, since no
 	// data has been persisted to the DB.
-	dummies, err = dummySvc.getAll(context.Background())
+	dummies, err = dummySvc.getAll(t.Context())
 	require.NoError(t, err)
 	require.Empty(t, dummies)
 }
@@ -88,7 +88,7 @@ func TestForceTx_firstInTransacationRollback(t *testing.T) {
 		db: dbWithTransaction,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Get dummies from empty db, no dummies expected.
 	dummies, err := dummySvc.getAll(ctx)
@@ -120,7 +120,7 @@ func TestForceTx_firstInTransacationRollback(t *testing.T) {
 
 	// Query dummies with fresh context, expect to not get any dummies, since no
 	// data has been persisted to the DB.
-	dummies, err = dummySvc.getAll(context.Background())
+	dummies, err = dummySvc.getAll(t.Context())
 	require.NoError(t, err)
 	require.Empty(t, dummies)
 }
@@ -145,7 +145,7 @@ func TestForceTx_withoutTransacationRollback(t *testing.T) {
 		db: dbWithTransaction,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Get dummies from empty db, no dummies expected.
 	dummies, err := dummySvc.getAll(ctx)
@@ -163,7 +163,20 @@ func TestForceTx_withoutTransacationRollback(t *testing.T) {
 
 	// Query dummies with fresh context, expect to not get any dummies, since no
 	// data has been persisted to the DB.
-	dummies, err = dummySvc.getAll(context.Background())
+	dummies, err = dummySvc.getAll(t.Context())
 	require.NoError(t, err)
 	require.Empty(t, dummies)
+}
+
+func TestIsActive(t *testing.T) {
+	ctx := t.Context()
+
+	require.False(t, transaction.IsActive(ctx))
+
+	err := transaction.Do(ctx, func(ctx context.Context) error {
+		require.True(t, transaction.IsActive(ctx))
+
+		return nil
+	})
+	require.NoError(t, err)
 }

--- a/internal/sql/transaction/transaction_test.go
+++ b/internal/sql/transaction/transaction_test.go
@@ -32,7 +32,7 @@ func TestRollback(t *testing.T) {
 		db: dbWithTransaction,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Get dummies from empty db, no dummies expected.
 	dummies, err := dummySvc.getAll(ctx)
@@ -57,7 +57,7 @@ func TestRollback(t *testing.T) {
 
 	// Query dummies with fresh context, expect to not get any dummies, since no
 	// data has been persisted to the DB.
-	dummies, err = dummySvc.getAll(context.Background())
+	dummies, err = dummySvc.getAll(t.Context())
 	require.NoError(t, err)
 	require.Empty(t, dummies)
 }
@@ -82,7 +82,7 @@ func TestCommit(t *testing.T) {
 		db: dbWithTransaction,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Get dummies from empty db, no dummies expected.
 	dummies, err := dummySvc.getAll(ctx)
@@ -116,7 +116,7 @@ func TestCommit(t *testing.T) {
 
 	// Query dummies with fresh context expect to get the dummy
 	// committed in the previous transaction.
-	dummies, err = dummySvc.getAll(context.Background())
+	dummies, err = dummySvc.getAll(t.Context())
 	require.NoError(t, err)
 	require.Len(t, dummies, 1)
 }
@@ -141,7 +141,7 @@ func TestTransactionInTransaction(t *testing.T) {
 		db: dbWithTransaction,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ctx, trans := transaction.Begin(ctx)
 	defer func() {
@@ -192,7 +192,7 @@ func TestDo_commit(t *testing.T) {
 		db: dbWithTransaction,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err = transaction.Do(ctx, func(ctx context.Context) error {
 		// Add dummy in transaction.
@@ -221,7 +221,7 @@ func TestDo_rollback(t *testing.T) {
 		db: dbWithTransaction,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	err = transaction.Do(ctx, func(ctx context.Context) error {
 		// Add dummy in transaction.

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -15,7 +15,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fabien-marty/slog-helpers/pkg/stacktrace"
 	"github.com/lmittmann/tint"
+
+	"github.com/FuturFusion/operations-center/internal/util/ptr"
 )
 
 const (
@@ -112,7 +115,10 @@ func SetLogLevel(level slog.Level) error {
 	}
 
 	logger := slog.New(
-		newContextHandler(slogHandler),
+		newContextHandler(stacktrace.New(slogHandler, &stacktrace.Options{
+			Mode:                                    stacktrace.ModeAddAttr,
+			MinimalLevelForStackTraceEnabledEnabled: ptr.To(slog.Level(100)), // Disable automatic addition of stack traces
+		})),
 	)
 
 	slog.SetDefault(logger)
@@ -244,4 +250,8 @@ func ContextWithAttr(parent context.Context, attr slog.Attr) context.Context {
 // or to add stack trace information in debug mode.
 func Err(err error) slog.Attr {
 	return slog.Any("err", err)
+}
+
+func AddStacktrace() slog.Attr {
+	return slog.Bool("add-stacktrace", true)
 }


### PR DESCRIPTION
This PR contains changes / fixes related to the rolling cluster update, in particular related to mixing of DB transactions with API calls, which can cause deadlock situations.

The main changes are:
* Improved logging:
  * more logging on Info level for the rolling update
  * silencing of some more "retryable" errors (incus client does not pass the errors with %w, so the initial logic with error.Is did not work. Now string comparison is used instead)
  * addition of warning logs, if API calls are performed with an ongoing DB transaction
* Proper detatching of context for the asynchronously handled life cycle events (to ensure, there is no issue with potentially ongoing DB transactions).
* Removal of client API calls from the DB transaction scope and adding reverter logic instead. 
* Introduction of a delay when there was a state change during the rolling update, before the life time signal is emitted.