### PR TITLE
Fix post restore delay

### DIFF
--- a/doc/development/server-status.md
+++ b/doc/development/server-status.md
@@ -65,6 +65,7 @@ stateDiagram-v2
     state "In maintenance (rebooting)" as UpdateInMaintenanceRebooting
     state "In maintenance (restore pending)" as UpdateInMaintenanceRestorePending
     state "Restoring" as UpdateRestoring
+    state "Post restore" as PostRestore
 
     UpdateReady --> UpdatePending: update available
     UpdatePending --> UpdateUpdating: update triggered
@@ -81,5 +82,6 @@ stateDiagram-v2
     UpdateInMaintenanceRebootPending --> UpdateInMaintenanceRebooting: trigger reboot
     UpdateInMaintenanceRebooting --> UpdateInMaintenanceRestorePending: self register or polling
     UpdateInMaintenanceRestorePending --> UpdateRestoring: restore triggered
-    UpdateRestoring --> UpdateReady: restore completed life cycle event received
+    UpdateRestoring --> PostRestore: restore completed life cycle event received
+    PostRestore --> UpdateReady: post restore delay elapsed
 ```

--- a/e2e_tests/create_cluster_and_then_cluster_update_test.go
+++ b/e2e_tests/create_cluster_and_then_cluster_update_test.go
@@ -77,6 +77,9 @@ func createClusterAndThenClusterUpdate(t *testing.T, tmpDir string) {
 	stopUpdate := timeTrack(t, "cluster update")
 	defer stopUpdate()
 
+	t.Log("Update post_restore_delay")
+	mustRun(t, `EDITOR='sed -i "s/    post_restore_delay:.*/    post_restore_delay: 20s/"' script -q -c '../bin/operations-center.linux.%s provisioning cluster edit incus-os-cluster' /dev/null`, cpuArch)
+
 	t.Log("Update cluster - trigger update")
 	mustRun(t, `../bin/operations-center.linux.%s provisioning cluster update incus-os-cluster --reboot`, cpuArch)
 
@@ -110,7 +113,7 @@ func createClusterAndThenClusterUpdate(t *testing.T, tmpDir string) {
 			t.Fatalf("Update deadline reached: %v", ctx.Err())
 			return
 
-		case <-time.After(10 * time.Second):
+		case <-time.After(1 * time.Second):
 		}
 	}
 

--- a/e2e_tests/helpers.go
+++ b/e2e_tests/helpers.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	shellwords "github.com/mattn/go-shellwords"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
@@ -180,26 +179,18 @@ func runWithTimeout(t *testing.T, command string, timeout time.Duration, args ..
 func runWithContext(ctx context.Context, t *testing.T, command string, args ...any) cmdResponse {
 	t.Helper()
 
-	command = fmt.Sprintf(`bash -c %q`, command)
-	command = fmt.Sprintf(command, args...)
-	shellArgs, err := shellwords.Parse(command)
-	if err != nil {
-		return cmdResponse{
-			err: fmt.Errorf("run parse command %q: %w", command, err),
-		}
-	}
-
-	name := shellArgs[0]
-	if len(shellArgs) > 1 {
-		shellArgs = shellArgs[1:]
+	name := "bash"
+	cmdArgs := []string{
+		"-c",
+		fmt.Sprintf(command, args...),
 	}
 
 	resp := cmdResponse{
-		command: fmt.Sprintf("%s %s", name, strings.Join(shellArgs, " ")),
+		command: fmt.Sprintf("bash -c %q", fmt.Sprintf(command, args...)),
 		output:  &bytes.Buffer{},
 	}
 
-	cmd := exec.CommandContext(ctx, name, shellArgs...)
+	cmd := exec.CommandContext(ctx, name, cmdArgs...)
 
 	e2eGoCoverDir := os.Getenv("OPERATIONS_CENTER_E2E_GOCOVERDIR")
 	if e2eGoCoverDir != "" {
@@ -211,7 +202,7 @@ func runWithContext(ctx context.Context, t *testing.T, command string, args ...a
 	cmd.Stdout = resp.output
 	cmd.Stderr = resp.output
 
-	err = cmd.Run()
+	err := cmd.Run()
 	if err != nil {
 		exitErr := &exec.ExitError{}
 		if !errors.As(err, &exitErr) {

--- a/internal/api/api_provisioning_cluster.go
+++ b/internal/api/api_provisioning_cluster.go
@@ -354,14 +354,7 @@ func (c *clusterHandler) clusterPut(r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	ctx, trans := transaction.Begin(r.Context())
-	defer func() {
-		rollbackErr := trans.Rollback()
-		if rollbackErr != nil {
-			response.SmartError(fmt.Errorf("Transaction rollback failed: %v, reason: %w", rollbackErr, err))
-		}
-	}()
-
+	ctx := r.Context()
 	currentCluster, err := c.service.GetByName(ctx, name)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed to get cluster %q: %w", name, err))
@@ -382,11 +375,6 @@ func (c *clusterHandler) clusterPut(r *http.Request) response.Response {
 	err = c.service.Update(ctx, *currentCluster, true)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed updating cluster %q: %w", name, err))
-	}
-
-	err = trans.Commit()
-	if err != nil {
-		return response.SmartError(fmt.Errorf("Failed commit transaction: %w", err))
 	}
 
 	return response.SyncResponseLocation(true, nil, "/"+api.APIVersion+"/provisioning/clusters/"+name)

--- a/internal/inventory/repo/sqlite/entities/server.mapper.go
+++ b/internal/inventory/repo/sqlite/entities/server.mapper.go
@@ -10,7 +10,7 @@ import (
 )
 
 var serverObjects = RegisterStmt(`
-SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen
+SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen, servers.last_status_updated
   FROM servers
   LEFT JOIN clusters ON servers.cluster_id = clusters.id
   JOIN channels ON servers.channel_id = channels.id

--- a/internal/provisioning/adapter/incus/client.go
+++ b/internal/provisioning/adapter/incus/client.go
@@ -101,6 +101,36 @@ func (c client) Ping(ctx context.Context, endpoint provisioning.Endpoint) error 
 	return nil
 }
 
+func (c client) IsReady(ctx context.Context, server provisioning.Server) error {
+	client, err := c.getClient(ctx, server)
+	if err != nil {
+		return err
+	}
+
+	resp, _, err := client.RawQuery(http.MethodGet, "/os/1.0", http.NoBody, "")
+	if err != nil {
+		err = api.AsNotIncusOSError(err)
+
+		return fmt.Errorf("Get resources from %q (%s) failed: %w", server.GetName(), server.GetConnectionURL(), err)
+	}
+
+	var osData struct {
+		Environment struct {
+			Uptime int `json:"uptime"`
+		} `json:"environment"`
+	}
+	err = json.Unmarshal(resp.Metadata, &osData)
+	if err != nil {
+		return fmt.Errorf("Unexpected response metadata while fetching OS information from %q (%s): %w", server.Name, server.GetConnectionURL(), err)
+	}
+
+	if osData.Environment.Uptime < 120 {
+		return domain.NewRetryableErr(fmt.Errorf("Server uptime is less than 120s"))
+	}
+
+	return nil
+}
+
 func (c client) GetResources(ctx context.Context, endpoint provisioning.Endpoint) (api.HardwareData, error) {
 	client, err := c.getClient(ctx, endpoint)
 	if err != nil {

--- a/internal/provisioning/adapter/incus/client_test.go
+++ b/internal/provisioning/adapter/incus/client_test.go
@@ -451,6 +451,86 @@ func TestClientServer(t *testing.T) {
 
 	methods := []methodTestSetServer{
 		{
+			name: "IsReady",
+			clientCall: func(ctx context.Context, c clientPort, server provisioning.Server) (any, error) {
+				return nil, c.IsReady(ctx, server)
+			},
+			testCases: []methodTestCase{
+				{
+					name: "success",
+					response: []queue.Item[response]{
+						{
+							Value: response{
+								statusCode: http.StatusOK,
+								responseBody: []byte(`{
+  "metadata": {
+    "environment": {
+      "uptime": 3600
+    }
+  }
+}`),
+							},
+						},
+					},
+
+					assertErr: require.NoError,
+					wantPaths: []string{"GET /os/1.0"},
+				},
+				{
+					name: "error - unexpected http status code",
+					response: []queue.Item[response]{
+						{
+							Value: response{
+								statusCode: http.StatusInternalServerError,
+							},
+						},
+					},
+
+					assertErr: require.Error,
+					wantPaths: []string{"GET /os/1.0"},
+				},
+				{
+					name: "error - resource data invalid JSON",
+					response: []queue.Item[response]{
+						{
+							Value: response{
+								statusCode: http.StatusOK,
+								responseBody: []byte(`{
+  "metadata": []
+}`), // array for metadata is invalid.
+							},
+						},
+					},
+
+					assertErr: require.Error,
+					wantPaths: []string{"GET /os/1.0"},
+				},
+				{
+					name: "error - not ready",
+					response: []queue.Item[response]{
+						{
+							Value: response{
+								statusCode: http.StatusOK,
+								responseBody: []byte(`{
+  "metadata": {
+    "environment": {
+      "uptime": 0
+    }
+  }
+}`),
+							},
+						},
+					},
+
+					assertErr: func(tt require.TestingT, err error, a ...any) {
+						require.True(tt, domain.IsRetryableError(err))
+					},
+					wantPaths: []string{"GET /os/1.0"},
+				},
+			},
+		},
+
+		{
 			name: "GetResources",
 			clientCall: func(ctx context.Context, client clientPort, target provisioning.Server) (any, error) {
 				return client.GetResources(ctx, target)

--- a/internal/provisioning/adapter/middleware/server_client_port_error_wrapper_gen.go
+++ b/internal/provisioning/adapter/middleware/server_client_port_error_wrapper_gen.go
@@ -146,6 +146,16 @@ func (_d ServerClientPortWithErrorWrapper) GetVersionData(ctx context.Context, s
 	return _d._base.GetVersionData(ctx, server)
 }
 
+// IsReady implements provisioning.ServerClientPort.
+func (_d ServerClientPortWithErrorWrapper) IsReady(ctx context.Context, server provisioning.Server) (err error) {
+	defer func() {
+		if err != nil {
+			err = _d._wrapErrFunc(err)
+		}
+	}()
+	return _d._base.IsReady(ctx, server)
+}
+
 // Ping implements provisioning.ServerClientPort.
 func (_d ServerClientPortWithErrorWrapper) Ping(ctx context.Context, endpoint provisioning.Endpoint) (err error) {
 	defer func() {

--- a/internal/provisioning/adapter/middleware/server_client_port_prometheus_gen.go
+++ b/internal/provisioning/adapter/middleware/server_client_port_prometheus_gen.go
@@ -206,6 +206,20 @@ func (_d ServerClientPortWithPrometheus) GetVersionData(ctx context.Context, ser
 	return _d.base.GetVersionData(ctx, server)
 }
 
+// IsReady implements provisioning.ServerClientPort.
+func (_d ServerClientPortWithPrometheus) IsReady(ctx context.Context, server provisioning.Server) (err error) {
+	_since := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+
+		serverClientPortDurationSummaryVec.WithLabelValues(_d.instanceName, "IsReady", result).Observe(time.Since(_since).Seconds())
+	}()
+	return _d.base.IsReady(ctx, server)
+}
+
 // Ping implements provisioning.ServerClientPort.
 func (_d ServerClientPortWithPrometheus) Ping(ctx context.Context, endpoint provisioning.Endpoint) (err error) {
 	_since := time.Now()

--- a/internal/provisioning/adapter/middleware/server_client_port_slog_gen.go
+++ b/internal/provisioning/adapter/middleware/server_client_port_slog_gen.go
@@ -460,6 +460,40 @@ func (_d ServerClientPortWithSlog) GetVersionData(ctx context.Context, server pr
 	return _d._base.GetVersionData(ctx, server)
 }
 
+// IsReady implements provisioning.ServerClientPort.
+func (_d ServerClientPortWithSlog) IsReady(ctx context.Context, server provisioning.Server) (err error) {
+	log := slog.With()
+	if slog.Default().Enabled(ctx, logger.LevelTrace) {
+		log = log.With(
+			slog.Any("ctx", ctx),
+			slog.Any("server", server),
+		)
+	}
+	log.DebugContext(ctx, "=> calling IsReady")
+	defer func() {
+		log := slog.With()
+		if slog.Default().Enabled(ctx, logger.LevelTrace) {
+			log = slog.With(
+				slog.Any("err", err),
+			)
+		} else {
+			if err != nil {
+				log = slog.With("err", err)
+			}
+		}
+		if err != nil {
+			if _d._isInformativeErrFunc(err) {
+				log.DebugContext(ctx, "<= method IsReady returned an informative error")
+			} else {
+				log.ErrorContext(ctx, "<= method IsReady returned an error")
+			}
+		} else {
+			log.DebugContext(ctx, "<= method IsReady finished")
+		}
+	}()
+	return _d._base.IsReady(ctx, server)
+}
+
 // Ping implements provisioning.ServerClientPort.
 func (_d ServerClientPortWithSlog) Ping(ctx context.Context, endpoint provisioning.Endpoint) (err error) {
 	log := slog.With()

--- a/internal/provisioning/adapter/mock/server_client_port_mock_gen.go
+++ b/internal/provisioning/adapter/mock/server_client_port_mock_gen.go
@@ -58,6 +58,9 @@ var _ provisioning.ServerClientPort = &ServerClientPortMock{}
 //			GetVersionDataFunc: func(ctx context.Context, server provisioning.Server) (api.ServerVersionData, error) {
 //				panic("mock out the GetVersionData method")
 //			},
+//			IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
+//				panic("mock out the IsReady method")
+//			},
 //			PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
 //				panic("mock out the Ping method")
 //			},
@@ -133,6 +136,9 @@ type ServerClientPortMock struct {
 
 	// GetVersionDataFunc mocks the GetVersionData method.
 	GetVersionDataFunc func(ctx context.Context, server provisioning.Server) (api.ServerVersionData, error)
+
+	// IsReadyFunc mocks the IsReady method.
+	IsReadyFunc func(ctx context.Context, server provisioning.Server) error
 
 	// PingFunc mocks the Ping method.
 	PingFunc func(ctx context.Context, endpoint provisioning.Endpoint) error
@@ -257,6 +263,13 @@ type ServerClientPortMock struct {
 			// Server is the server argument value.
 			Server provisioning.Server
 		}
+		// IsReady holds details about calls to the IsReady method.
+		IsReady []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Server is the server argument value.
+			Server provisioning.Server
+		}
 		// Ping holds details about calls to the Ping method.
 		Ping []struct {
 			// Ctx is the ctx argument value.
@@ -359,6 +372,7 @@ type ServerClientPortMock struct {
 	lockGetSystemLogging     sync.RWMutex
 	lockGetUpdateConfig      sync.RWMutex
 	lockGetVersionData       sync.RWMutex
+	lockIsReady              sync.RWMutex
 	lockPing                 sync.RWMutex
 	lockPoweroff             sync.RWMutex
 	lockReboot               sync.RWMutex
@@ -809,6 +823,42 @@ func (mock *ServerClientPortMock) GetVersionDataCalls() []struct {
 	mock.lockGetVersionData.RLock()
 	calls = mock.calls.GetVersionData
 	mock.lockGetVersionData.RUnlock()
+	return calls
+}
+
+// IsReady calls IsReadyFunc.
+func (mock *ServerClientPortMock) IsReady(ctx context.Context, server provisioning.Server) error {
+	if mock.IsReadyFunc == nil {
+		panic("ServerClientPortMock.IsReadyFunc: method is nil but ServerClientPort.IsReady was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		Server provisioning.Server
+	}{
+		Ctx:    ctx,
+		Server: server,
+	}
+	mock.lockIsReady.Lock()
+	mock.calls.IsReady = append(mock.calls.IsReady, callInfo)
+	mock.lockIsReady.Unlock()
+	return mock.IsReadyFunc(ctx, server)
+}
+
+// IsReadyCalls gets all the calls that were made to IsReady.
+// Check the length with:
+//
+//	len(mockedServerClientPort.IsReadyCalls())
+func (mock *ServerClientPortMock) IsReadyCalls() []struct {
+	Ctx    context.Context
+	Server provisioning.Server
+} {
+	var calls []struct {
+		Ctx    context.Context
+		Server provisioning.Server
+	}
+	mock.lockIsReady.RLock()
+	calls = mock.calls.IsReady
+	mock.lockIsReady.RUnlock()
 	return calls
 }
 

--- a/internal/provisioning/cluster_service.go
+++ b/internal/provisioning/cluster_service.go
@@ -1369,7 +1369,7 @@ func (s *clusterService) executeRollingRestartNextStep(ctx context.Context, clus
 			case api.ServerUpdateStateInMaintenancePostRestore:
 				// Check if the post restore delay has passed.
 				postRestoreDelay, _ := time.ParseDuration(cluster.Config.RollingRestart.PostRestoreDelay) // Duration is validated on save, we ignore the error here.
-				if server.LastUpdated.Add(postRestoreDelay).Before(s.now()) {
+				if server.LastStatusUpdated.Add(postRestoreDelay).Before(s.now()) {
 					nextAction = func(ctx context.Context) error {
 						return s.serverSvc.PostRestoreSystemDoneByName(ctx, server.Name)
 					}

--- a/internal/provisioning/cluster_service.go
+++ b/internal/provisioning/cluster_service.go
@@ -51,6 +51,8 @@ type clusterService struct {
 	lifecycleEventHandlerBackoffLimit time.Duration
 
 	clusterUpdatePendingUpdateRecheckInterval time.Duration
+
+	clusterUpdateControlLoopMu sync.Mutex
 }
 
 var _ ClusterService = &clusterService{}
@@ -143,7 +145,7 @@ func (s *clusterService) SetInventorySyncers(inventorySyncers map[domain.Resourc
 //     Create an "internal" network bridge on each server.
 //     Update the default profile in the default project to use incusbr0 for networking.
 //     Update the default profile in the internal project to use internal-mesh for networking.
-func (s clusterService) Create(ctx context.Context, newCluster Cluster) (_ Cluster, err error) {
+func (s *clusterService) Create(ctx context.Context, newCluster Cluster) (_ Cluster, err error) {
 	if newCluster.Channel == "" {
 		newCluster.Channel = config.GetUpdates().ServerDefaultChannel
 	}
@@ -556,11 +558,11 @@ func determineClusterRoleAddress(server Server) (string, error) {
 	return net.JoinHostPort(ip.String(), "8443"), nil
 }
 
-func (s clusterService) GetAll(ctx context.Context) (Clusters, error) {
+func (s *clusterService) GetAll(ctx context.Context) (Clusters, error) {
 	return s.repo.GetAll(ctx)
 }
 
-func (s clusterService) GetAllWithFilter(ctx context.Context, filter ClusterFilter) (Clusters, error) {
+func (s *clusterService) GetAllWithFilter(ctx context.Context, filter ClusterFilter) (Clusters, error) {
 	var filterExpression *vm.Program
 	var err error
 
@@ -616,11 +618,11 @@ func (s clusterService) GetAllWithFilter(ctx context.Context, filter ClusterFilt
 	return clusters, nil
 }
 
-func (s clusterService) GetAllNames(ctx context.Context) ([]string, error) {
+func (s *clusterService) GetAllNames(ctx context.Context) ([]string, error) {
 	return s.repo.GetAllNames(ctx)
 }
 
-func (s clusterService) GetAllNamesWithFilter(ctx context.Context, filter ClusterFilter) ([]string, error) {
+func (s *clusterService) GetAllNamesWithFilter(ctx context.Context, filter ClusterFilter) ([]string, error) {
 	var filterExpression *vm.Program
 	var err error
 
@@ -665,7 +667,7 @@ func (s clusterService) GetAllNamesWithFilter(ctx context.Context, filter Cluste
 	return clusterIDs, nil
 }
 
-func (s clusterService) GetByName(ctx context.Context, name string) (*Cluster, error) {
+func (s *clusterService) GetByName(ctx context.Context, name string) (*Cluster, error) {
 	if name == "" {
 		return nil, fmt.Errorf("Cluster name cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
@@ -692,7 +694,7 @@ func (s clusterService) GetByName(ctx context.Context, name string) (*Cluster, e
 	return cluster, nil
 }
 
-func (s clusterService) getClusterUpdateStatus(ctx context.Context, name string, clusterUpdateStatus *api.ClusterUpdateStatus) error {
+func (s *clusterService) getClusterUpdateStatus(ctx context.Context, name string, clusterUpdateStatus *api.ClusterUpdateStatus) error {
 	servers, err := s.serverSvc.GetAllWithFilter(ctx, ServerFilter{
 		Cluster: ptr.To(name),
 	})
@@ -725,7 +727,7 @@ func (s clusterService) getClusterUpdateStatus(ctx context.Context, name string,
 	return nil
 }
 
-func (s clusterService) Update(ctx context.Context, newCluster Cluster, updateServers bool) error {
+func (s *clusterService) Update(ctx context.Context, newCluster Cluster, updateServers bool) error {
 	err := newCluster.Validate()
 	if err != nil {
 		return err
@@ -795,7 +797,7 @@ func (s clusterService) Update(ctx context.Context, newCluster Cluster, updateSe
 	return nil
 }
 
-func (s clusterService) Rename(ctx context.Context, oldName string, newName string) error {
+func (s *clusterService) Rename(ctx context.Context, oldName string, newName string) error {
 	if oldName == "" {
 		return fmt.Errorf("Cluster name cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
@@ -818,7 +820,7 @@ func (s clusterService) Rename(ctx context.Context, oldName string, newName stri
 	return nil
 }
 
-func (s clusterService) DeleteByName(ctx context.Context, name string, force bool) error {
+func (s *clusterService) DeleteByName(ctx context.Context, name string, force bool) error {
 	if name == "" {
 		return fmt.Errorf("Cluster name cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
@@ -886,7 +888,7 @@ func (s clusterService) DeleteByName(ctx context.Context, name string, force boo
 	return nil
 }
 
-func (s clusterService) DeleteAndFactoryResetByName(ctx context.Context, name string, tokenID *uuid.UUID, tokenSeedName *string) error {
+func (s *clusterService) DeleteAndFactoryResetByName(ctx context.Context, name string, tokenID *uuid.UUID, tokenSeedName *string) error {
 	if name == "" {
 		return fmt.Errorf("Cluster name cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
@@ -976,7 +978,7 @@ func (s clusterService) DeleteAndFactoryResetByName(ctx context.Context, name st
 	return nil
 }
 
-func (s clusterService) ResyncInventory(ctx context.Context) error {
+func (s *clusterService) ResyncInventory(ctx context.Context) error {
 	clusters, err := s.GetAll(ctx)
 	if err != nil {
 		return fmt.Errorf("Failed to get clusters while resyncing the inventory: %w", err)
@@ -998,7 +1000,7 @@ func (s clusterService) ResyncInventory(ctx context.Context) error {
 	return nil
 }
 
-func (s clusterService) ResyncInventoryByName(ctx context.Context, name string) error {
+func (s *clusterService) ResyncInventoryByName(ctx context.Context, name string) error {
 	if name == "" {
 		return fmt.Errorf("Cluster name cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
@@ -1017,7 +1019,7 @@ func (s clusterService) ResyncInventoryByName(ctx context.Context, name string) 
 	return nil
 }
 
-func (s clusterService) IsInstanceLifecycleOperationPermitted(ctx context.Context, name string) bool {
+func (s *clusterService) IsInstanceLifecycleOperationPermitted(ctx context.Context, name string) bool {
 	if name == "" {
 		return true
 	}
@@ -1030,7 +1032,7 @@ func (s clusterService) IsInstanceLifecycleOperationPermitted(ctx context.Contex
 	return !cluster.IsUpdateInProgress()
 }
 
-func (s clusterService) LaunchClusterUpdate(ctx context.Context, name string, reboot bool) error {
+func (s *clusterService) LaunchClusterUpdate(ctx context.Context, name string, reboot bool) error {
 	// Check, that no update is in progress for this cluster and set cluster
 	// update status to "in progress".
 	var cluster *Cluster
@@ -1141,7 +1143,10 @@ func (s clusterService) LaunchClusterUpdate(ctx context.Context, name string, re
 	return nil
 }
 
-func (s clusterService) ClusterUpdateControlLoop(ctx context.Context, clusterNameFilter *string) error {
+func (s *clusterService) ClusterUpdateControlLoop(ctx context.Context, clusterNameFilter *string) error {
+	s.clusterUpdateControlLoopMu.Lock()
+	defer s.clusterUpdateControlLoopMu.Unlock()
+
 	clusters, err := s.GetAllWithFilter(ctx, ClusterFilter{
 		Name:       clusterNameFilter,
 		Expression: ptr.To(`update_status.in_progress_status.in_progress != ""`),
@@ -1215,7 +1220,7 @@ func (s clusterService) ClusterUpdateControlLoop(ctx context.Context, clusterNam
 	return errors.Join(errs...)
 }
 
-func (s clusterService) executeRollingUpdate(ctx context.Context, cluster Cluster, servers Servers) error {
+func (s *clusterService) executeRollingUpdate(ctx context.Context, cluster Cluster, servers Servers) error {
 	log := slog.With(slog.String("cluster", cluster.Name))
 
 	// Trigger update on each server, applications get updated immediately,
@@ -1303,7 +1308,7 @@ func (s clusterService) executeRollingUpdate(ctx context.Context, cluster Cluste
 	return nil
 }
 
-func (s clusterService) executeRollingRestartNextStep(ctx context.Context, cluster Cluster, servers Servers) error {
+func (s *clusterService) executeRollingRestartNextStep(ctx context.Context, cluster Cluster, servers Servers) error {
 	log := slog.With(slog.String("cluster", cluster.Name))
 
 	// Calculate, if we are done based on the current state of all servers and the desired target state and
@@ -1353,19 +1358,24 @@ func (s clusterService) executeRollingRestartNextStep(ctx context.Context, clust
 					continue
 				}
 
-				// Check if the post restore delay has passed.
-				postRestoreDelay, _ := time.ParseDuration(cluster.Config.RollingRestart.PostRestoreDelay) // Duration is validated on save, we ignore the error here.
-				if cluster.UpdateStatus.InProgressStatus.LastUpdated.Add(postRestoreDelay).Before(s.now()) {
-					restoreModeSkip := cluster.Config.RollingRestart.RestoreMode == "skip"
-					nextAction = func(ctx context.Context) error {
-						return s.serverSvc.RestoreSystemByName(ctx, server.Name, true, false, restoreModeSkip)
-					}
-				} else {
-					nextAction = noop
+				restoreModeSkip := cluster.Config.RollingRestart.RestoreMode == "skip"
+				nextAction = func(ctx context.Context) error {
+					return s.serverSvc.RestoreSystemByName(ctx, server.Name, true, false, restoreModeSkip)
 				}
 
 			case api.ServerUpdateStateInMaintenanceRestoring:
 				nextAction = noop
+
+			case api.ServerUpdateStateInMaintenancePostRestore:
+				// Check if the post restore delay has passed.
+				postRestoreDelay, _ := time.ParseDuration(cluster.Config.RollingRestart.PostRestoreDelay) // Duration is validated on save, we ignore the error here.
+				if server.LastUpdated.Add(postRestoreDelay).Before(s.now()) {
+					nextAction = func(ctx context.Context) error {
+						return s.serverSvc.PostRestoreSystemDoneByName(ctx, server.Name)
+					}
+				} else {
+					nextAction = noop
+				}
 
 			default:
 				return fmt.Errorf("Server update state %q for %q (%s) is not supported", server.UpdateState(), server.Name, server.ConnectionURL)
@@ -1403,6 +1413,7 @@ func (s clusterService) executeRollingRestartNextStep(ctx context.Context, clust
 		case api.ServerUpdateStateEvacuating,
 			api.ServerUpdateStateInMaintenanceRebooting,
 			api.ServerUpdateStateInMaintenanceRestoring,
+			api.ServerUpdateStateInMaintenancePostRestore,
 			api.ServerUpdateStateRebootPending,
 			api.ServerUpdateStateRebooting:
 
@@ -1450,7 +1461,7 @@ func (s clusterService) executeRollingRestartNextStep(ctx context.Context, clust
 	return nil
 }
 
-func (s clusterService) updateInProgressStatus(ctx context.Context, clusterName string, inProgressStatus api.ClusterUpdateInProgressStatus) error {
+func (s *clusterService) updateInProgressStatus(ctx context.Context, clusterName string, inProgressStatus api.ClusterUpdateInProgressStatus) error {
 	return transaction.Do(ctx, func(ctx context.Context) error {
 		inProgressStatus.LastUpdated = s.now()
 
@@ -1471,6 +1482,8 @@ func (s clusterService) updateInProgressStatus(ctx context.Context, clusterName 
 }
 
 func clusterUpdateState(clusterUpdateInProgressStatus api.ClusterUpdateInProgressStatus, servers Servers) string {
+	const perServerSteps = 9
+
 	totalSteps := 0
 	pendingSteps := 0
 	currentStep := ""
@@ -1491,24 +1504,24 @@ func clusterUpdateState(clusterUpdateInProgressStatus api.ClusterUpdateInProgres
 		api.ClusterUpdateInProgressApplyUpdateWithReboot:
 		firstEvacuationPendingServer := ""
 		for _, server := range servers {
-			totalSteps += 8
+			totalSteps += perServerSteps
 
 			switch server.UpdateState() {
 			case api.ServerUpdateStateUpdatePending:
-				pendingSteps += 8
+				pendingSteps += perServerSteps
 				if currentServer == "" {
 					currentStep = server.UpdateState().String()
 					currentServer = server.Name
 				}
 
 			case api.ServerUpdateStateUpdating:
-				pendingSteps += 7
+				pendingSteps += perServerSteps - 1
 				currentStep = server.UpdateState().String()
 				currentServer = server.Name
 
 			case api.ServerUpdateStateEvacuationPending,
 				api.ServerUpdateStateEvacuating:
-				pendingSteps += 6
+				pendingSteps += perServerSteps - 2
 				// Don't set the currentServer here, since these servers are ready for evacuation, but we might still have
 				// servers, which are not yet done with updating.
 				if firstEvacuationPendingServer == "" {
@@ -1528,38 +1541,43 @@ func clusterUpdateState(clusterUpdateInProgressStatus api.ClusterUpdateInProgres
 
 	case api.ClusterUpdateInProgressRollingRestart:
 		for _, server := range servers {
-			totalSteps += 8
+			totalSteps += perServerSteps
 
 			switch server.UpdateState() {
 			case api.ServerUpdateStateEvacuationPending:
-				pendingSteps += 6
+				pendingSteps += perServerSteps - 2
 				if currentServer == "" {
 					currentStep = server.UpdateState().String()
 					currentServer = server.Name
 				}
 
 			case api.ServerUpdateStateEvacuating:
-				pendingSteps += 5
+				pendingSteps += perServerSteps - 3
 				currentStep = server.UpdateState().String()
 				currentServer = server.Name
 
 			case api.ServerUpdateStateInMaintenanceRebootPending:
-				pendingSteps += 4
+				pendingSteps += perServerSteps - 4
 				currentStep = server.UpdateState().String()
 				currentServer = server.Name
 
 			case api.ServerUpdateStateInMaintenanceRebooting:
-				pendingSteps += 3
+				pendingSteps += perServerSteps - 5
 				currentStep = server.UpdateState().String()
 				currentServer = server.Name
 
 			case api.ServerUpdateStateInMaintenanceRestorePending:
-				pendingSteps += 2
+				pendingSteps += perServerSteps - 6
 				currentStep = server.UpdateState().String()
 				currentServer = server.Name
 
 			case api.ServerUpdateStateInMaintenanceRestoring:
-				pendingSteps += 1
+				pendingSteps += perServerSteps - 7
+				currentStep = server.UpdateState().String()
+				currentServer = server.Name
+
+			case api.ServerUpdateStateInMaintenancePostRestore:
+				pendingSteps += perServerSteps - 8
 				currentStep = server.UpdateState().String()
 				currentServer = server.Name
 			}
@@ -1573,7 +1591,7 @@ func clusterUpdateState(clusterUpdateInProgressStatus api.ClusterUpdateInProgres
 	return ""
 }
 
-func (s clusterService) AbortClusterUpdate(ctx context.Context, name string) error {
+func (s *clusterService) AbortClusterUpdate(ctx context.Context, name string) error {
 	err := transaction.Do(ctx, func(ctx context.Context) error {
 		cluster, err := s.repo.GetByName(ctx, name)
 		if err != nil {
@@ -1598,7 +1616,7 @@ func (s clusterService) AbortClusterUpdate(ctx context.Context, name string) err
 	return nil
 }
 
-func (s clusterService) AddServerSystemNetworkVLANTags(ctx context.Context, clusterName string, interfaceName string, vlanTags []int) (err error) {
+func (s *clusterService) AddServerSystemNetworkVLANTags(ctx context.Context, clusterName string, interfaceName string, vlanTags []int) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("Add VLAN tags to interface %q on cluster members for %q failed: %w", interfaceName, clusterName, err)
@@ -1674,7 +1692,7 @@ func (s clusterService) AddServerSystemNetworkVLANTags(ctx context.Context, clus
 	return nil
 }
 
-func (s clusterService) RemoveServerSystemNetworkVLANTags(ctx context.Context, clusterName string, interfaceName string, vlanTags []int) (err error) {
+func (s *clusterService) RemoveServerSystemNetworkVLANTags(ctx context.Context, clusterName string, interfaceName string, vlanTags []int) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("Remove VLAN tags from interface %q on cluster members for %q failed: %w", interfaceName, clusterName, err)
@@ -1749,7 +1767,7 @@ func (s clusterService) RemoveServerSystemNetworkVLANTags(ctx context.Context, c
 	return nil
 }
 
-func (s clusterService) UpdateSystemLogging(ctx context.Context, clusterName string, loggingConfig ServerSystemLogging) (err error) {
+func (s *clusterService) UpdateSystemLogging(ctx context.Context, clusterName string, loggingConfig ServerSystemLogging) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("Update logging for cluster members for %q failed: %w", clusterName, err)
@@ -1790,7 +1808,7 @@ func (s clusterService) UpdateSystemLogging(ctx context.Context, clusterName str
 	return nil
 }
 
-func (s clusterService) UpdateSystemKernel(ctx context.Context, clusterName string, kernelConfig ServerSystemKernel) (err error) {
+func (s *clusterService) UpdateSystemKernel(ctx context.Context, clusterName string, kernelConfig ServerSystemKernel) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("Update kernel for cluster members for %q failed: %w", clusterName, err)
@@ -1831,7 +1849,7 @@ func (s clusterService) UpdateSystemKernel(ctx context.Context, clusterName stri
 	return nil
 }
 
-func (s clusterService) AddApplication(ctx context.Context, clusterName string, applicationName string) (err error) {
+func (s *clusterService) AddApplication(ctx context.Context, clusterName string, applicationName string) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("Add application to cluster members for %q failed: %w", clusterName, err)
@@ -1853,7 +1871,7 @@ func (s clusterService) AddApplication(ctx context.Context, clusterName string, 
 	return nil
 }
 
-func (s clusterService) AddStorageTargetISCSI(ctx context.Context, clusterName string, target incusosapi.ServiceISCSITarget) (err error) {
+func (s *clusterService) AddStorageTargetISCSI(ctx context.Context, clusterName string, target incusosapi.ServiceISCSITarget) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("Add iscsi storage target to cluster members for %q failed: %w", clusterName, err)
@@ -1913,7 +1931,7 @@ func (s clusterService) AddStorageTargetISCSI(ctx context.Context, clusterName s
 	return nil
 }
 
-func (s clusterService) RemoveStorageTargetISCSI(ctx context.Context, clusterName string, target incusosapi.ServiceISCSITarget) (err error) {
+func (s *clusterService) RemoveStorageTargetISCSI(ctx context.Context, clusterName string, target incusosapi.ServiceISCSITarget) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("Remove iscsi storage target from cluster members for %q failed: %w", clusterName, err)
@@ -1975,7 +1993,7 @@ func (s clusterService) RemoveStorageTargetISCSI(ctx context.Context, clusterNam
 	return nil
 }
 
-func (s clusterService) AddStorageTargetMultipath(ctx context.Context, clusterName string, target string) (err error) {
+func (s *clusterService) AddStorageTargetMultipath(ctx context.Context, clusterName string, target string) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("Add multipath storage target to cluster members for %q failed: %w", clusterName, err)
@@ -2035,7 +2053,7 @@ func (s clusterService) AddStorageTargetMultipath(ctx context.Context, clusterNa
 	return nil
 }
 
-func (s clusterService) RemoveStorageTargetMultipath(ctx context.Context, clusterName string, target string) (err error) {
+func (s *clusterService) RemoveStorageTargetMultipath(ctx context.Context, clusterName string, target string) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("Remove multipath storage target from cluster members for %q failed: %w", clusterName, err)
@@ -2097,7 +2115,7 @@ func (s clusterService) RemoveStorageTargetMultipath(ctx context.Context, cluste
 	return nil
 }
 
-func (s clusterService) AddStorageTargetNVME(ctx context.Context, clusterName string, target incusosapi.ServiceNVMETarget) (err error) {
+func (s *clusterService) AddStorageTargetNVME(ctx context.Context, clusterName string, target incusosapi.ServiceNVMETarget) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("Add nvme storage target to cluster members for %q failed: %w", clusterName, err)
@@ -2157,7 +2175,7 @@ func (s clusterService) AddStorageTargetNVME(ctx context.Context, clusterName st
 	return nil
 }
 
-func (s clusterService) RemoveStorageTargetNVME(ctx context.Context, clusterName string, target incusosapi.ServiceNVMETarget) (err error) {
+func (s *clusterService) RemoveStorageTargetNVME(ctx context.Context, clusterName string, target incusosapi.ServiceNVMETarget) (err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("Remove nvme storage target from cluster members for %q failed: %w", clusterName, err)
@@ -2219,7 +2237,7 @@ func (s clusterService) RemoveStorageTargetNVME(ctx context.Context, clusterName
 	return nil
 }
 
-func (s clusterService) prepareBulkUpdate(ctx context.Context, clusterName string) (Servers, error) {
+func (s *clusterService) prepareBulkUpdate(ctx context.Context, clusterName string) (Servers, error) {
 	cluster, err := s.GetByName(ctx, clusterName)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get cluster %q: %w", clusterName, err)
@@ -2262,7 +2280,7 @@ func (s clusterService) prepareBulkUpdate(ctx context.Context, clusterName strin
 	return servers, nil
 }
 
-func (s clusterService) StartLifecycleEventsMonitor(ctx context.Context) error {
+func (s *clusterService) StartLifecycleEventsMonitor(ctx context.Context) error {
 	clusters, err := s.GetAll(ctx)
 	if err != nil {
 		return fmt.Errorf("Failed to initially load clusters for lifecycle events monitor: %w", err)
@@ -2312,7 +2330,7 @@ func (s clusterService) StartLifecycleEventsMonitor(ctx context.Context) error {
 	return nil
 }
 
-func (s clusterService) startLifecycleEventHandler(ctx context.Context, clusterName string) (context.CancelFunc, error) {
+func (s *clusterService) startLifecycleEventHandler(ctx context.Context, clusterName string) (context.CancelFunc, error) {
 	endpoint, err := s.GetEndpoint(ctx, clusterName)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get cluster endpoint for lifecycle event handler: %w", err)
@@ -2391,7 +2409,7 @@ func exponentialBackoff(start time.Duration, limit time.Duration) iter.Seq[time.
 	}
 }
 
-func (s clusterService) UpdateCertificate(ctx context.Context, name string, certificatePEM string, keyPEM string) error {
+func (s *clusterService) UpdateCertificate(ctx context.Context, name string, certificatePEM string, keyPEM string) error {
 	_, err := tls.X509KeyPair([]byte(certificatePEM), []byte(keyPEM))
 	if err != nil {
 		return domain.NewValidationErrf("Failed to validate key pair: %v", err)
@@ -2424,7 +2442,7 @@ func (s clusterService) UpdateCertificate(ctx context.Context, name string, cert
 	})
 }
 
-func (s clusterService) GetEndpoint(ctx context.Context, name string) (Endpoint, error) {
+func (s *clusterService) GetEndpoint(ctx context.Context, name string) (Endpoint, error) {
 	servers, err := s.serverSvc.GetAllWithFilter(ctx, ServerFilter{
 		Cluster: &name,
 	})
@@ -2435,7 +2453,7 @@ func (s clusterService) GetEndpoint(ctx context.Context, name string) (Endpoint,
 	return ClusterEndpoint(servers), nil
 }
 
-func (s clusterService) GetClusterArtifactAll(ctx context.Context, clusterName string) (ClusterArtifacts, error) {
+func (s *clusterService) GetClusterArtifactAll(ctx context.Context, clusterName string) (ClusterArtifacts, error) {
 	if clusterName == "" {
 		return nil, fmt.Errorf("Cluster name cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
@@ -2443,7 +2461,7 @@ func (s clusterService) GetClusterArtifactAll(ctx context.Context, clusterName s
 	return s.localartifact.GetClusterArtifactAll(ctx, clusterName)
 }
 
-func (s clusterService) GetClusterArtifactAllNames(ctx context.Context, clusterName string) ([]string, error) {
+func (s *clusterService) GetClusterArtifactAllNames(ctx context.Context, clusterName string) ([]string, error) {
 	if clusterName == "" {
 		return nil, fmt.Errorf("Cluster name cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
@@ -2451,7 +2469,7 @@ func (s clusterService) GetClusterArtifactAllNames(ctx context.Context, clusterN
 	return s.localartifact.GetClusterArtifactAllNames(ctx, clusterName)
 }
 
-func (s clusterService) GetClusterArtifactByName(ctx context.Context, clusterName string, artifactName string) (*ClusterArtifact, error) {
+func (s *clusterService) GetClusterArtifactByName(ctx context.Context, clusterName string, artifactName string) (*ClusterArtifact, error) {
 	if clusterName == "" {
 		return nil, fmt.Errorf("Cluster name cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
@@ -2463,7 +2481,7 @@ func (s clusterService) GetClusterArtifactByName(ctx context.Context, clusterNam
 	return s.localartifact.GetClusterArtifactByName(ctx, clusterName, artifactName)
 }
 
-func (s clusterService) GetClusterArtifactFileByName(ctx context.Context, clusterName string, artifactName string, filename string) (*ClusterArtifactFile, error) {
+func (s *clusterService) GetClusterArtifactFileByName(ctx context.Context, clusterName string, artifactName string, filename string) (*ClusterArtifactFile, error) {
 	if filename == "" {
 		return nil, fmt.Errorf("Filename cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
@@ -2482,7 +2500,7 @@ func (s clusterService) GetClusterArtifactFileByName(ctx context.Context, cluste
 	return nil, fmt.Errorf("File %q not found in artifact %q for cluster %q: %w", filename, artifactName, clusterName, domain.ErrNotFound)
 }
 
-func (s clusterService) GetClusterArtifactArchiveByName(ctx context.Context, clusterName string, artifactName string, archiveType ClusterArtifactArchiveType) (_ io.ReadCloser, size int, _ error) {
+func (s *clusterService) GetClusterArtifactArchiveByName(ctx context.Context, clusterName string, artifactName string, archiveType ClusterArtifactArchiveType) (_ io.ReadCloser, size int, _ error) {
 	rc, size, err := s.localartifact.GetClusterArtifactArchiveByName(ctx, clusterName, artifactName, archiveType)
 	if err != nil {
 		return nil, 0, fmt.Errorf("Failed to get artifact %q for cluster %q: %w", artifactName, clusterName, err)

--- a/internal/provisioning/cluster_service.go
+++ b/internal/provisioning/cluster_service.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"slices"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
@@ -1585,7 +1586,8 @@ func clusterUpdateState(clusterUpdateInProgressStatus api.ClusterUpdateInProgres
 	}
 
 	if pendingSteps > 0 {
-		return fmt.Sprintf("[%d/%d] %s server %q", totalSteps-pendingSteps+1, totalSteps, currentStep, currentServer)
+		format := fmt.Sprintf("[%%%[1]dd/%%%[1]dd] %%s server %%q", len(strconv.Itoa(totalSteps)))
+		return fmt.Sprintf(format, totalSteps-pendingSteps+1, totalSteps, currentStep, currentServer)
 	}
 
 	return ""

--- a/internal/provisioning/cluster_service_update_control_loop_test.go
+++ b/internal/provisioning/cluster_service_update_control_loop_test.go
@@ -123,7 +123,7 @@ func TestClusterService_ClusterUpdateControlLoopSingleNodeCluster(t *testing.T) 
 		logSink = io.MultiWriter(os.Stdout, logBuf)
 	}
 
-	err = logger.InitLogger(logSink, "", false, true, false)
+	err = logger.InitLogger(logSink, "", false, true, true)
 	require.NoError(t, err)
 
 	tmpDir := t.TempDir()
@@ -453,15 +453,16 @@ func TestClusterService_ClusterUpdateControlLoopSingleNodeCluster(t *testing.T) 
 	}
 
 	require.True(t, success)
-	log.Contains(`[1/8] update pending server \"one\"`)(t, logBuf)
-	log.Contains(`[2/8] updating server \"one\"`)(t, logBuf)
+	log.Contains(`[1/9] update pending server \"one\"`)(t, logBuf)
+	log.Contains(`[2/9] updating server \"one\"`)(t, logBuf)
 
-	log.Contains(`[3/8] evacuation pending server \"one\"`)(t, logBuf)
-	log.Contains(`[4/8] evacuating server \"one\"`)(t, logBuf)
-	log.Contains(`[5/8] in maintenance, reboot pending server \"one\"`)(t, logBuf)
-	log.Contains(`[6/8] in maintenance, rebooting server \"one\"`)(t, logBuf)
-	log.Contains(`[7/8] in maintenance, restore pending server \"one\"`)(t, logBuf)
-	log.Contains(`[8/8] restoring server \"one\"`)(t, logBuf)
+	log.Contains(`[3/9] evacuation pending server \"one\"`)(t, logBuf)
+	log.Contains(`[4/9] evacuating server \"one\"`)(t, logBuf)
+	log.Contains(`[5/9] in maintenance, reboot pending server \"one\"`)(t, logBuf)
+	log.Contains(`[6/9] in maintenance, rebooting server \"one\"`)(t, logBuf)
+	log.Contains(`[7/9] in maintenance, restore pending server \"one\"`)(t, logBuf)
+	log.Contains(`[8/9] restoring server \"one\"`)(t, logBuf)
+	log.Contains(`[9/9] post restore server \"one\"`)(t, logBuf)
 }
 
 func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
@@ -492,6 +493,11 @@ func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
 		Status:        api.ClusterStatusReady,
 		ServerNames:   []string{"serverA", "serverB", "serverC"},
 		Channel:       "stable",
+		Config: api.ClusterConfig{
+			RollingRestart: api.ClusterConfigRollingRestart{
+				PostRestoreDelay: (4 * asyncActionsDelay).String(),
+			},
+		},
 	}
 
 	serverA := provisioning.Server{
@@ -648,7 +654,7 @@ func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
 		logSink = io.MultiWriter(os.Stdout, logBuf)
 	}
 
-	err = logger.InitLogger(logSink, "", false, true, false)
+	err = logger.InitLogger(logSink, "", false, true, true)
 	require.NoError(t, err)
 
 	tmpDir := t.TempDir()
@@ -967,7 +973,7 @@ func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
 	require.NoError(t, err)
 
 	success := false
-	for range 100 {
+	for range 150 {
 		c, err := clusterSvc.GetByName(ctx, "clusterA")
 		require.NoError(t, err)
 		if c.UpdateStatus.InProgressStatus.InProgress == api.ClusterUpdateInProgressInactive {
@@ -982,35 +988,38 @@ func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
 	}
 
 	require.True(t, success)
-	log.Contains(`[1/24] update pending server \"serverA\"`)(t, logBuf)
-	log.Contains(`[2/24] updating server \"serverA\"`)(t, logBuf)
+	log.Contains(`[1/27] update pending server \"serverA\"`)(t, logBuf)
+	log.Contains(`[2/27] updating server \"serverA\"`)(t, logBuf)
 
-	log.Contains(`[3/24] update pending server \"serverB\"`)(t, logBuf)
-	log.Contains(`[4/24] updating server \"serverB\"`)(t, logBuf)
+	log.Contains(`[3/27] update pending server \"serverB\"`)(t, logBuf)
+	log.Contains(`[4/27] updating server \"serverB\"`)(t, logBuf)
 
-	log.Contains(`[5/24] update pending server \"serverC\"`)(t, logBuf)
-	log.Contains(`[6/24] updating server \"serverC\"`)(t, logBuf)
+	log.Contains(`[5/27] update pending server \"serverC\"`)(t, logBuf)
+	log.Contains(`[6/27] updating server \"serverC\"`)(t, logBuf)
 
-	log.Contains(`[7/24] evacuation pending server \"serverA\"`)(t, logBuf)
-	log.Contains(`[8/24] evacuating server \"serverA\"`)(t, logBuf)
-	log.Contains(`[9/24] in maintenance, reboot pending server \"serverA\"`)(t, logBuf)
-	log.Contains(`[10/24] in maintenance, rebooting server \"serverA\"`)(t, logBuf)
-	log.Contains(`[11/24] in maintenance, restore pending server \"serverA\"`)(t, logBuf)
-	log.Contains(`[12/24] restoring server \"serverA\"`)(t, logBuf)
+	log.Contains(`[7/27] evacuation pending server \"serverA\"`)(t, logBuf)
+	log.Contains(`[8/27] evacuating server \"serverA\"`)(t, logBuf)
+	log.Contains(`[9/27] in maintenance, reboot pending server \"serverA\"`)(t, logBuf)
+	log.Contains(`[10/27] in maintenance, rebooting server \"serverA\"`)(t, logBuf)
+	log.Contains(`[11/27] in maintenance, restore pending server \"serverA\"`)(t, logBuf)
+	log.Contains(`[12/27] restoring server \"serverA\"`)(t, logBuf)
+	log.Contains(`[13/27] post restore server \"serverA\"`)(t, logBuf)
 
-	log.Contains(`[13/24] evacuation pending server \"serverB\"`)(t, logBuf)
-	log.Contains(`[14/24] evacuating server \"serverB\"`)(t, logBuf)
-	log.Contains(`[15/24] in maintenance, reboot pending server \"serverB\"`)(t, logBuf)
-	log.Contains(`[16/24] in maintenance, rebooting server \"serverB\"`)(t, logBuf)
-	log.Contains(`[17/24] in maintenance, restore pending server \"serverB\"`)(t, logBuf)
-	log.Contains(`[18/24] restoring server \"serverB\"`)(t, logBuf)
+	log.Contains(`[14/27] evacuation pending server \"serverB\"`)(t, logBuf)
+	log.Contains(`[15/27] evacuating server \"serverB\"`)(t, logBuf)
+	log.Contains(`[16/27] in maintenance, reboot pending server \"serverB\"`)(t, logBuf)
+	log.Contains(`[17/27] in maintenance, rebooting server \"serverB\"`)(t, logBuf)
+	log.Contains(`[18/27] in maintenance, restore pending server \"serverB\"`)(t, logBuf)
+	log.Contains(`[19/27] restoring server \"serverB\"`)(t, logBuf)
+	log.Contains(`[20/27] post restore server \"serverB\"`)(t, logBuf)
 
-	log.Contains(`[19/24] evacuation pending server \"serverC\"`)(t, logBuf)
-	log.Contains(`[20/24] evacuating server \"serverC\"`)(t, logBuf)
-	log.Contains(`[21/24] in maintenance, reboot pending server \"serverC\"`)(t, logBuf)
-	log.Contains(`[22/24] in maintenance, rebooting server \"serverC\"`)(t, logBuf)
-	log.Contains(`[23/24] in maintenance, restore pending server \"serverC\"`)(t, logBuf)
-	log.Contains(`[24/24] restoring server \"serverC\"`)(t, logBuf)
+	log.Contains(`[21/27] evacuation pending server \"serverC\"`)(t, logBuf)
+	log.Contains(`[22/27] evacuating server \"serverC\"`)(t, logBuf)
+	log.Contains(`[23/27] in maintenance, reboot pending server \"serverC\"`)(t, logBuf)
+	log.Contains(`[24/27] in maintenance, rebooting server \"serverC\"`)(t, logBuf)
+	log.Contains(`[25/27] in maintenance, restore pending server \"serverC\"`)(t, logBuf)
+	log.Contains(`[26/27] restoring server \"serverC\"`)(t, logBuf)
+	log.Contains(`[27/27] post restore server \"serverC\"`)(t, logBuf)
 }
 
 func TestClusterService_ClusterUpdateControlLoop(t *testing.T) {

--- a/internal/provisioning/cluster_service_update_control_loop_test.go
+++ b/internal/provisioning/cluster_service_update_control_loop_test.go
@@ -994,18 +994,18 @@ func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
 	}
 
 	require.True(t, success)
-	log.Contains(`[1/27] update pending server \"serverA\"`)(t, logBuf)
-	log.Contains(`[2/27] updating server \"serverA\"`)(t, logBuf)
+	log.Contains(`[ 1/27] update pending server \"serverA\"`)(t, logBuf)
+	log.Contains(`[ 2/27] updating server \"serverA\"`)(t, logBuf)
 
-	log.Contains(`[3/27] update pending server \"serverB\"`)(t, logBuf)
-	log.Contains(`[4/27] updating server \"serverB\"`)(t, logBuf)
+	log.Contains(`[ 3/27] update pending server \"serverB\"`)(t, logBuf)
+	log.Contains(`[ 4/27] updating server \"serverB\"`)(t, logBuf)
 
-	log.Contains(`[5/27] update pending server \"serverC\"`)(t, logBuf)
-	log.Contains(`[6/27] updating server \"serverC\"`)(t, logBuf)
+	log.Contains(`[ 5/27] update pending server \"serverC\"`)(t, logBuf)
+	log.Contains(`[ 6/27] updating server \"serverC\"`)(t, logBuf)
 
-	log.Contains(`[7/27] evacuation pending server \"serverA\"`)(t, logBuf)
-	log.Contains(`[8/27] evacuating server \"serverA\"`)(t, logBuf)
-	log.Contains(`[9/27] in maintenance, reboot pending server \"serverA\"`)(t, logBuf)
+	log.Contains(`[ 7/27] evacuation pending server \"serverA\"`)(t, logBuf)
+	log.Contains(`[ 8/27] evacuating server \"serverA\"`)(t, logBuf)
+	log.Contains(`[ 9/27] in maintenance, reboot pending server \"serverA\"`)(t, logBuf)
 	log.Contains(`[10/27] in maintenance, rebooting server \"serverA\"`)(t, logBuf)
 	log.Contains(`[11/27] in maintenance, restore pending server \"serverA\"`)(t, logBuf)
 	log.Contains(`[12/27] restoring server \"serverA\"`)(t, logBuf)

--- a/internal/provisioning/cluster_service_update_control_loop_test.go
+++ b/internal/provisioning/cluster_service_update_control_loop_test.go
@@ -192,6 +192,9 @@ func TestClusterService_ClusterUpdateControlLoopSingleNodeCluster(t *testing.T) 
 
 			return nil
 		},
+		IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
+			return nil
+		},
 		GetResourcesFunc: func(ctx context.Context, endpoint provisioning.Endpoint) (api.HardwareData, error) {
 			return api.HardwareData{}, nil
 		},
@@ -725,6 +728,9 @@ func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
 				return domain.NewRetryableErr(errors.New("rebooting"))
 			}
 
+			return nil
+		},
+		IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
 			return nil
 		},
 		GetResourcesFunc: func(ctx context.Context, endpoint provisioning.Endpoint) (api.HardwareData, error) {

--- a/internal/provisioning/middleware/server_service_prometheus_gen.go
+++ b/internal/provisioning/middleware/server_service_prometheus_gen.go
@@ -264,6 +264,20 @@ func (_d ServerServiceWithPrometheus) PollServers(ctx context.Context, serverFil
 	return _d.base.PollServers(ctx, serverFilter, updateServerConfiguration)
 }
 
+// PostRestoreSystemDoneByName implements provisioning.ServerService.
+func (_d ServerServiceWithPrometheus) PostRestoreSystemDoneByName(ctx context.Context, name string) (err error) {
+	_since := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+
+		serverServiceDurationSummaryVec.WithLabelValues(_d.instanceName, "PostRestoreSystemDoneByName", result).Observe(time.Since(_since).Seconds())
+	}()
+	return _d.base.PostRestoreSystemDoneByName(ctx, name)
+}
+
 // PoweroffSystemByName implements provisioning.ServerService.
 func (_d ServerServiceWithPrometheus) PoweroffSystemByName(ctx context.Context, name string, force bool) (err error) {
 	_since := time.Now()

--- a/internal/provisioning/middleware/server_service_slog_gen.go
+++ b/internal/provisioning/middleware/server_service_slog_gen.go
@@ -601,6 +601,40 @@ func (_d ServerServiceWithSlog) PollServers(ctx context.Context, serverFilter pr
 	return _d._base.PollServers(ctx, serverFilter, updateServerConfiguration)
 }
 
+// PostRestoreSystemDoneByName implements provisioning.ServerService.
+func (_d ServerServiceWithSlog) PostRestoreSystemDoneByName(ctx context.Context, name string) (err error) {
+	log := slog.With()
+	if slog.Default().Enabled(ctx, logger.LevelTrace) {
+		log = log.With(
+			slog.Any("ctx", ctx),
+			slog.String("name", name),
+		)
+	}
+	log.DebugContext(ctx, "=> calling PostRestoreSystemDoneByName")
+	defer func() {
+		log := slog.With()
+		if slog.Default().Enabled(ctx, logger.LevelTrace) {
+			log = slog.With(
+				slog.Any("err", err),
+			)
+		} else {
+			if err != nil {
+				log = slog.With("err", err)
+			}
+		}
+		if err != nil {
+			if _d._isInformativeErrFunc(err) {
+				log.DebugContext(ctx, "<= method PostRestoreSystemDoneByName returned an informative error")
+			} else {
+				log.ErrorContext(ctx, "<= method PostRestoreSystemDoneByName returned an error")
+			}
+		} else {
+			log.DebugContext(ctx, "<= method PostRestoreSystemDoneByName finished")
+		}
+	}()
+	return _d._base.PostRestoreSystemDoneByName(ctx, name)
+}
+
 // PoweroffSystemByName implements provisioning.ServerService.
 func (_d ServerServiceWithSlog) PoweroffSystemByName(ctx context.Context, name string, force bool) (err error) {
 	log := slog.With()

--- a/internal/provisioning/mock/server_service_mock_gen.go
+++ b/internal/provisioning/mock/server_service_mock_gen.go
@@ -72,6 +72,9 @@ var _ provisioning.ServerService = &ServerServiceMock{}
 //			PollServersFunc: func(ctx context.Context, serverFilter provisioning.ServerFilter, updateServerConfiguration bool) error {
 //				panic("mock out the PollServers method")
 //			},
+//			PostRestoreSystemDoneByNameFunc: func(ctx context.Context, name string) error {
+//				panic("mock out the PostRestoreSystemDoneByName method")
+//			},
 //			PoweroffSystemByNameFunc: func(ctx context.Context, name string, force bool) error {
 //				panic("mock out the PoweroffSystemByName method")
 //			},
@@ -177,6 +180,9 @@ type ServerServiceMock struct {
 
 	// PollServersFunc mocks the PollServers method.
 	PollServersFunc func(ctx context.Context, serverFilter provisioning.ServerFilter, updateServerConfiguration bool) error
+
+	// PostRestoreSystemDoneByNameFunc mocks the PostRestoreSystemDoneByName method.
+	PostRestoreSystemDoneByNameFunc func(ctx context.Context, name string) error
 
 	// PoweroffSystemByNameFunc mocks the PoweroffSystemByName method.
 	PoweroffSystemByNameFunc func(ctx context.Context, name string, force bool) error
@@ -351,6 +357,13 @@ type ServerServiceMock struct {
 			// UpdateServerConfiguration is the updateServerConfiguration argument value.
 			UpdateServerConfiguration bool
 		}
+		// PostRestoreSystemDoneByName holds details about calls to the PostRestoreSystemDoneByName method.
+		PostRestoreSystemDoneByName []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Name is the name argument value.
+			Name string
+		}
 		// PoweroffSystemByName holds details about calls to the PoweroffSystemByName method.
 		PoweroffSystemByName []struct {
 			// Ctx is the ctx argument value.
@@ -517,6 +530,7 @@ type ServerServiceMock struct {
 	lockGetSystemUpdate              sync.RWMutex
 	lockPollServer                   sync.RWMutex
 	lockPollServers                  sync.RWMutex
+	lockPostRestoreSystemDoneByName  sync.RWMutex
 	lockPoweroffSystemByName         sync.RWMutex
 	lockRebootSystemByName           sync.RWMutex
 	lockRename                       sync.RWMutex
@@ -1125,6 +1139,42 @@ func (mock *ServerServiceMock) PollServersCalls() []struct {
 	mock.lockPollServers.RLock()
 	calls = mock.calls.PollServers
 	mock.lockPollServers.RUnlock()
+	return calls
+}
+
+// PostRestoreSystemDoneByName calls PostRestoreSystemDoneByNameFunc.
+func (mock *ServerServiceMock) PostRestoreSystemDoneByName(ctx context.Context, name string) error {
+	if mock.PostRestoreSystemDoneByNameFunc == nil {
+		panic("ServerServiceMock.PostRestoreSystemDoneByNameFunc: method is nil but ServerService.PostRestoreSystemDoneByName was just called")
+	}
+	callInfo := struct {
+		Ctx  context.Context
+		Name string
+	}{
+		Ctx:  ctx,
+		Name: name,
+	}
+	mock.lockPostRestoreSystemDoneByName.Lock()
+	mock.calls.PostRestoreSystemDoneByName = append(mock.calls.PostRestoreSystemDoneByName, callInfo)
+	mock.lockPostRestoreSystemDoneByName.Unlock()
+	return mock.PostRestoreSystemDoneByNameFunc(ctx, name)
+}
+
+// PostRestoreSystemDoneByNameCalls gets all the calls that were made to PostRestoreSystemDoneByName.
+// Check the length with:
+//
+//	len(mockedServerService.PostRestoreSystemDoneByNameCalls())
+func (mock *ServerServiceMock) PostRestoreSystemDoneByNameCalls() []struct {
+	Ctx  context.Context
+	Name string
+} {
+	var calls []struct {
+		Ctx  context.Context
+		Name string
+	}
+	mock.lockPostRestoreSystemDoneByName.RLock()
+	calls = mock.calls.PostRestoreSystemDoneByName
+	mock.lockPostRestoreSystemDoneByName.RUnlock()
 	return calls
 }
 

--- a/internal/provisioning/repo/sqlite/entities/server.mapper.go
+++ b/internal/provisioning/repo/sqlite/entities/server.mapper.go
@@ -14,7 +14,7 @@ import (
 )
 
 var serverObjects = RegisterStmt(`
-SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen
+SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen, servers.last_status_updated
   FROM servers
   LEFT JOIN clusters ON servers.cluster_id = clusters.id
   JOIN channels ON servers.channel_id = channels.id
@@ -22,7 +22,7 @@ SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers
 `)
 
 var serverObjectsByName = RegisterStmt(`
-SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen
+SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen, servers.last_status_updated
   FROM servers
   LEFT JOIN clusters ON servers.cluster_id = clusters.id
   JOIN channels ON servers.channel_id = channels.id
@@ -31,7 +31,7 @@ SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers
 `)
 
 var serverObjectsByCluster = RegisterStmt(`
-SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen
+SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen, servers.last_status_updated
   FROM servers
   LEFT JOIN clusters ON servers.cluster_id = clusters.id
   JOIN channels ON servers.channel_id = channels.id
@@ -40,7 +40,7 @@ SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers
 `)
 
 var serverObjectsByClusterAndName = RegisterStmt(`
-SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen
+SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen, servers.last_status_updated
   FROM servers
   LEFT JOIN clusters ON servers.cluster_id = clusters.id
   JOIN channels ON servers.channel_id = channels.id
@@ -49,7 +49,7 @@ SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers
 `)
 
 var serverObjectsByClusterAndStatus = RegisterStmt(`
-SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen
+SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen, servers.last_status_updated
   FROM servers
   LEFT JOIN clusters ON servers.cluster_id = clusters.id
   JOIN channels ON servers.channel_id = channels.id
@@ -58,7 +58,7 @@ SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers
 `)
 
 var serverObjectsByStatus = RegisterStmt(`
-SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen
+SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen, servers.last_status_updated
   FROM servers
   LEFT JOIN clusters ON servers.cluster_id = clusters.id
   JOIN channels ON servers.channel_id = channels.id
@@ -67,7 +67,7 @@ SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers
 `)
 
 var serverObjectsByStatusAndStatusDetail = RegisterStmt(`
-SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen
+SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen, servers.last_status_updated
   FROM servers
   LEFT JOIN clusters ON servers.cluster_id = clusters.id
   JOIN channels ON servers.channel_id = channels.id
@@ -76,7 +76,7 @@ SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers
 `)
 
 var serverObjectsByCertificate = RegisterStmt(`
-SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen
+SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen, servers.last_status_updated
   FROM servers
   LEFT JOIN clusters ON servers.cluster_id = clusters.id
   JOIN channels ON servers.channel_id = channels.id
@@ -85,7 +85,7 @@ SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers
 `)
 
 var serverObjectsByType = RegisterStmt(`
-SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen
+SELECT servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen, servers.last_status_updated
   FROM servers
   LEFT JOIN clusters ON servers.cluster_id = clusters.id
   JOIN channels ON servers.channel_id = channels.id
@@ -113,13 +113,13 @@ SELECT servers.id FROM servers
 `)
 
 var serverCreate = RegisterStmt(`
-INSERT INTO servers (cluster_id, name, type, connection_url, public_connection_url, certificate, hardware_data, os_data, version_data, channel_id, status, status_detail, description, properties, last_updated, last_seen)
-  VALUES ((SELECT clusters.id FROM clusters WHERE clusters.name = ?), ?, ?, ?, ?, ?, ?, ?, ?, (SELECT channels.id FROM channels WHERE channels.name = ?), ?, ?, ?, ?, ?, ?)
+INSERT INTO servers (cluster_id, name, type, connection_url, public_connection_url, certificate, hardware_data, os_data, version_data, channel_id, status, status_detail, description, properties, last_updated, last_seen, last_status_updated)
+  VALUES ((SELECT clusters.id FROM clusters WHERE clusters.name = ?), ?, ?, ?, ?, ?, ?, ?, ?, (SELECT channels.id FROM channels WHERE channels.name = ?), ?, ?, ?, ?, ?, ?, ?)
 `)
 
 var serverUpdate = RegisterStmt(`
 UPDATE servers
-  SET cluster_id = (SELECT clusters.id FROM clusters WHERE clusters.name = ?), name = ?, type = ?, connection_url = ?, public_connection_url = ?, certificate = ?, hardware_data = ?, os_data = ?, version_data = ?, channel_id = (SELECT channels.id FROM channels WHERE channels.name = ?), status = ?, status_detail = ?, description = ?, properties = ?, last_updated = ?, last_seen = ?
+  SET cluster_id = (SELECT clusters.id FROM clusters WHERE clusters.name = ?), name = ?, type = ?, connection_url = ?, public_connection_url = ?, certificate = ?, hardware_data = ?, os_data = ?, version_data = ?, channel_id = (SELECT channels.id FROM channels WHERE channels.name = ?), status = ?, status_detail = ?, description = ?, properties = ?, last_updated = ?, last_seen = ?, last_status_updated = ?
  WHERE id = ?
 `)
 
@@ -211,7 +211,7 @@ func GetServer(ctx context.Context, db dbtx, name string) (_ *provisioning.Serve
 // serverColumns returns a string of column names to be used with a SELECT statement for the entity.
 // Use this function when building statements to retrieve database entries matching the Server entity.
 func serverColumns() string {
-	return "servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen"
+	return "servers.id, clusters.name AS cluster, servers.name, servers.type, servers.connection_url, servers.public_connection_url, servers.certificate, clusters.certificate AS cluster_certificate, clusters.connection_url AS cluster_connection_url, servers.hardware_data, servers.os_data, servers.version_data, channels.name AS channel, servers.status, servers.status_detail, servers.description, servers.properties, servers.last_updated, servers.last_seen, servers.last_status_updated"
 }
 
 // getServers can be used to run handwritten sql.Stmts to return a slice of objects.
@@ -220,7 +220,7 @@ func getServers(ctx context.Context, stmt *sql.Stmt, args ...any) ([]provisionin
 
 	dest := func(scan func(dest ...any) error) error {
 		s := provisioning.Server{}
-		err := scan(&s.ID, &s.Cluster, &s.Name, &s.Type, &s.ConnectionURL, &s.PublicConnectionURL, &s.Certificate, &s.ClusterCertificate, &s.ClusterConnectionURL, &s.HardwareData, &s.OSData, &s.VersionData, &s.Channel, &s.Status, &s.StatusDetail, &s.Description, &s.Properties, &s.LastUpdated, &s.LastSeen)
+		err := scan(&s.ID, &s.Cluster, &s.Name, &s.Type, &s.ConnectionURL, &s.PublicConnectionURL, &s.Certificate, &s.ClusterCertificate, &s.ClusterConnectionURL, &s.HardwareData, &s.OSData, &s.VersionData, &s.Channel, &s.Status, &s.StatusDetail, &s.Description, &s.Properties, &s.LastUpdated, &s.LastSeen, &s.LastStatusUpdated)
 		if err != nil {
 			return err
 		}
@@ -244,7 +244,7 @@ func getServersRaw(ctx context.Context, db dbtx, sql string, args ...any) ([]pro
 
 	dest := func(scan func(dest ...any) error) error {
 		s := provisioning.Server{}
-		err := scan(&s.ID, &s.Cluster, &s.Name, &s.Type, &s.ConnectionURL, &s.PublicConnectionURL, &s.Certificate, &s.ClusterCertificate, &s.ClusterConnectionURL, &s.HardwareData, &s.OSData, &s.VersionData, &s.Channel, &s.Status, &s.StatusDetail, &s.Description, &s.Properties, &s.LastUpdated, &s.LastSeen)
+		err := scan(&s.ID, &s.Cluster, &s.Name, &s.Type, &s.ConnectionURL, &s.PublicConnectionURL, &s.Certificate, &s.ClusterCertificate, &s.ClusterConnectionURL, &s.HardwareData, &s.OSData, &s.VersionData, &s.Channel, &s.Status, &s.StatusDetail, &s.Description, &s.Properties, &s.LastUpdated, &s.LastSeen, &s.LastStatusUpdated)
 		if err != nil {
 			return err
 		}
@@ -596,7 +596,7 @@ func CreateServer(ctx context.Context, db dbtx, object provisioning.Server) (_ i
 		_err = mapErr(_err, "Server")
 	}()
 
-	args := make([]any, 16)
+	args := make([]any, 17)
 
 	// Populate the statement arguments.
 	args[0] = object.Cluster
@@ -615,6 +615,7 @@ func CreateServer(ctx context.Context, db dbtx, object provisioning.Server) (_ i
 	args[13] = object.Properties
 	args[14] = time.Now().UTC().Format(time.RFC3339)
 	args[15] = object.LastSeen
+	args[16] = object.LastStatusUpdated
 
 	// Prepared statement to use.
 	stmt, err := Stmt(db, serverCreate)
@@ -657,7 +658,7 @@ func UpdateServer(ctx context.Context, db tx, name string, object provisioning.S
 		return fmt.Errorf("Failed to get \"serverUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Cluster, object.Name, object.Type, object.ConnectionURL, object.PublicConnectionURL, object.Certificate, object.HardwareData, object.OSData, object.VersionData, object.Channel, object.Status, object.StatusDetail, object.Description, object.Properties, time.Now().UTC().Format(time.RFC3339), object.LastSeen, id)
+	result, err := stmt.Exec(object.Cluster, object.Name, object.Type, object.ConnectionURL, object.PublicConnectionURL, object.Certificate, object.HardwareData, object.OSData, object.VersionData, object.Channel, object.Status, object.StatusDetail, object.Description, object.Properties, time.Now().UTC().Format(time.RFC3339), object.LastSeen, object.LastStatusUpdated, id)
 	if err != nil {
 		return fmt.Errorf("Update \"servers\" entry failed: %w", err)
 	}

--- a/internal/provisioning/repo/sqlite/server_test.go
+++ b/internal/provisioning/repo/sqlite/server_test.go
@@ -121,6 +121,9 @@ func TestServerDatabaseActions(t *testing.T) {
 		PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
 			return nil
 		},
+		IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
+			return nil
+		},
 		GetResourcesFunc: func(ctx context.Context, endpoint provisioning.Endpoint) (api.HardwareData, error) {
 			return api.HardwareData{}, nil
 		},

--- a/internal/provisioning/server_expr_gen.go
+++ b/internal/provisioning/server_expr_gen.go
@@ -372,6 +372,7 @@ type ExprServer struct {
 	Properties           api.ConfigMap            `json:"properties" expr:"properties"`
 	LastUpdated          time.Time                `json:"last_updated"           db:"update_timestamp" expr:"last_updated"`
 	LastSeen             time.Time                `json:"last_seen" expr:"last_seen"`
+	LastStatusUpdated    time.Time                `json:"last_status_updated" expr:"last_status_updated"`
 }
 
 func ToExprApiApplicationVersionData(a api.ApplicationVersionData) ExprApiApplicationVersionData {
@@ -818,5 +819,6 @@ func ToExprServer(s Server) ExprServer {
 		Properties:           s.Properties,
 		LastUpdated:          s.LastUpdated,
 		LastSeen:             s.LastSeen,
+		LastStatusUpdated:    s.LastStatusUpdated,
 	}
 }

--- a/internal/provisioning/server_model.go
+++ b/internal/provisioning/server_model.go
@@ -41,6 +41,7 @@ type Server struct {
 	Properties           api.ConfigMap          `json:"properties"`
 	LastUpdated          time.Time              `json:"last_updated"           db:"update_timestamp"`
 	LastSeen             time.Time              `json:"last_seen"`
+	LastStatusUpdated    time.Time              `json:"last_status_updated"`
 }
 
 func (s Server) GetConnectionURL() string {

--- a/internal/provisioning/server_ports.go
+++ b/internal/provisioning/server_ports.go
@@ -64,6 +64,7 @@ type ServerRepo interface {
 
 type ServerClientPort interface {
 	Ping(ctx context.Context, endpoint Endpoint) error
+	IsReady(ctx context.Context, server Server) error
 	GetResources(ctx context.Context, endpoint Endpoint) (api.HardwareData, error)
 	GetOSData(ctx context.Context, endpoint Endpoint) (api.OSData, error)
 	GetVersionData(ctx context.Context, server Server) (api.ServerVersionData, error)

--- a/internal/provisioning/server_ports.go
+++ b/internal/provisioning/server_ports.go
@@ -39,6 +39,7 @@ type ServerService interface {
 	PoweroffSystemByName(ctx context.Context, name string, force bool) error
 	RebootSystemByName(ctx context.Context, name string, force bool) error
 	RestoreSystemByName(ctx context.Context, name string, clusterUpdate bool, force bool, restoreModeSkip bool) error
+	PostRestoreSystemDoneByName(ctx context.Context, name string) error
 	UpdateSystemByName(ctx context.Context, name string, updateRequest api.ServerUpdatePost, force bool) error
 
 	GetSystemLogging(ctx context.Context, name string) (ServerSystemLogging, error)

--- a/internal/provisioning/server_service.go
+++ b/internal/provisioning/server_service.go
@@ -1189,6 +1189,8 @@ func (s *serverService) RestoreSystemByName(ctx context.Context, name string, cl
 			return fmt.Errorf("Lifecycle operation for server %q currently not permitted: %w", name, domain.ErrOperationNotPermitted)
 		}
 
+		server.StatusDetail = api.ServerStatusDetailReadyRestoring
+
 		for i := range server.VersionData.Applications {
 			if server.VersionData.Applications[i].Name == string(images.UpdateFileComponentIncus) {
 				server.VersionData.Applications[i].InMaintenance = api.InMaintenanceRestoring
@@ -1220,6 +1222,39 @@ func (s *serverService) RestoreSystemByName(ctx context.Context, name string, cl
 	}
 
 	reverter.Success()
+
+	server.signalLifecycleEvent()
+
+	return nil
+}
+
+func (s *serverService) PostRestoreSystemDoneByName(ctx context.Context, name string) error {
+	var server *Server
+
+	err := transaction.Do(ctx, func(ctx context.Context) error {
+		var err error
+
+		server, err = s.GetByName(ctx, name)
+		if err != nil {
+			return fmt.Errorf("Failed to get server %q by name: %w", name, err)
+		}
+
+		if server.Type != api.ServerTypeIncus {
+			return fmt.Errorf("Server %q is not of type %q: %w", name, api.ServerTypeIncus, domain.ErrOperationNotPermitted)
+		}
+
+		server.StatusDetail = api.ServerStatusDetailNone
+
+		err = s.repo.Update(ctx, *server)
+		if err != nil {
+			return fmt.Errorf("Failed put server %q in restoring: %w", name, err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
 
 	server.signalLifecycleEvent()
 

--- a/internal/provisioning/server_service.go
+++ b/internal/provisioning/server_service.go
@@ -135,6 +135,7 @@ func (s *serverService) Create(ctx context.Context, token uuid.UUID, newServer S
 
 		newServer.Status = api.ServerStatusPending
 		newServer.StatusDetail = api.ServerStatusDetailPendingReconfiguring
+		newServer.LastStatusUpdated = s.now()
 		newServer.LastSeen = s.now()
 		newServer.Channel = channel
 
@@ -481,7 +482,7 @@ func (s *serverService) UpdateSystemNetwork(ctx context.Context, name string, sy
 		updatedServer.OSData.Network = systemNetwork
 		updatedServer.Status = api.ServerStatusPending
 		updatedServer.StatusDetail = api.ServerStatusDetailPendingReconfiguring
-
+		updatedServer.LastStatusUpdated = s.now()
 		updatedServer.LastSeen = s.now()
 
 		err = s.Update(ctx, *updatedServer, true, false)
@@ -549,7 +550,7 @@ func (s *serverService) UpdateSystemStorage(ctx context.Context, name string, sy
 		updatedServer.OSData.Storage = systemStorage
 		updatedServer.Status = api.ServerStatusPending
 		updatedServer.StatusDetail = api.ServerStatusDetailPendingReconfiguring
-
+		updatedServer.LastStatusUpdated = s.now()
 		updatedServer.LastSeen = s.now()
 
 		err = s.Update(ctx, *updatedServer, true, false)
@@ -776,6 +777,7 @@ func (s *serverService) SelfRegisterOperationsCenter(ctx context.Context) error 
 				Certificate:         string(serverCert),
 				Status:              api.ServerStatusReady,
 				StatusDetail:        api.ServerStatusDetailNone,
+				LastStatusUpdated:   s.now(),
 				LastSeen:            s.now(),
 				Channel:             config.GetUpdates().ServerDefaultChannel,
 			}
@@ -795,6 +797,7 @@ func (s *serverService) SelfRegisterOperationsCenter(ctx context.Context) error 
 			server.Certificate = string(serverCert)
 			server.Status = api.ServerStatusReady
 			server.StatusDetail = api.ServerStatusDetailNone
+			server.LastStatusUpdated = s.now()
 			server.LastSeen = s.now()
 
 			upsert = func(ctx context.Context, server Server) error {
@@ -1031,6 +1034,7 @@ func (s *serverService) PoweroffSystemByName(ctx context.Context, name string, f
 
 		server.Status = api.ServerStatusOffline
 		server.StatusDetail = api.ServerStatusDetailOfflineShutdown
+		server.LastStatusUpdated = s.now()
 
 		err = s.Update(ctx, *server, false, false)
 		if err != nil {
@@ -1099,6 +1103,7 @@ func (s *serverService) RebootSystemByName(ctx context.Context, name string, for
 
 		server.Status = api.ServerStatusOffline
 		server.StatusDetail = api.ServerStatusDetailOfflineRebooting
+		server.LastStatusUpdated = s.now()
 
 		err = s.Update(ctx, *server, false, false)
 		if err != nil {
@@ -1190,6 +1195,7 @@ func (s *serverService) RestoreSystemByName(ctx context.Context, name string, cl
 		}
 
 		server.StatusDetail = api.ServerStatusDetailReadyRestoring
+		server.LastStatusUpdated = s.now()
 
 		for i := range server.VersionData.Applications {
 			if server.VersionData.Applications[i].Name == string(images.UpdateFileComponentIncus) {
@@ -1244,6 +1250,7 @@ func (s *serverService) PostRestoreSystemDoneByName(ctx context.Context, name st
 		}
 
 		server.StatusDetail = api.ServerStatusDetailNone
+		server.LastStatusUpdated = s.now()
 
 		err = s.repo.Update(ctx, *server)
 		if err != nil {
@@ -1289,6 +1296,7 @@ func (s *serverService) UpdateSystemByName(ctx context.Context, name string, upd
 		previousServer = server.Clone()
 
 		server.StatusDetail = api.ServerStatusDetailReadyUpdating
+		server.LastStatusUpdated = s.now()
 
 		err = s.Update(ctx, *server, false, false)
 		if err != nil {
@@ -1555,6 +1563,7 @@ func (s *serverService) PollServer(ctx context.Context, server Server, updateSer
 
 					updateServer.Status = api.ServerStatusOffline
 					updateServer.StatusDetail = api.ServerStatusDetailOfflineUnresponsive
+					updateServer.LastStatusUpdated = s.now()
 					err = s.repo.Update(ctx, *updateServer)
 					if err != nil {
 						return err
@@ -1649,11 +1658,11 @@ func (s *serverService) PollServer(ctx context.Context, server Server, updateSer
 		// of reboot or reconfiguration.
 		if server.Status != api.ServerStatusReady {
 			s.volatileServerStates.reset(server.Name, operationReboot)
+			server.Status = api.ServerStatusReady
 			server.StatusDetail = api.ServerStatusDetailNone
+			server.LastStatusUpdated = s.now()
 			signalLifecycle = true
 		}
-
-		server.Status = api.ServerStatusReady
 
 		if updateServerConfiguration {
 			server.HardwareData = hardwareData

--- a/internal/provisioning/server_service.go
+++ b/internal/provisioning/server_service.go
@@ -1601,6 +1601,11 @@ func (s *serverService) PollServer(ctx context.Context, server Server, updateSer
 		return connTestErr
 	}
 
+	err = s.client.IsReady(ctx, server)
+	if err != nil {
+		return err
+	}
+
 	var hardwareData api.HardwareData
 	var osData api.OSData
 	var versionData api.ServerVersionData

--- a/internal/provisioning/server_service_test.go
+++ b/internal/provisioning/server_service_test.go
@@ -153,6 +153,9 @@ func TestServerService_UpdateCertificate(t *testing.T) {
 				PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
 					return nil
 				},
+				IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
+					return nil
+				},
 				GetResourcesFunc: func(ctx context.Context, endpoint provisioning.Endpoint) (api.HardwareData, error) {
 					return api.HardwareData{}, nil
 				},
@@ -323,6 +326,9 @@ one
 
 			client := &adapterMock.ServerClientPortMock{
 				PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
+					return nil
+				},
+				IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
 					return nil
 				},
 				GetResourcesFunc: func(ctx context.Context, endpoint provisioning.Endpoint) (api.HardwareData, error) {
@@ -1333,6 +1339,9 @@ one
 				PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
 					return errors.New("") // short cirquite pollServer, since we don't care about this part in this test.
 				},
+				IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
+					return nil
+				},
 				UpdateUpdateConfigFunc: func(ctx context.Context, server provisioning.Server, providerConfig provisioning.ServerSystemUpdate) error {
 					return nil
 				},
@@ -2214,6 +2223,9 @@ one
 				PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
 					return nil
 				},
+				IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
+					return nil
+				},
 				GetResourcesFunc: func(ctx context.Context, endpoint provisioning.Endpoint) (api.HardwareData, error) {
 					return api.HardwareData{}, boom.Error // Since we do not care too much, if the server poll was successful, we always return an error here.
 				},
@@ -2559,6 +2571,9 @@ func TestServerService_SelfUpdate(t *testing.T) {
 				PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
 					return nil
 				},
+				IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
+					return nil
+				},
 				GetResourcesFunc: func(ctx context.Context, endpoint provisioning.Endpoint) (api.HardwareData, error) {
 					return api.HardwareData{}, nil
 				},
@@ -2702,6 +2717,9 @@ func TestServerService_SelfRegisterOperationsCenter(t *testing.T) {
 
 			client := &adapterMock.ServerClientPortMock{
 				PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
+					return nil
+				},
+				IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
 					return nil
 				},
 				GetResourcesFunc: func(ctx context.Context, endpoint provisioning.Endpoint) (api.HardwareData, error) {
@@ -3001,6 +3019,9 @@ func TestServerService_PollServers(t *testing.T) {
 			client := &adapterMock.ServerClientPortMock{
 				PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
 					return tc.clientPingErr
+				},
+				IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
+					return nil
 				},
 			}
 
@@ -3589,6 +3610,9 @@ foobar
 					_, err := queue.Pop(t, &tc.clientPing)
 					return err
 				},
+				IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
+					return nil
+				},
 			}
 
 			clusterSvc := &svcMock.ClusterServiceMock{
@@ -3626,6 +3650,7 @@ func TestServerService_PollServer(t *testing.T) {
 		name                         string
 		serverArg                    provisioning.Server
 		updateServerConfigArg        bool
+		clientIsReadyErr             error
 		clientGetResourcesErr        error
 		clientGetOSData              api.OSData
 		clientGetOSDataErr           error
@@ -3734,6 +3759,34 @@ func TestServerService_PollServer(t *testing.T) {
 			assertLog: log.Empty,
 		},
 
+		{
+			name: "error - client IsReady",
+			serverArg: provisioning.Server{
+				Name:   "one",
+				Status: api.ServerStatusPending,
+			},
+			updateServerConfigArg: true,
+			clientIsReadyErr:      boom.Error,
+			clientGetOSData: api.OSData{
+				Network: incusosapi.SystemNetwork{
+					State: incusosapi.SystemNetworkState{
+						Interfaces: map[string]incusosapi.SystemNetworkInterfaceState{
+							"eth0": {
+								Addresses: []string{
+									"192.168.0.100",
+								},
+								Roles: []string{
+									"management",
+								},
+							},
+						},
+					},
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+			assertLog: log.Empty,
+		},
 		{
 			name: "error - client GetResources",
 			serverArg: provisioning.Server{
@@ -4005,6 +4058,9 @@ func TestServerService_PollServer(t *testing.T) {
 				PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
 					return nil
 				},
+				IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
+					return tc.clientIsReadyErr
+				},
 				GetResourcesFunc: func(ctx context.Context, endpoint provisioning.Endpoint) (api.HardwareData, error) {
 					return api.HardwareData{}, tc.clientGetResourcesErr
 				},
@@ -4059,6 +4115,9 @@ func TestServerService_PollServer_in_transaction(t *testing.T) {
 
 	client := &adapterMock.ServerClientPortMock{
 		PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
+			return nil
+		},
+		IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
 			return nil
 		},
 	}
@@ -4232,6 +4291,9 @@ func TestServerService_ResyncByName(t *testing.T) {
 
 			client := &adapterMock.ServerClientPortMock{
 				PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
+					return nil
+				},
+				IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
 					return nil
 				},
 				GetResourcesFunc: func(ctx context.Context, endpoint provisioning.Endpoint) (api.HardwareData, error) {
@@ -6061,6 +6123,9 @@ func TestServerService_UpdateSystemByName(t *testing.T) {
 				},
 				PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
 					return errors.New("") // short cirquite pollServer, since we don't care about this part in this test.
+				},
+				IsReadyFunc: func(ctx context.Context, server provisioning.Server) error {
+					return nil
 				},
 				UpdateUpdateConfigFunc: func(ctx context.Context, server provisioning.Server, providerConfig provisioning.ServerSystemUpdate) error {
 					return nil

--- a/internal/provisioning/server_service_test.go
+++ b/internal/provisioning/server_service_test.go
@@ -5741,6 +5741,101 @@ func TestServerService_RestoreSystemByName(t *testing.T) {
 	}
 }
 
+func TestServerService_PostRestoreSystemDoneByName(t *testing.T) {
+	tests := []struct {
+		name               string
+		argRestoreModeSkip bool
+		repoGetByName      provisioning.Server
+		repoGetByNameErr   error
+		repoUpdateErr      error
+
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "success",
+			repoGetByName: provisioning.Server{
+				Name:   "one",
+				Status: api.ServerStatusReady,
+				Type:   api.ServerTypeIncus,
+				VersionData: api.ServerVersionData{
+					Applications: []api.ApplicationVersionData{
+						{
+							Name: "incus",
+						},
+					},
+				},
+			},
+
+			assertErr: require.NoError,
+		},
+		{
+			name:             "error - repo.GetByName",
+			repoGetByNameErr: boom.Error,
+
+			assertErr: boom.ErrorIs,
+		},
+		{
+			name: "error - not type incus",
+			repoGetByName: provisioning.Server{
+				Name:   "one",
+				Status: api.ServerStatusReady,
+				Type:   api.ServerTypeOperationsCenter,
+			},
+
+			assertErr: func(tt require.TestingT, err error, a ...any) {
+				require.ErrorIs(tt, err, domain.ErrOperationNotPermitted)
+			},
+		},
+		{
+			name: "error - repo.Update",
+			repoGetByName: provisioning.Server{
+				Name:   "one",
+				Status: api.ServerStatusReady,
+				Type:   api.ServerTypeIncus,
+				VersionData: api.ServerVersionData{
+					Applications: []api.ApplicationVersionData{
+						{
+							Name: "incus",
+						},
+					},
+				},
+			},
+			repoUpdateErr: boom.Error,
+
+			assertErr: boom.ErrorIs,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+
+			repo := &repoMock.ServerRepoMock{
+				GetByNameFunc: func(ctx context.Context, name string) (*provisioning.Server, error) {
+					return &tc.repoGetByName, tc.repoGetByNameErr
+				},
+				UpdateFunc: func(ctx context.Context, server provisioning.Server) error {
+					return tc.repoUpdateErr
+				},
+			}
+
+			updateSvc := &svcMock.UpdateServiceMock{
+				GetAllWithFilterFunc: func(ctx context.Context, filter provisioning.UpdateFilter) (provisioning.Updates, error) {
+					return provisioning.Updates{}, nil
+				},
+			}
+
+			serverSvc := provisioning.NewServerService(repo, nil, nil, nil, nil, updateSvc, tls.Certificate{})
+
+			// Run test
+			err := serverSvc.PostRestoreSystemDoneByName(t.Context(), "one")
+
+			// Assert
+			tc.assertErr(t, err)
+		})
+	}
+}
+
 func TestServerService_UpdateSystemByName(t *testing.T) {
 	tests := []struct {
 		name                                            string

--- a/internal/sql/dbschema/schema/000001_freshschema.sql
+++ b/internal/sql/dbschema/schema/000001_freshschema.sql
@@ -60,6 +60,7 @@ CREATE TABLE servers (
   status_detail TEXT NOT NULL DEFAULT '',
   description TEXT NOT NULL DEFAULT '',
   properties TEXT NOT NULL DEFAULT '',
+  last_status_updated DATETIME NOT NULL DEFAULT '0000-01-01 00:00:00.0+00:00',
   UNIQUE (name),
   UNIQUE (certificate),
   FOREIGN KEY (cluster_id) REFERENCES clusters(id) ON DELETE CASCADE,
@@ -407,4 +408,4 @@ CREATE VIEW resources AS
     LEFT JOIN servers ON storage_volumes.server_id = servers.id
 ;
 
-INSERT INTO schema (version, updated_at) VALUES (32, strftime("%s"));
+INSERT INTO schema (version, updated_at) VALUES (33, strftime("%s"));

--- a/internal/sql/dbschema/seed/seed.go
+++ b/internal/sql/dbschema/seed/seed.go
@@ -77,17 +77,20 @@ func DB(ctx context.Context, db *sql.DB, config Config) error {
 			}
 
 			servers = append(servers, serverName)
+			updatedAt := faker.Date()
 			_, err = serverRepo.Create(ctx, provisioning.Server{
-				Cluster:       &clusterName,
-				Name:          serverName,
-				Type:          api.ServerType(faker.RandomString([]string{"unknown", "incus", "migration-manager", "operations-center"})),
-				ConnectionURL: fmt.Sprintf("https://%s.domain.tdl", serverName),
-				Certificate:   string(certPEM),
-				HardwareData:  api.HardwareData{},
-				OSData:        api.OSData{},
-				Status:        api.ServerStatusReady,
-				LastUpdated:   faker.Date(),
-				Channel:       "stable",
+				Cluster:           &clusterName,
+				Name:              serverName,
+				Type:              api.ServerType(faker.RandomString([]string{"unknown", "incus", "migration-manager", "operations-center"})),
+				ConnectionURL:     fmt.Sprintf("https://%s.domain.tdl", serverName),
+				Certificate:       string(certPEM),
+				HardwareData:      api.HardwareData{},
+				OSData:            api.OSData{},
+				Status:            api.ServerStatusReady,
+				LastStatusUpdated: updatedAt,
+				LastUpdated:       updatedAt,
+				LastSeen:          updatedAt,
+				Channel:           "stable",
 			})
 			if err != nil {
 				return err

--- a/internal/sql/dbschema/update.go
+++ b/internal/sql/dbschema/update.go
@@ -60,6 +60,16 @@ var updates = map[int]update{
 	30: updateFromV29,
 	31: updateFromV30,
 	32: updateFromV31,
+	33: updateFromV32,
+}
+
+func updateFromV32(ctx context.Context, tx *sql.Tx) error {
+	// v32..v33 add field last_status_updated to servers table.
+	stmt := `
+ALTER TABLE servers ADD COLUMN last_status_updated DATETIME NOT NULL DEFAULT '0000-01-01 00:00:00.0+00:00';
+`
+	_, err := tx.Exec(stmt)
+	return MapDBError(err)
 }
 
 func updateFromV31(ctx context.Context, tx *sql.Tx) error {

--- a/internal/util/editor/editor.go
+++ b/internal/util/editor/editor.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/lxc/incus/v6/shared/revert"
+	"github.com/mattn/go-shellwords"
 )
 
 // Spawn the editor with a temporary YAML file for editing configs.
@@ -77,8 +77,12 @@ func Spawn(inPath string, inContent []byte) ([]byte, error) {
 		path = inPath
 	}
 
-	cmdParts := strings.Fields(editor)
-	cmd := exec.Command(cmdParts[0], append(cmdParts[1:], path)...)
+	args, err := shellwords.Parse(editor)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	cmd := exec.Command(args[0], append(args[1:], path)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/shared/api/provisioning_server.go
+++ b/shared/api/provisioning_server.go
@@ -154,7 +154,8 @@ const (
 
 	ServerStatusDetailPendingReconfiguring ServerStatusDetail = "re-configuring"
 
-	ServerStatusDetailReadyUpdating ServerStatusDetail = "updating"
+	ServerStatusDetailReadyUpdating  ServerStatusDetail = "updating"
+	ServerStatusDetailReadyRestoring ServerStatusDetail = "restoring"
 
 	ServerStatusDetailOfflineRebooting    ServerStatusDetail = "rebooting"
 	ServerStatusDetailOfflineShutdown     ServerStatusDetail = "shut down"
@@ -165,6 +166,7 @@ var serverStatusDetails = map[ServerStatusDetail]struct{}{
 	ServerStatusDetailNone:                 {},
 	ServerStatusDetailPendingReconfiguring: {},
 	ServerStatusDetailReadyUpdating:        {},
+	ServerStatusDetailReadyRestoring:       {},
 	ServerStatusDetailOfflineRebooting:     {},
 	ServerStatusDetailOfflineShutdown:      {},
 	ServerStatusDetailOfflineUnresponsive:  {},
@@ -661,7 +663,8 @@ const (
 	ServerUpdateStateInMaintenanceRebootPending  ServerUpdateState = "in maintenance, reboot pending"  // ServerStatusReady, NeedsUpdate: false, NeedsReboot: true, InMaintenance: InMaintenanceEvacuated
 	ServerUpdateStateInMaintenanceRebooting      ServerUpdateState = "in maintenance, rebooting"       // ServerStatusOffline, ServerStatusDetailOfflineRebooting, InMaintenance: InMaintenanceEvacuated
 	ServerUpdateStateInMaintenanceRestorePending ServerUpdateState = "in maintenance, restore pending" // ServerStatusReady, NeedsUpdate: false, InMaintenance: InMaintenanceEvacuated
-	ServerUpdateStateInMaintenanceRestoring      ServerUpdateState = "restoring"                       // ServerStatusReady, NeedsUpdate: false, InMaintenance: InMaintenanceRestoring
+	ServerUpdateStateInMaintenanceRestoring      ServerUpdateState = "restoring"                       // ServerStatusReady, ServerStatusDetailReadyRestoring, NeedsUpdate: false, InMaintenance: InMaintenanceRestoring
+	ServerUpdateStateInMaintenancePostRestore    ServerUpdateState = "post restore"                    // ServerStatusReady, ServerStatusDetailReadyRestoring, NeedsUpdate: false, InMaintenance: NotInMaintenance
 	ServerUpdateStateRebootPending               ServerUpdateState = "reboot pending"                  // ServerStatusReady, NeedsUpdate: false, NeedsReboot: true, IsIncusCluster: false, InMaintenance: NotInMaintenance
 	ServerUpdateStateRebooting                   ServerUpdateState = "rebooting"                       // ServerStatusOffline, ServerStatusDetailOfflineRebooting
 )
@@ -695,7 +698,8 @@ func (s Server) UpdateState() ServerUpdateState {
 
 	if !ptr.From(s.VersionData.NeedsUpdate) &&
 		!ptr.From(s.VersionData.NeedsReboot) &&
-		ptr.From(s.VersionData.InMaintenance) == NotInMaintenance {
+		ptr.From(s.VersionData.InMaintenance) == NotInMaintenance &&
+		((s.Status == ServerStatusReady && s.StatusDetail == ServerStatusDetailNone) || s.Status == ServerStatusOffline) {
 		return ServerUpdateStateUpToDate
 	}
 
@@ -709,6 +713,10 @@ func (s Server) UpdateState() ServerUpdateState {
 
 	case InMaintenanceRestoring:
 		return ServerUpdateStateInMaintenanceRestoring
+	}
+
+	if s.StatusDetail == ServerStatusDetailReadyRestoring {
+		return ServerUpdateStateInMaintenancePostRestore
 	}
 
 	if ptr.From(s.VersionData.NeedsReboot) {

--- a/shared/api/provisioning_server_test.go
+++ b/shared/api/provisioning_server_test.go
@@ -167,7 +167,7 @@ func TestServerVersionData_State(t *testing.T) {
 		},
 		{
 			status:        api.ServerStatusReady,
-			statusDetail:  api.ServerStatusDetailNone,
+			statusDetail:  api.ServerStatusDetailReadyRestoring,
 			cluster:       "one",
 			needsUpdate:   false,
 			needsReboot:   false,
@@ -175,6 +175,17 @@ func TestServerVersionData_State(t *testing.T) {
 			isTypeIncus:   true,
 
 			wantServerUpdateState: api.ServerUpdateStateInMaintenanceRestoring,
+		},
+		{
+			status:        api.ServerStatusReady,
+			statusDetail:  api.ServerStatusDetailReadyRestoring,
+			cluster:       "one",
+			needsUpdate:   false,
+			needsReboot:   false,
+			inMaintenance: api.NotInMaintenance,
+			isTypeIncus:   true,
+
+			wantServerUpdateState: api.ServerUpdateStateInMaintenancePostRestore,
 		},
 		{
 			status:        api.ServerStatusReady,


### PR DESCRIPTION
This PR includes the following changes and fixes:

* Introduction of a dedicated `PostRestore` state.
* Introduction of a timestamp, when the server status has been changed for the last time (required to determine if the post_restore_delay has elapsed).
* Checking and waiting for "ready state" of IncusOS after a reboot.
* Extension for the E2E tests to update cluster configuration with post_restore_delay
* Removal of API calls within DB transaction
* Arguments handling for the call out to the external editor in the CLI (required to make the E2E tests work)
* Several fixes to the E2E tests