### PR TITLE
provisioning/adapter/terraform: disable accept_remote_certificate

### DIFF
--- a/internal/provisioning/adapter/terraform/templates/providers.tf.gotmpl
+++ b/internal/provisioning/adapter/terraform/templates/providers.tf.gotmpl
@@ -27,7 +27,7 @@ provider "incus" {
   // Automatically accept the Incus remote's certificate.
   // If this is not set to true, you must accept the certificate out of band of Terraform.
   // This can also be set with the INCUS_ACCEPT_SERVER_CERTIFICATE environment variable.
-  accept_remote_certificate = true
+  //accept_remote_certificate = true
 
   default_remote = "{{ .ClusterName }}"
 

--- a/internal/provisioning/adapter/terraform/testdata/providers.tf
+++ b/internal/provisioning/adapter/terraform/testdata/providers.tf
@@ -27,7 +27,7 @@ provider "incus" {
   // Automatically accept the Incus remote's certificate.
   // If this is not set to true, you must accept the certificate out of band of Terraform.
   // This can also be set with the INCUS_ACCEPT_SERVER_CERTIFICATE environment variable.
-  accept_remote_certificate = true
+  //accept_remote_certificate = true
 
   default_remote = "foobar"
 


### PR DESCRIPTION
End 2 end test still pass with this change. Operations Center does already use the correct server certificates and does not rely on the `accept_remote_certificate` directive. It is mainly there for convenience of the user.

Resolves: #610 