### PR TITLE
Apply file filters on refresh of updates

### DIFF
--- a/e2e_tests/helpers.go
+++ b/e2e_tests/helpers.go
@@ -422,7 +422,7 @@ func waitExpectedLogWithContext(ctx context.Context, t *testing.T, vm string, un
 func mustWaitUpdatesReady(t *testing.T) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(t.Context(), strechedTimeout(5*time.Minute))
+	ctx, cancel := context.WithTimeout(t.Context(), strechedTimeout(7*time.Minute))
 	defer cancel()
 
 	count := 0

--- a/internal/provisioning/repo/localfs/localfs.go
+++ b/internal/provisioning/repo/localfs/localfs.go
@@ -169,6 +169,11 @@ func (l localfs) PruneFiles(ctx context.Context, update provisioning.Update) err
 	// Remove all files from the update, that are not required by the update.
 	basePath := filepath.Join(l.storageDir, update.UUID.String())
 
+	filesLookup := make(map[string]bool, len(update.Files))
+	for _, updateFile := range update.Files {
+		filesLookup[updateFile.Filename] = true
+	}
+
 	err := filepath.WalkDir(basePath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return err
@@ -191,15 +196,7 @@ func (l localfs) PruneFiles(ctx context.Context, update provisioning.Update) err
 			return nil
 		}
 
-		found := false
-		for _, update := range update.Files {
-			if update.Filename == relPath {
-				found = true
-				break
-			}
-		}
-
-		if !found {
+		if !filesLookup[relPath] {
 			err = os.RemoveAll(path)
 			if err != nil {
 				return err

--- a/internal/provisioning/repo/localfs/localfs.go
+++ b/internal/provisioning/repo/localfs/localfs.go
@@ -87,19 +87,28 @@ func (l localfs) Put(ctx context.Context, update provisioning.Update, filename s
 	fullFilename := filepath.Join(l.storageDir, update.UUID.String(), filename)
 	temporaryFullFilename := fullFilename + ".partial"
 
+	cancel := func() error {
+		err := content.Close()
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
 	err := os.MkdirAll(filepath.Dir(fullFilename), 0o700)
 	if err != nil {
-		return nil, nil, err
+		return nil, cancel, err
 	}
 
 	target, err := os.OpenFile(temporaryFullFilename, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o600)
 	if err != nil {
-		return nil, nil, err
+		return nil, cancel, err
 	}
 
 	_, err = io.Copy(target, content)
 	if err != nil {
-		return nil, nil, err
+		return nil, cancel, err
 	}
 
 	committed := false
@@ -129,7 +138,7 @@ func (l localfs) Put(ctx context.Context, update provisioning.Update, filename s
 		return nil
 	}
 
-	cancel := func() error {
+	cancel = func() error {
 		if committed {
 			return nil
 		}

--- a/internal/provisioning/repo/localfs/localfs.go
+++ b/internal/provisioning/repo/localfs/localfs.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -49,6 +50,21 @@ func New(storageDir string, signatureVerificationRootCA string) (*localfs, error
 		storageDir:     storageDir,
 		verifier:       signature.NewVerifier([]byte(signatureVerificationRootCA)),
 	}, nil
+}
+
+func (l localfs) Exists(ctx context.Context, update provisioning.Update, filename string) (bool, error) {
+	fullFilename := filepath.Join(l.storageDir, update.UUID.String(), filename)
+
+	_, err := os.Stat(fullFilename)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
 }
 
 func (l localfs) Get(ctx context.Context, update provisioning.Update, filename string) (io.ReadCloser, int, error) {
@@ -138,6 +154,53 @@ func (l localfs) Delete(ctx context.Context, update provisioning.Update) error {
 	fullFilename := filepath.Join(l.storageDir, update.UUID.String())
 
 	return os.RemoveAll(fullFilename)
+}
+
+func (l localfs) PruneFiles(ctx context.Context, update provisioning.Update) error {
+	// Remove all files from the update, that are not required by the update.
+	basePath := filepath.Join(l.storageDir, update.UUID.String())
+
+	err := filepath.WalkDir(basePath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(basePath, path)
+		if err != nil {
+			return err
+		}
+
+		if relPath == "." {
+			// Skip the basePath directory.
+			return nil
+		}
+
+		if d.IsDir() {
+			// Ignore directories. If all files are removed, an empty directory might
+			// be kept, but this is ok and will get cleaned up when the update is
+			// obsolete.
+			return nil
+		}
+
+		found := false
+		for _, update := range update.Files {
+			if update.Filename == relPath {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			err = os.RemoveAll(path)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	return err
 }
 
 func (l localfs) CleanupAll(ctx context.Context) error {

--- a/internal/provisioning/repo/localfs/localfs.go
+++ b/internal/provisioning/repo/localfs/localfs.go
@@ -170,7 +170,7 @@ func (l localfs) PruneFiles(ctx context.Context, update provisioning.Update) err
 	basePath := filepath.Join(l.storageDir, update.UUID.String())
 
 	err := filepath.WalkDir(basePath, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}
 

--- a/internal/provisioning/repo/localfs/localfs_internal_test.go
+++ b/internal/provisioning/repo/localfs/localfs_internal_test.go
@@ -3,12 +3,12 @@ package localfs
 import (
 	"archive/tar"
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"embed"
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -24,7 +24,84 @@ import (
 	"github.com/FuturFusion/operations-center/internal/security/signature/signaturetest"
 	"github.com/FuturFusion/operations-center/internal/util/file"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
+	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 )
+
+func TestLocalfs_Exists(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupTmpDir func(t *testing.T, destDir string)
+		update      provisioning.Update
+
+		assertErr  require.ErrorAssertionFunc
+		wantExists bool
+	}{
+		{
+			name: "file exists",
+			setupTmpDir: func(t *testing.T, destDir string) {
+				t.Helper()
+				updateID := uuidgen.FromPattern(t, "0").String()
+
+				err := os.MkdirAll(filepath.Join(destDir, updateID), 0o700)
+				require.NoError(t, err)
+
+				err = os.WriteFile(filepath.Join(destDir, updateID, "file1.txt"), []byte(`file1 body`), 0o600)
+				require.NoError(t, err)
+			},
+			update: provisioning.Update{
+				UUID: uuidgen.FromPattern(t, "0"),
+			},
+
+			assertErr:  require.NoError,
+			wantExists: true,
+		},
+		{
+			name: "file does not exist",
+			setupTmpDir: func(t *testing.T, destDir string) {
+				t.Helper()
+			},
+			update: provisioning.Update{
+				UUID: uuidgen.FromPattern(t, "0"),
+			},
+
+			assertErr:  require.NoError,
+			wantExists: false,
+		},
+		{
+			name: "no permission",
+			setupTmpDir: func(t *testing.T, destDir string) {
+				t.Helper()
+				updateID := uuidgen.FromPattern(t, "0").String()
+
+				err := os.MkdirAll(filepath.Join(destDir, updateID), 0o000)
+				require.NoError(t, err)
+			},
+			update: provisioning.Update{
+				UUID: uuidgen.FromPattern(t, "0"),
+			},
+
+			assertErr:  require.Error,
+			wantExists: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			tmpDir := t.TempDir()
+			tc.setupTmpDir(t, tmpDir)
+			lfs, err := New(tmpDir, "")
+			require.NoError(t, err)
+
+			// Run test
+			exists, err := lfs.Exists(t.Context(), tc.update, "file1.txt")
+
+			// Assert
+			tc.assertErr(t, err)
+			require.Equal(t, tc.wantExists, exists)
+		})
+	}
+}
 
 func TestLocalfs_Get(t *testing.T) {
 	tests := []struct {
@@ -92,7 +169,7 @@ func TestLocalfs_Get(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run test
-			gotReader, _, err := lfs.Get(context.Background(), tc.update, tc.filename)
+			gotReader, _, err := lfs.Get(t.Context(), tc.update, tc.filename)
 
 			// Assert
 			tc.assertErr(t, err)
@@ -177,7 +254,7 @@ func TestLocalfs_Put(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run test
-			commit, cancel, err := lfs.Put(context.Background(), tc.update, "file.name", tc.stream)
+			commit, cancel, err := lfs.Put(t.Context(), tc.update, "file.name", tc.stream)
 
 			var commitErr error
 			if tc.commit {
@@ -246,12 +323,106 @@ func TestLocalfs_Delete(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run test
-			err = lfs.Delete(context.Background(), tc.update)
+			err = lfs.Delete(t.Context(), tc.update)
 
 			// Assert
 			tc.assertErr(t, err)
 		})
 	}
+}
+
+func TestLocalfs_PruneFiles(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupTmpDir func(t *testing.T, destDir string)
+		update      provisioning.Update
+
+		assertErr require.ErrorAssertionFunc
+		wantFiles []string
+	}{
+		{
+			name: "success",
+			setupTmpDir: func(t *testing.T, destDir string) {
+				t.Helper()
+
+				updateID := uuidgen.FromPattern(t, "0").String()
+
+				err := os.MkdirAll(filepath.Join(destDir, updateID), 0o700)
+				require.NoError(t, err)
+
+				err = os.MkdirAll(filepath.Join(destDir, updateID, "x86_64"), 0o700)
+				require.NoError(t, err)
+
+				err = os.WriteFile(filepath.Join(destDir, updateID, "x86_64", "file1.txt"), []byte(`file1 body`), 0o600)
+				require.NoError(t, err)
+				err = os.WriteFile(filepath.Join(destDir, updateID, "x86_64", "file2.txt"), []byte(`file2 body`), 0o600) // removed, update does not contain x86_64/file2.txt.
+				require.NoError(t, err)
+
+				err = os.MkdirAll(filepath.Join(destDir, updateID, "aarch64"), 0o700)
+				require.NoError(t, err)
+
+				err = os.WriteFile(filepath.Join(destDir, updateID, "aarch64", "file1.txt"), []byte(`file1 body`), 0o600) // removed, update does not contain any files for aarch64.
+				require.NoError(t, err)
+			},
+			update: provisioning.Update{
+				UUID: uuidgen.FromPattern(t, "0"),
+				Files: provisioning.UpdateFiles{
+					{
+						Filename: "x86_64/file1.txt",
+					},
+				},
+			},
+
+			assertErr: require.NoError,
+			wantFiles: []string{
+				"x86_64/file1.txt",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			tmpDir := t.TempDir()
+			tc.setupTmpDir(t, tmpDir)
+			lfs, err := New(tmpDir, "")
+			require.NoError(t, err)
+
+			// Run test
+			err = lfs.PruneFiles(t.Context(), tc.update)
+
+			// Assert
+			tc.assertErr(t, err)
+			gotFiles, err := listFiles(filepath.Join(tmpDir, tc.update.UUID.String()))
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.wantFiles, gotFiles)
+		})
+	}
+}
+
+func listFiles(root string) ([]string, error) {
+	var files []string
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
+		files = append(files, relPath)
+
+		return nil
+	})
+
+	return files, err
 }
 
 func TestLocalfs_CleanupAll(t *testing.T) {
@@ -289,7 +460,7 @@ func TestLocalfs_CleanupAll(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run test
-			err = lfs.CleanupAll(context.Background())
+			err = lfs.CleanupAll(t.Context())
 
 			// Assert
 			require.NoError(t, err)
@@ -533,7 +704,7 @@ func TestLocalfs_CreateFromArchive(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run test
-			gotUpdate, err := lfs.CreateFromArchive(context.Background(), tr)
+			gotUpdate, err := lfs.CreateFromArchive(t.Context(), tr)
 
 			// Assert
 			tc.assertErr(t, err)

--- a/internal/provisioning/repo/middleware/update_files_repo_prometheus_gen.go
+++ b/internal/provisioning/repo/middleware/update_files_repo_prometheus_gen.go
@@ -81,6 +81,20 @@ func (_d UpdateFilesRepoWithPrometheus) Delete(ctx context.Context, update provi
 	return _d.base.Delete(ctx, update)
 }
 
+// Exists implements provisioning.UpdateFilesRepo.
+func (_d UpdateFilesRepoWithPrometheus) Exists(ctx context.Context, update provisioning.Update, filename string) (b bool, err error) {
+	_since := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+
+		updateFilesRepoDurationSummaryVec.WithLabelValues(_d.instanceName, "Exists", result).Observe(time.Since(_since).Seconds())
+	}()
+	return _d.base.Exists(ctx, update, filename)
+}
+
 // Get implements provisioning.UpdateFilesRepo.
 func (_d UpdateFilesRepoWithPrometheus) Get(ctx context.Context, update provisioning.Update, filename string) (readCloser io.ReadCloser, size int, err error) {
 	_since := time.Now()
@@ -93,6 +107,20 @@ func (_d UpdateFilesRepoWithPrometheus) Get(ctx context.Context, update provisio
 		updateFilesRepoDurationSummaryVec.WithLabelValues(_d.instanceName, "Get", result).Observe(time.Since(_since).Seconds())
 	}()
 	return _d.base.Get(ctx, update, filename)
+}
+
+// PruneFiles implements provisioning.UpdateFilesRepo.
+func (_d UpdateFilesRepoWithPrometheus) PruneFiles(ctx context.Context, update provisioning.Update) (err error) {
+	_since := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+
+		updateFilesRepoDurationSummaryVec.WithLabelValues(_d.instanceName, "PruneFiles", result).Observe(time.Since(_since).Seconds())
+	}()
+	return _d.base.PruneFiles(ctx, update)
 }
 
 // Put implements provisioning.UpdateFilesRepo.

--- a/internal/provisioning/repo/middleware/update_files_repo_slog_gen.go
+++ b/internal/provisioning/repo/middleware/update_files_repo_slog_gen.go
@@ -143,6 +143,42 @@ func (_d UpdateFilesRepoWithSlog) Delete(ctx context.Context, update provisionin
 	return _d._base.Delete(ctx, update)
 }
 
+// Exists implements provisioning.UpdateFilesRepo.
+func (_d UpdateFilesRepoWithSlog) Exists(ctx context.Context, update provisioning.Update, filename string) (b bool, err error) {
+	log := slog.With()
+	if slog.Default().Enabled(ctx, logger.LevelTrace) {
+		log = log.With(
+			slog.Any("ctx", ctx),
+			slog.Any("update", update),
+			slog.String("filename", filename),
+		)
+	}
+	log.DebugContext(ctx, "=> calling Exists")
+	defer func() {
+		log := slog.With()
+		if slog.Default().Enabled(ctx, logger.LevelTrace) {
+			log = slog.With(
+				slog.Bool("b", b),
+				slog.Any("err", err),
+			)
+		} else {
+			if err != nil {
+				log = slog.With("err", err)
+			}
+		}
+		if err != nil {
+			if _d._isInformativeErrFunc(err) {
+				log.DebugContext(ctx, "<= method Exists returned an informative error")
+			} else {
+				log.ErrorContext(ctx, "<= method Exists returned an error")
+			}
+		} else {
+			log.DebugContext(ctx, "<= method Exists finished")
+		}
+	}()
+	return _d._base.Exists(ctx, update, filename)
+}
+
 // Get implements provisioning.UpdateFilesRepo.
 func (_d UpdateFilesRepoWithSlog) Get(ctx context.Context, update provisioning.Update, filename string) (readCloser io.ReadCloser, size int, err error) {
 	log := slog.With()
@@ -178,6 +214,40 @@ func (_d UpdateFilesRepoWithSlog) Get(ctx context.Context, update provisioning.U
 		}
 	}()
 	return _d._base.Get(ctx, update, filename)
+}
+
+// PruneFiles implements provisioning.UpdateFilesRepo.
+func (_d UpdateFilesRepoWithSlog) PruneFiles(ctx context.Context, update provisioning.Update) (err error) {
+	log := slog.With()
+	if slog.Default().Enabled(ctx, logger.LevelTrace) {
+		log = log.With(
+			slog.Any("ctx", ctx),
+			slog.Any("update", update),
+		)
+	}
+	log.DebugContext(ctx, "=> calling PruneFiles")
+	defer func() {
+		log := slog.With()
+		if slog.Default().Enabled(ctx, logger.LevelTrace) {
+			log = slog.With(
+				slog.Any("err", err),
+			)
+		} else {
+			if err != nil {
+				log = slog.With("err", err)
+			}
+		}
+		if err != nil {
+			if _d._isInformativeErrFunc(err) {
+				log.DebugContext(ctx, "<= method PruneFiles returned an informative error")
+			} else {
+				log.ErrorContext(ctx, "<= method PruneFiles returned an error")
+			}
+		} else {
+			log.DebugContext(ctx, "<= method PruneFiles finished")
+		}
+	}()
+	return _d._base.PruneFiles(ctx, update)
 }
 
 // Put implements provisioning.UpdateFilesRepo.

--- a/internal/provisioning/repo/mock/update_files_repo_mock_gen.go
+++ b/internal/provisioning/repo/mock/update_files_repo_mock_gen.go
@@ -32,8 +32,14 @@ var _ provisioning.UpdateFilesRepo = &UpdateFilesRepoMock{}
 //			DeleteFunc: func(ctx context.Context, update provisioning.Update) error {
 //				panic("mock out the Delete method")
 //			},
+//			ExistsFunc: func(ctx context.Context, update provisioning.Update, filename string) (bool, error) {
+//				panic("mock out the Exists method")
+//			},
 //			GetFunc: func(ctx context.Context, update provisioning.Update, filename string) (io.ReadCloser, int, error) {
 //				panic("mock out the Get method")
+//			},
+//			PruneFilesFunc: func(ctx context.Context, update provisioning.Update) error {
+//				panic("mock out the PruneFiles method")
 //			},
 //			PutFunc: func(ctx context.Context, update provisioning.Update, filename string, content io.ReadCloser) (provisioning.CommitFunc, provisioning.CancelFunc, error) {
 //				panic("mock out the Put method")
@@ -57,8 +63,14 @@ type UpdateFilesRepoMock struct {
 	// DeleteFunc mocks the Delete method.
 	DeleteFunc func(ctx context.Context, update provisioning.Update) error
 
+	// ExistsFunc mocks the Exists method.
+	ExistsFunc func(ctx context.Context, update provisioning.Update, filename string) (bool, error)
+
 	// GetFunc mocks the Get method.
 	GetFunc func(ctx context.Context, update provisioning.Update, filename string) (io.ReadCloser, int, error)
+
+	// PruneFilesFunc mocks the PruneFiles method.
+	PruneFilesFunc func(ctx context.Context, update provisioning.Update) error
 
 	// PutFunc mocks the Put method.
 	PutFunc func(ctx context.Context, update provisioning.Update, filename string, content io.ReadCloser) (provisioning.CommitFunc, provisioning.CancelFunc, error)
@@ -87,6 +99,15 @@ type UpdateFilesRepoMock struct {
 			// Update is the update argument value.
 			Update provisioning.Update
 		}
+		// Exists holds details about calls to the Exists method.
+		Exists []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Update is the update argument value.
+			Update provisioning.Update
+			// Filename is the filename argument value.
+			Filename string
+		}
 		// Get holds details about calls to the Get method.
 		Get []struct {
 			// Ctx is the ctx argument value.
@@ -95,6 +116,13 @@ type UpdateFilesRepoMock struct {
 			Update provisioning.Update
 			// Filename is the filename argument value.
 			Filename string
+		}
+		// PruneFiles holds details about calls to the PruneFiles method.
+		PruneFiles []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Update is the update argument value.
+			Update provisioning.Update
 		}
 		// Put holds details about calls to the Put method.
 		Put []struct {
@@ -116,7 +144,9 @@ type UpdateFilesRepoMock struct {
 	lockCleanupAll        sync.RWMutex
 	lockCreateFromArchive sync.RWMutex
 	lockDelete            sync.RWMutex
+	lockExists            sync.RWMutex
 	lockGet               sync.RWMutex
+	lockPruneFiles        sync.RWMutex
 	lockPut               sync.RWMutex
 	lockUsageInformation  sync.RWMutex
 }
@@ -225,6 +255,46 @@ func (mock *UpdateFilesRepoMock) DeleteCalls() []struct {
 	return calls
 }
 
+// Exists calls ExistsFunc.
+func (mock *UpdateFilesRepoMock) Exists(ctx context.Context, update provisioning.Update, filename string) (bool, error) {
+	if mock.ExistsFunc == nil {
+		panic("UpdateFilesRepoMock.ExistsFunc: method is nil but UpdateFilesRepo.Exists was just called")
+	}
+	callInfo := struct {
+		Ctx      context.Context
+		Update   provisioning.Update
+		Filename string
+	}{
+		Ctx:      ctx,
+		Update:   update,
+		Filename: filename,
+	}
+	mock.lockExists.Lock()
+	mock.calls.Exists = append(mock.calls.Exists, callInfo)
+	mock.lockExists.Unlock()
+	return mock.ExistsFunc(ctx, update, filename)
+}
+
+// ExistsCalls gets all the calls that were made to Exists.
+// Check the length with:
+//
+//	len(mockedUpdateFilesRepo.ExistsCalls())
+func (mock *UpdateFilesRepoMock) ExistsCalls() []struct {
+	Ctx      context.Context
+	Update   provisioning.Update
+	Filename string
+} {
+	var calls []struct {
+		Ctx      context.Context
+		Update   provisioning.Update
+		Filename string
+	}
+	mock.lockExists.RLock()
+	calls = mock.calls.Exists
+	mock.lockExists.RUnlock()
+	return calls
+}
+
 // Get calls GetFunc.
 func (mock *UpdateFilesRepoMock) Get(ctx context.Context, update provisioning.Update, filename string) (io.ReadCloser, int, error) {
 	if mock.GetFunc == nil {
@@ -262,6 +332,42 @@ func (mock *UpdateFilesRepoMock) GetCalls() []struct {
 	mock.lockGet.RLock()
 	calls = mock.calls.Get
 	mock.lockGet.RUnlock()
+	return calls
+}
+
+// PruneFiles calls PruneFilesFunc.
+func (mock *UpdateFilesRepoMock) PruneFiles(ctx context.Context, update provisioning.Update) error {
+	if mock.PruneFilesFunc == nil {
+		panic("UpdateFilesRepoMock.PruneFilesFunc: method is nil but UpdateFilesRepo.PruneFiles was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		Update provisioning.Update
+	}{
+		Ctx:    ctx,
+		Update: update,
+	}
+	mock.lockPruneFiles.Lock()
+	mock.calls.PruneFiles = append(mock.calls.PruneFiles, callInfo)
+	mock.lockPruneFiles.Unlock()
+	return mock.PruneFilesFunc(ctx, update)
+}
+
+// PruneFilesCalls gets all the calls that were made to PruneFiles.
+// Check the length with:
+//
+//	len(mockedUpdateFilesRepo.PruneFilesCalls())
+func (mock *UpdateFilesRepoMock) PruneFilesCalls() []struct {
+	Ctx    context.Context
+	Update provisioning.Update
+} {
+	var calls []struct {
+		Ctx    context.Context
+		Update provisioning.Update
+	}
+	mock.lockPruneFiles.RLock()
+	calls = mock.calls.PruneFiles
+	mock.lockPruneFiles.RUnlock()
 	return calls
 }
 

--- a/internal/provisioning/update/update_service.go
+++ b/internal/provisioning/update/update_service.go
@@ -1083,16 +1083,15 @@ func (s updateService) downloadFile(ctx context.Context, update provisioning.Upd
 	}
 
 	commit, cancel, err := s.filesRepo.Put(ctx, update, updateFile.Filename, teeStream)
-	if err != nil {
-		return fmt.Errorf(`Failed to read stream for update file "%s@%s": %w`, updateFile.Filename, update.Version, err)
-	}
-
 	defer func() {
 		cancelErr := cancel()
 		if cancelErr != nil {
 			err = errors.Join(err, cancelErr)
 		}
 	}()
+	if err != nil {
+		return fmt.Errorf(`Failed to read stream for update file "%s@%s": %w`, updateFile.Filename, update.Version, err)
+	}
 
 	if updateFile.Sha256 != "" {
 		checksum := hex.EncodeToString(h.Sum(nil))

--- a/internal/provisioning/update/update_service.go
+++ b/internal/provisioning/update/update_service.go
@@ -574,6 +574,7 @@ func (s updateService) Refresh(ctx context.Context) error {
 	}
 
 	toDownloadUpdates := make([]provisioning.Update, 0, len(originUpdates))
+	var toRefreshUpdates []provisioning.Update
 	err = transaction.Do(ctx, func(ctx context.Context) error {
 		servers, err := s.serverSvc.GetAll(ctx)
 		if err != nil {
@@ -591,7 +592,7 @@ func (s updateService) Refresh(ctx context.Context) error {
 		}
 
 		var toDeleteUpdates []provisioning.Update
-		toDeleteUpdates, toDownloadUpdates = s.determineToDeleteAndToDownloadUpdates(dbUpdates, originUpdates, updateVersionsInUse)
+		toDeleteUpdates, toRefreshUpdates, toDownloadUpdates = s.determineToDeleteAndToDownloadUpdates(dbUpdates, originUpdates, updateVersionsInUse)
 
 		// Remove updates marked for removal.
 		for _, update := range toDeleteUpdates {
@@ -606,10 +607,52 @@ func (s updateService) Refresh(ctx context.Context) error {
 			}
 		}
 
+		// Prune obsolete files from existing updates.
+		for _, update := range toRefreshUpdates {
+			err = s.filesRepo.PruneFiles(ctx, update)
+			if err != nil {
+				return fmt.Errorf("Failed to prune obsolete files for update %s: %w", update.UUID, err)
+			}
+
+			err = s.repo.Upsert(ctx, update)
+			if err != nil {
+				return fmt.Errorf("Failed to update update record %s in repository: %w", update.UUID, err)
+			}
+		}
+
 		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("Unable to refresh updates from source: %w", err)
+	}
+
+	for _, update := range toRefreshUpdates {
+		// Make sure, we do have enough space left in the files repository before downloading the files.
+		err = s.isSpaceAvailable(ctx, []provisioning.Update{update})
+		if err != nil {
+			return err
+		}
+
+		for _, updateFile := range update.Files {
+			if ctx.Err() != nil {
+				return fmt.Errorf("Stop refresh, context cancelled: %w", context.Cause(ctx))
+			}
+
+			ok, err := s.filesRepo.Exists(ctx, update, updateFile.Filename)
+			if err != nil {
+				return fmt.Errorf(`Failed to confirm existence for update file %s@%s: %w`, updateFile.Filename, update.Version, err)
+			}
+
+			if ok {
+				// File already present, no need to download it again.
+				continue
+			}
+
+			err = s.downloadFile(ctx, update, updateFile)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(toDownloadUpdates) > 0 {
@@ -650,42 +693,7 @@ func (s updateService) Refresh(ctx context.Context) error {
 				return fmt.Errorf("Stop refresh, context cancelled: %w", context.Cause(ctx))
 			}
 
-			err := func() (err error) {
-				var stream io.ReadCloser
-				stream, _, err = s.source.GetUpdateFileByFilenameUnverified(ctx, update, updateFile.Filename)
-				if err != nil {
-					return fmt.Errorf(`Failed to fetch update file "%s@%s": %w`, updateFile.Filename, update.Version, err)
-				}
-
-				teeStream := stream
-				var h hash.Hash
-
-				if updateFile.Sha256 != "" {
-					h = sha256.New()
-					teeStream = provisioning.NewTeeReadCloser(stream, h)
-				}
-
-				commit, cancel, err := s.filesRepo.Put(ctx, update, updateFile.Filename, teeStream)
-				if err != nil {
-					return fmt.Errorf(`Failed to read stream for update file "%s@%s": %w`, updateFile.Filename, update.Version, err)
-				}
-
-				defer func() {
-					cancelErr := cancel()
-					if cancelErr != nil {
-						err = errors.Join(err, cancelErr)
-					}
-				}()
-
-				if updateFile.Sha256 != "" {
-					checksum := hex.EncodeToString(h.Sum(nil))
-					if updateFile.Sha256 != checksum {
-						return fmt.Errorf("Invalid update, file sha256 mismatch for file %q, manifest: %s, actual: %s", updateFile.Filename, updateFile.Sha256, checksum)
-					}
-				}
-
-				return commit()
-			}()
+			err := s.downloadFile(ctx, update, updateFile)
 			if err != nil {
 				return err
 			}
@@ -843,34 +851,36 @@ func UpdateFileExprEnvFrom(u provisioning.UpdateFile) UpdateFileExprEnv {
 }
 
 func (s updateService) filterUpdateFileByFilterExpression(updates provisioning.Updates) (provisioning.Updates, error) {
-	if config.GetUpdates().FileFilterExpression != "" {
-		// The file filter expression is already compiled as part of the validation
-		// of the config so we can assume the filter expression to compile without
-		// error.
-		// If not the case, the Run call will fail with a "program is nil" error.
-		fileFilterExpression, _ := expr.Compile(
-			config.GetUpdates().FileFilterExpression,
-			UpdateFileExprEnvFrom(provisioning.UpdateFile{}).ExprCompileOptions()...,
-		)
+	if config.GetUpdates().FileFilterExpression == "" {
+		return updates, nil
+	}
 
-		for i := range updates {
-			n := 0
-			for j := range updates[i].Files {
-				result, err := expr.Run(fileFilterExpression, UpdateFileExprEnvFrom(updates[i].Files[j]))
-				if err != nil {
-					return nil, err
-				}
+	// The file filter expression is already compiled as part of the validation
+	// of the config so we can assume the filter expression to compile without
+	// error.
+	// If not the case, the Run call will fail with a "program is nil" error.
+	fileFilterExpression, _ := expr.Compile(
+		config.GetUpdates().FileFilterExpression,
+		UpdateFileExprEnvFrom(provisioning.UpdateFile{}).ExprCompileOptions()...,
+	)
 
-				if !result.(bool) {
-					continue
-				}
-
-				updates[i].Files[n] = updates[i].Files[j]
-				n++
+	for i := range updates {
+		n := 0
+		for j := range updates[i].Files {
+			result, err := expr.Run(fileFilterExpression, UpdateFileExprEnvFrom(updates[i].Files[j]))
+			if err != nil {
+				return nil, err
 			}
 
-			updates[i].Files = updates[i].Files[:n]
+			if !result.(bool) {
+				continue
+			}
+
+			updates[i].Files[n] = updates[i].Files[j]
+			n++
 		}
+
+		updates[i].Files = updates[i].Files[:n]
 	}
 
 	return updates, nil
@@ -880,16 +890,21 @@ func (s updateService) filterUpdateFileByFilterExpression(updates provisioning.U
 // upstream as well as the list of updates, that are to be removed from the DB.
 //
 // This implements the logic described in the function description of the Refresh method.
-func (s updateService) determineToDeleteAndToDownloadUpdates(dbUpdates []provisioning.Update, originUpdates []provisioning.Update, updateVersionsInUse map[string]bool) (toDeleteUpdates []provisioning.Update, toDownloadUpdates []provisioning.Update) {
+func (s updateService) determineToDeleteAndToDownloadUpdates(dbUpdates []provisioning.Update, originUpdates []provisioning.Update, updateVersionsInUse map[string]bool) (toDeleteUpdates []provisioning.Update, toRefreshUpdates []provisioning.Update, toDownloadUpdates []provisioning.Update) {
 	// Merge dbUpdates and originUpdates to the desired end state.
 	mergedUpdates := make([]provisioning.Update, 0, len(dbUpdates)+len(originUpdates))
 	mergedUpdates = append(mergedUpdates, dbUpdates...)
 	for _, originUpdate := range originUpdates {
 		// Add updates from origin to the merged updates list, if they are not yet present.
 		var found bool
-		for _, update := range mergedUpdates {
+		for i, update := range mergedUpdates {
 			if originUpdate.UUID == update.UUID {
 				found = true
+
+				// replace Files in mergedUpdates with the Files entry from originUpdates,
+				// since the current file filter expression has been applied there.
+				mergedUpdates[i].Files = originUpdate.Files
+
 				break
 			}
 		}
@@ -926,6 +941,7 @@ func (s updateService) determineToDeleteAndToDownloadUpdates(dbUpdates []provisi
 	mostRecentInDBFound := len(dbUpdates) == 0
 
 	toDeleteUpdates = make([]provisioning.Update, 0, len(dbUpdates))
+	toRefreshUpdates = make([]provisioning.Update, 0, len(dbUpdates))
 	toDownloadUpdates = make([]provisioning.Update, 0, len(originUpdates))
 	updateCount := 0
 	for _, update := range mergedUpdates {
@@ -945,7 +961,11 @@ func (s updateService) determineToDeleteAndToDownloadUpdates(dbUpdates []provisi
 				// If this is not the case, this update is marked for removal.
 				if !updateVersionsInUse[update.Version] {
 					toDeleteUpdates = append(toDeleteUpdates, update)
+
+					continue
 				}
+
+				toRefreshUpdates = append(toRefreshUpdates, update)
 
 				continue
 			}
@@ -959,6 +979,8 @@ func (s updateService) determineToDeleteAndToDownloadUpdates(dbUpdates []provisi
 				mostRecentInDBFound = true
 				updateCount++
 			}
+
+			toRefreshUpdates = append(toRefreshUpdates, update)
 
 		case api.UpdateStatusUnknown:
 			mostRecentInDBHeadroom := 0
@@ -987,7 +1009,7 @@ func (s updateService) determineToDeleteAndToDownloadUpdates(dbUpdates []provisi
 		}
 	}
 
-	return toDeleteUpdates, toDownloadUpdates
+	return toDeleteUpdates, toRefreshUpdates, toDownloadUpdates
 }
 
 // providesMissingComponentsForChannels checks for all required components in all channels, if the given update
@@ -1044,4 +1066,40 @@ func (s updateService) isSpaceAvailable(ctx context.Context, downloadUpdates []p
 	}
 
 	return nil
+}
+
+func (s updateService) downloadFile(ctx context.Context, update provisioning.Update, updateFile provisioning.UpdateFile) (err error) {
+	stream, _, err := s.source.GetUpdateFileByFilenameUnverified(ctx, update, updateFile.Filename)
+	if err != nil {
+		return fmt.Errorf(`Failed to fetch update file "%s@%s": %w`, updateFile.Filename, update.Version, err)
+	}
+
+	teeStream := stream
+	var h hash.Hash
+
+	if updateFile.Sha256 != "" {
+		h = sha256.New()
+		teeStream = provisioning.NewTeeReadCloser(stream, h)
+	}
+
+	commit, cancel, err := s.filesRepo.Put(ctx, update, updateFile.Filename, teeStream)
+	if err != nil {
+		return fmt.Errorf(`Failed to read stream for update file "%s@%s": %w`, updateFile.Filename, update.Version, err)
+	}
+
+	defer func() {
+		cancelErr := cancel()
+		if cancelErr != nil {
+			err = errors.Join(err, cancelErr)
+		}
+	}()
+
+	if updateFile.Sha256 != "" {
+		checksum := hex.EncodeToString(h.Sum(nil))
+		if updateFile.Sha256 != checksum {
+			return fmt.Errorf("Invalid update, file sha256 mismatch for file %q, manifest: %s, actual: %s", updateFile.Filename, updateFile.Sha256, checksum)
+		}
+	}
+
+	return commit()
 }

--- a/internal/provisioning/update/update_service_internal_test.go
+++ b/internal/provisioning/update/update_service_internal_test.go
@@ -37,6 +37,7 @@ func Test_updateService_determineToDeleteAndToDownloadUpdates(t *testing.T) {
 		updateVersionsInUse map[string]bool
 
 		wantToDeleteIDs   []string
+		wantToRefreshIDs  []string
 		wantToDownloadIDs []string
 	}{
 		{
@@ -103,6 +104,10 @@ func Test_updateService_determineToDeleteAndToDownloadUpdates(t *testing.T) {
 			wantToDeleteIDs: []string{
 				"01",
 			},
+			wantToRefreshIDs: []string{
+				"02",
+				"03",
+			},
 			wantToDownloadIDs: []string{
 				"06",
 			},
@@ -164,6 +169,9 @@ func Test_updateService_determineToDeleteAndToDownloadUpdates(t *testing.T) {
 			wantToDeleteIDs: []string{
 				"01",
 				"02",
+			},
+			wantToRefreshIDs: []string{
+				"03",
 			},
 			wantToDownloadIDs: []string{
 				"05",
@@ -230,6 +238,10 @@ func Test_updateService_determineToDeleteAndToDownloadUpdates(t *testing.T) {
 			wantToDeleteIDs: []string{
 				"02",
 			},
+			wantToRefreshIDs: []string{
+				"01",
+				"03",
+			},
 			wantToDownloadIDs: []string{
 				"05",
 				"06",
@@ -285,7 +297,12 @@ func Test_updateService_determineToDeleteAndToDownloadUpdates(t *testing.T) {
 			},
 			updateVersionsInUse: map[string]bool{},
 
-			wantToDeleteIDs:   []string{},
+			wantToDeleteIDs: []string{},
+			wantToRefreshIDs: []string{
+				"01",
+				"02",
+				"03",
+			},
 			wantToDownloadIDs: []string{},
 		},
 		{
@@ -312,6 +329,9 @@ func Test_updateService_determineToDeleteAndToDownloadUpdates(t *testing.T) {
 			wantToDeleteIDs: []string{
 				"02",
 			},
+			wantToRefreshIDs: []string{
+				"01",
+			},
 			wantToDownloadIDs: []string{},
 		},
 		{
@@ -335,7 +355,10 @@ func Test_updateService_determineToDeleteAndToDownloadUpdates(t *testing.T) {
 			originUpdates:       provisioning.Updates{},
 			updateVersionsInUse: map[string]bool{},
 
-			wantToDeleteIDs:   []string{},
+			wantToDeleteIDs: []string{},
+			wantToRefreshIDs: []string{
+				"01",
+			},
 			wantToDownloadIDs: []string{},
 		},
 		{
@@ -418,6 +441,11 @@ func Test_updateService_determineToDeleteAndToDownloadUpdates(t *testing.T) {
 				"01", // supernumerary update, only used by channel "prod".
 				"03", // supernumerary update, only used by channel "stable".
 			},
+			wantToRefreshIDs: []string{
+				"02",
+				"04",
+				"05",
+			},
 			wantToDownloadIDs: []string{
 				"06", // 2nd fresh update for channel "stable".
 				"07", // 1st fresh update for channel "stable".
@@ -499,6 +527,10 @@ func Test_updateService_determineToDeleteAndToDownloadUpdates(t *testing.T) {
 				"02", // supernumerary update
 				"04", // supernumerary update, does only provide component Incus
 			},
+			wantToRefreshIDs: []string{
+				"03",
+				"05",
+			},
 			wantToDownloadIDs: []string{
 				"06", // 2nd fresh update for channel "stable".
 				"07", // 1st fresh update for channel "stable".
@@ -522,17 +554,27 @@ func Test_updateService_determineToDeleteAndToDownloadUpdates(t *testing.T) {
 				wantToDeleteUpdateIDs = append(wantToDeleteUpdateIDs, uuidgen.FromPattern(t, id))
 			}
 
+			wantToRefreshUpdateIDs := make([]uuid.UUID, 0, len(tc.wantToRefreshIDs))
+			for _, id := range tc.wantToRefreshIDs {
+				wantToRefreshUpdateIDs = append(wantToRefreshUpdateIDs, uuidgen.FromPattern(t, id))
+			}
+
 			wantToDownloadUpdateIDs := make([]uuid.UUID, 0, len(tc.wantToDownloadIDs))
 			for _, id := range tc.wantToDownloadIDs {
 				wantToDownloadUpdateIDs = append(wantToDownloadUpdateIDs, uuidgen.FromPattern(t, id))
 			}
 
 			// Run test
-			toDeleteUpdates, toDownloadUpdates := updateSvc.determineToDeleteAndToDownloadUpdates(tc.dbUpdates, tc.originUpdates, tc.updateVersionsInUse)
+			toDeleteUpdates, toRefreshUpdates, toDownloadUpdates := updateSvc.determineToDeleteAndToDownloadUpdates(tc.dbUpdates, tc.originUpdates, tc.updateVersionsInUse)
 
 			toDeleteUpdateIDs := make([]uuid.UUID, 0, len(toDeleteUpdates))
 			for _, update := range toDeleteUpdates {
 				toDeleteUpdateIDs = append(toDeleteUpdateIDs, update.UUID)
+			}
+
+			toRefreshUpdateIDs := make([]uuid.UUID, 0, len(toRefreshUpdates))
+			for _, update := range toRefreshUpdates {
+				toRefreshUpdateIDs = append(toRefreshUpdateIDs, update.UUID)
 			}
 
 			toDownloadUpdateIDs := make([]uuid.UUID, 0, len(toDownloadUpdates))
@@ -542,6 +584,7 @@ func Test_updateService_determineToDeleteAndToDownloadUpdates(t *testing.T) {
 
 			// Assert
 			require.ElementsMatch(t, wantToDeleteUpdateIDs, toDeleteUpdateIDs)
+			require.ElementsMatch(t, wantToRefreshUpdateIDs, toRefreshUpdateIDs)
 			require.ElementsMatch(t, wantToDownloadUpdateIDs, toDownloadUpdateIDs)
 		})
 	}

--- a/internal/provisioning/update/update_service_test.go
+++ b/internal/provisioning/update/update_service_test.go
@@ -205,7 +205,7 @@ func TestUpdateService_CleanupAll(t *testing.T) {
 		filesRepoCleanupAllErr error
 		repoGetAll             provisioning.Updates
 		repoGetAllErr          error
-		repoDeleteByUUID       []queue.Item[struct{}]
+		repoDeleteByUUID       queue.Errs
 
 		assertErr require.ErrorAssertionFunc
 	}{
@@ -218,10 +218,6 @@ func TestUpdateService_CleanupAll(t *testing.T) {
 				{
 					UUID: uuid.MustParse("ce9b4489-cc2e-4726-9103-ea22d07a2110"),
 				},
-			},
-			repoDeleteByUUID: []queue.Item[struct{}]{
-				{},
-				{},
 			},
 
 			assertErr: require.NoError,
@@ -248,10 +244,8 @@ func TestUpdateService_CleanupAll(t *testing.T) {
 					UUID: uuid.MustParse("ce9b4489-cc2e-4726-9103-ea22d07a2110"),
 				},
 			},
-			repoDeleteByUUID: []queue.Item[struct{}]{
-				{
-					Err: boom.Error,
-				},
+			repoDeleteByUUID: queue.Errs{
+				boom.Error,
 			},
 
 			assertErr: boom.ErrorIs,
@@ -266,8 +260,7 @@ func TestUpdateService_CleanupAll(t *testing.T) {
 					return tc.repoGetAll, tc.repoGetAllErr
 				},
 				DeleteByUUIDFunc: func(ctx context.Context, id uuid.UUID) error {
-					_, err := queue.Pop(t, &tc.repoDeleteByUUID)
-					return err
+					return tc.repoDeleteByUUID.PopOrNil(t)
 				},
 			}
 
@@ -301,8 +294,8 @@ func TestUpdateService_Prune(t *testing.T) {
 		repoGetAllWithFilter    provisioning.Updates
 		repoGetAllWithFilterErr error
 		filesRepoGet            []queue.Item[fileDetail]
-		filesRepoDelete         []queue.Item[struct{}]
-		repoDeleteByUUID        []queue.Item[struct{}]
+		filesRepoDelete         queue.Errs
+		repoDeleteByUUID        queue.Errs
 
 		assertErr require.ErrorAssertionFunc
 	}{
@@ -345,14 +338,6 @@ func TestUpdateService_Prune(t *testing.T) {
 					Err: os.ErrNotExist,
 				},
 			},
-			filesRepoDelete: []queue.Item[struct{}]{
-				{},
-				{},
-			},
-			repoDeleteByUUID: []queue.Item[struct{}]{
-				{},
-				{},
-			},
 
 			assertErr: require.NoError,
 		},
@@ -374,15 +359,8 @@ func TestUpdateService_Prune(t *testing.T) {
 					Status: api.UpdateStatusPending,
 				},
 			},
-			filesRepoDelete: []queue.Item[struct{}]{
-				{
-					Err: boom.Error,
-				},
-				{},
-			},
-			repoDeleteByUUID: []queue.Item[struct{}]{
-				{},
-				{},
+			filesRepoDelete: queue.Errs{
+				boom.Error,
 			},
 
 			assertErr: boom.ErrorIs,
@@ -399,13 +377,8 @@ func TestUpdateService_Prune(t *testing.T) {
 					Status: api.UpdateStatusPending,
 				},
 			},
-			filesRepoDelete: []queue.Item[struct{}]{
-				{},
-			},
-			repoDeleteByUUID: []queue.Item[struct{}]{
-				{
-					Err: boom.Error,
-				},
+			repoDeleteByUUID: queue.Errs{
+				boom.Error,
 			},
 
 			assertErr: boom.ErrorIs,
@@ -420,8 +393,7 @@ func TestUpdateService_Prune(t *testing.T) {
 					return tc.repoGetAllWithFilter, tc.repoGetAllWithFilterErr
 				},
 				DeleteByUUIDFunc: func(ctx context.Context, id uuid.UUID) error {
-					_, err := queue.Pop(t, &tc.repoDeleteByUUID)
-					return err
+					return tc.repoDeleteByUUID.PopOrNil(t)
 				},
 			}
 
@@ -431,8 +403,7 @@ func TestUpdateService_Prune(t *testing.T) {
 					return fileDetails.rc, fileDetails.size, err
 				},
 				DeleteFunc: func(ctx context.Context, update provisioning.Update) error {
-					_, err := queue.Pop(t, &tc.filesRepoDelete)
-					return err
+					return tc.filesRepoDelete.PopOrNil(t)
 				},
 			}
 
@@ -1928,9 +1899,9 @@ func TestUpdateService_Refresh(t *testing.T) {
 
 		repoGetAllUpdates  provisioning.Updates
 		repoGetAllErr      error
-		repoUpsert         []queue.Item[struct{}]
-		repoDeleteByUUID   []queue.Item[struct{}]
-		repoAssignChannels []queue.Item[struct{}]
+		repoUpsert         queue.Errs
+		repoDeleteByUUID   queue.Errs
+		repoAssignChannels queue.Errs
 
 		repoUpdateFilesExist            []queue.Item[bool]
 		repoUpdateFilesUsageInformation []queue.Item[provisioning.UsageInformation]
@@ -1938,7 +1909,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			commitErr error
 			cancelErr error
 		}]
-		repoUpdateFilesDelete     []queue.Item[struct{}]
+		repoUpdateFilesDelete     queue.Errs
 		repoUpdateFilesPruneFiles queue.Errs
 
 		sourceGetLatestUpdates        provisioning.Updates
@@ -2066,15 +2037,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 					Value: usageInfoGiB(50, 10),
 				},
 			},
-			repoUpsert: []queue.Item[struct{}]{
-				// pending
-				{},
-				// ready
-				{},
-			},
-			repoAssignChannels: []queue.Item[struct{}]{
-				{},
-			},
 
 			sourceGetUpdateFileByFilename: []queue.Item[struct {
 				stream io.ReadCloser
@@ -2164,10 +2126,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 					},
 				},
 			},
-			repoUpsert: []queue.Item[struct{}]{
-				// 04
-				{},
-			},
 			repoUpdateFilesUsageInformation: []queue.Item[provisioning.UsageInformation]{
 				// global check
 				{
@@ -2179,18 +2137,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 				{
 					Value: true,
 				},
-			},
-			repoUpdateFilesDelete: []queue.Item[struct{}]{
-				// 05
-				{},
-				// 03
-				{},
-			},
-			repoDeleteByUUID: []queue.Item[struct{}]{
-				// 05
-				{},
-				// 03
-				{},
 			},
 
 			assertErr: require.NoError,
@@ -2239,10 +2185,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 						},
 					},
 				},
-			},
-			repoUpsert: []queue.Item[struct{}]{
-				// 01
-				{},
 			},
 			repoUpdateFilesUsageInformation: []queue.Item[provisioning.UsageInformation]{
 				// global check
@@ -2373,10 +2315,8 @@ func TestUpdateService_Refresh(t *testing.T) {
 					PublishedAt: dateTime3,
 				},
 			},
-			repoUpdateFilesDelete: []queue.Item[struct{}]{
-				{
-					Err: boom.Error,
-				},
+			repoUpdateFilesDelete: queue.Errs{
+				boom.Error,
 			},
 
 			assertErr: boom.ErrorIs,
@@ -2399,13 +2339,8 @@ func TestUpdateService_Refresh(t *testing.T) {
 					PublishedAt: dateTime3,
 				},
 			},
-			repoUpdateFilesDelete: []queue.Item[struct{}]{
-				{},
-			},
-			repoDeleteByUUID: []queue.Item[struct{}]{
-				{
-					Err: boom.Error,
-				},
+			repoDeleteByUUID: queue.Errs{
+				boom.Error,
 			},
 
 			assertErr: boom.ErrorIs,
@@ -2478,10 +2413,8 @@ func TestUpdateService_Refresh(t *testing.T) {
 					},
 				},
 			},
-			repoUpsert: []queue.Item[struct{}]{
-				{
-					Err: boom.Error,
-				},
+			repoUpsert: queue.Errs{
+				boom.Error,
 			},
 
 			assertErr: boom.ErrorIs,
@@ -2516,9 +2449,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 						},
 					},
 				},
-			},
-			repoUpsert: []queue.Item[struct{}]{
-				{},
 			},
 			repoUpdateFilesUsageInformation: []queue.Item[provisioning.UsageInformation]{
 				// global check
@@ -2564,9 +2494,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 					},
 				},
 			},
-			repoUpsert: []queue.Item[struct{}]{
-				{},
-			},
 			repoUpdateFilesUsageInformation: []queue.Item[provisioning.UsageInformation]{
 				// global check
 				{
@@ -2606,9 +2533,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 						},
 					},
 				},
-			},
-			repoUpsert: []queue.Item[struct{}]{
-				{},
 			},
 			repoUpdateFilesUsageInformation: []queue.Item[provisioning.UsageInformation]{
 				// global check
@@ -2654,9 +2578,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 						},
 					},
 				},
-			},
-			repoUpsert: []queue.Item[struct{}]{
-				{},
 			},
 			repoUpdateFilesUsageInformation: []queue.Item[provisioning.UsageInformation]{
 				// global check
@@ -2827,11 +2748,9 @@ func TestUpdateService_Refresh(t *testing.T) {
 					Value: usageInfoGiB(50, 10),
 				},
 			},
-			repoUpsert: []queue.Item[struct{}]{
+			repoUpsert: queue.Errs{
 				// pending
-				{
-					Err: boom.Error,
-				},
+				boom.Error,
 			},
 
 			assertErr: boom.ErrorIs,
@@ -2865,10 +2784,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 				{
 					Value: usageInfoGiB(50, 0), // All space consumed
 				},
-			},
-			repoUpsert: []queue.Item[struct{}]{
-				// pending
-				{},
 			},
 
 			assertErr: func(tt require.TestingT, err error, a ...any) {
@@ -2909,10 +2824,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 					Value: usageInfoGiB(50, 10),
 				},
 			},
-			repoUpsert: []queue.Item[struct{}]{
-				// pending
-				{},
-			},
 
 			assertErr: boom.ErrorIs,
 		},
@@ -2945,10 +2856,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 				{
 					Value: usageInfoGiB(50, 10),
 				},
-			},
-			repoUpsert: []queue.Item[struct{}]{
-				// pending
-				{},
 			},
 			sourceGetUpdateFileByFilename: []queue.Item[struct {
 				stream io.ReadCloser
@@ -2993,10 +2900,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 				{
 					Value: usageInfoGiB(50, 10),
 				},
-			},
-			repoUpsert: []queue.Item[struct{}]{
-				// pending
-				{},
 			},
 			sourceGetUpdateFileByFilename: []queue.Item[struct {
 				stream io.ReadCloser
@@ -3055,10 +2958,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 					Value: usageInfoGiB(50, 10),
 				},
 			},
-			repoUpsert: []queue.Item[struct{}]{
-				// pending
-				{},
-			},
 			sourceGetUpdateFileByFilename: []queue.Item[struct {
 				stream io.ReadCloser
 				size   int
@@ -3113,10 +3012,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 				{
 					Value: usageInfoGiB(50, 10),
 				},
-			},
-			repoUpsert: []queue.Item[struct{}]{
-				// pending
-				{},
 			},
 			sourceGetUpdateFileByFilename: []queue.Item[struct {
 				stream io.ReadCloser
@@ -3178,10 +3073,6 @@ func TestUpdateService_Refresh(t *testing.T) {
 					Value: usageInfoGiB(50, 10),
 				},
 			},
-			repoUpsert: []queue.Item[struct{}]{
-				// pending
-				{},
-			},
 			sourceGetUpdateFileByFilename: []queue.Item[struct {
 				stream io.ReadCloser
 				size   int
@@ -3242,13 +3133,11 @@ func TestUpdateService_Refresh(t *testing.T) {
 					Value: usageInfoGiB(50, 10),
 				},
 			},
-			repoUpsert: []queue.Item[struct{}]{
+			repoUpsert: queue.Errs{
 				// pending
-				{},
+				nil,
 				// ready
-				{
-					Err: boom.Error,
-				},
+				boom.Error,
 			},
 			sourceGetUpdateFileByFilename: []queue.Item[struct {
 				stream io.ReadCloser
@@ -3303,16 +3192,8 @@ func TestUpdateService_Refresh(t *testing.T) {
 					Value: usageInfoGiB(50, 10),
 				},
 			},
-			repoUpsert: []queue.Item[struct{}]{
-				// pending
-				{},
-				// ready
-				{},
-			},
-			repoAssignChannels: []queue.Item[struct{}]{
-				{
-					Err: boom.Error,
-				},
+			repoAssignChannels: queue.Errs{
+				boom.Error,
 			},
 			sourceGetUpdateFileByFilename: []queue.Item[struct {
 				stream io.ReadCloser
@@ -3353,16 +3234,13 @@ func TestUpdateService_Refresh(t *testing.T) {
 					return tc.repoGetAllUpdates, tc.repoGetAllErr
 				},
 				UpsertFunc: func(ctx context.Context, update provisioning.Update) error {
-					_, err := queue.Pop(t, &tc.repoUpsert)
-					return err
+					return tc.repoUpsert.PopOrNil(t)
 				},
 				DeleteByUUIDFunc: func(ctx context.Context, id uuid.UUID) error {
-					_, err := queue.Pop(t, &tc.repoDeleteByUUID)
-					return err
+					return tc.repoDeleteByUUID.PopOrNil(t)
 				},
 				AssignChannelsFunc: func(ctx context.Context, id uuid.UUID, channelNames []string) error {
-					_, err := queue.Pop(t, &tc.repoAssignChannels)
-					return err
+					return tc.repoAssignChannels.PopOrNil(t)
 				},
 			}
 
@@ -3383,8 +3261,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 					return commitFunc, cancelFunc, err
 				},
 				DeleteFunc: func(ctx context.Context, update provisioning.Update) error {
-					_, err := queue.Pop(t, &tc.repoUpdateFilesDelete)
-					return err
+					return tc.repoUpdateFilesDelete.PopOrNil(t)
 				},
 				PruneFilesFunc: func(ctx context.Context, update provisioning.Update) error {
 					return tc.repoUpdateFilesPruneFiles.PopOrNil(t)

--- a/internal/provisioning/update/update_service_test.go
+++ b/internal/provisioning/update/update_service_test.go
@@ -1932,12 +1932,14 @@ func TestUpdateService_Refresh(t *testing.T) {
 		repoDeleteByUUID   []queue.Item[struct{}]
 		repoAssignChannels []queue.Item[struct{}]
 
+		repoUpdateFilesExist            []queue.Item[bool]
 		repoUpdateFilesUsageInformation []queue.Item[provisioning.UsageInformation]
 		repoUpdateFilesPut              []queue.Item[struct {
 			commitErr error
 			cancelErr error
 		}]
-		repoUpdateFilesDelete []queue.Item[struct{}]
+		repoUpdateFilesDelete     []queue.Item[struct{}]
+		repoUpdateFilesPruneFiles queue.Errs
 
 		sourceGetLatestUpdates        provisioning.Updates
 		sourceGetLatestErr            error
@@ -1956,7 +1958,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			name:                 "success - no updates, no state in the DB",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
-			fileFilterExpression: `true`,
+			fileFilterExpression: ``,
 
 			assertErr: require.NoError,
 		},
@@ -2162,12 +2164,121 @@ func TestUpdateService_Refresh(t *testing.T) {
 					},
 				},
 			},
-			repoUpdateFilesDelete: []queue.Item[struct{}]{
+			repoUpsert: []queue.Item[struct{}]{
+				// 04
 				{},
+			},
+			repoUpdateFilesUsageInformation: []queue.Item[provisioning.UsageInformation]{
+				// global check
+				{
+					Value: usageInfoGiB(50, 10),
+				},
+			},
+			repoUpdateFilesExist: []queue.Item[bool]{
+				// 04
+				{
+					Value: true,
+				},
+			},
+			repoUpdateFilesDelete: []queue.Item[struct{}]{
+				// 05
+				{},
+				// 03
 				{},
 			},
 			repoDeleteByUUID: []queue.Item[struct{}]{
+				// 05
 				{},
+				// 03
+				{},
+			},
+
+			assertErr: require.NoError,
+		},
+		{
+			name:                 "success - one update, which refreshes the current state from the db",
+			ctx:                  t.Context(),
+			filterExpression:     `true`,
+			fileFilterExpression: `true`,
+
+			sourceGetLatestUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusUnknown,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+							Filename:  "new_file",
+							Size:      5,
+							// Generate hash: echo -n "dummy" | sha256sum
+							Sha256: "b5a2c96250612366ea272ffac6d9744aaf4b45aacd96aa7cfcb931ee3b558259",
+						},
+						{
+							Component: images.UpdateFileComponentOS,
+							Filename:  "present_file",
+						},
+					},
+				},
+			},
+			repoGetAllUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusReady,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+							Filename:  "present_file",
+						},
+						{
+							Component: images.UpdateFileComponentOS,
+							Filename:  "obsolete_file",
+						},
+					},
+				},
+			},
+			repoUpsert: []queue.Item[struct{}]{
+				// 01
+				{},
+			},
+			repoUpdateFilesUsageInformation: []queue.Item[provisioning.UsageInformation]{
+				// global check
+				{
+					Value: usageInfoGiB(50, 10),
+				},
+			},
+			repoUpdateFilesExist: []queue.Item[bool]{
+				// 01, new_file
+				{
+					Value: false,
+				},
+				// 01, present_file
+				{
+					Value: true,
+				},
+			},
+			sourceGetUpdateFileByFilename: []queue.Item[struct {
+				stream io.ReadCloser
+				size   int
+			}]{
+				{
+					Value: struct {
+						stream io.ReadCloser
+						size   int
+					}{
+						stream: io.NopCloser(bytes.NewBufferString(`dummy`)),
+						size:   5,
+					},
+				},
+			},
+			repoUpdateFilesPut: []queue.Item[struct {
+				commitErr error
+				cancelErr error
+			}]{
+				// store new_file
 				{},
 			},
 
@@ -2271,7 +2382,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name:                 "error - filesRepo.Delete",
+			name:                 "error - repo.DeleteByUUID",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2300,7 +2411,275 @@ func TestUpdateService_Refresh(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name:                 "error - filesRepo.UsageInformation",
+			name:                 "error - toRefreshUpdates - filesRepo.PruneFiles",
+			ctx:                  t.Context(),
+			filterExpression:     `true`,
+			fileFilterExpression: `true`,
+			sourceGetLatestUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusUnknown,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+						},
+					},
+				},
+			},
+			repoGetAllUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusReady,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+						},
+					},
+				},
+			},
+			repoUpdateFilesPruneFiles: queue.Errs{
+				boom.Error,
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
+			name:                 "error - toRefreshUpdates - repo.Upsert",
+			ctx:                  t.Context(),
+			filterExpression:     `true`,
+			fileFilterExpression: `true`,
+			sourceGetLatestUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusUnknown,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+						},
+					},
+				},
+			},
+			repoGetAllUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusReady,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+						},
+					},
+				},
+			},
+			repoUpsert: []queue.Item[struct{}]{
+				{
+					Err: boom.Error,
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
+			name:                 "error - toRefreshUpdates - filesRepo.UsageInformation",
+			ctx:                  t.Context(),
+			filterExpression:     `true`,
+			fileFilterExpression: `true`,
+			sourceGetLatestUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusUnknown,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+						},
+					},
+				},
+			},
+			repoGetAllUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusReady,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+						},
+					},
+				},
+			},
+			repoUpsert: []queue.Item[struct{}]{
+				{},
+			},
+			repoUpdateFilesUsageInformation: []queue.Item[provisioning.UsageInformation]{
+				// global check
+				{
+					Err: boom.Error,
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
+			name: "error - toRefreshUpdates - context cancelled",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancelCause(t.Context())
+				cancel(boom.Error)
+				return ctx
+			}(),
+			filterExpression:     `true`,
+			fileFilterExpression: `true`,
+			sourceGetLatestUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusUnknown,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+						},
+					},
+				},
+			},
+			repoGetAllUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusReady,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+						},
+					},
+				},
+			},
+			repoUpsert: []queue.Item[struct{}]{
+				{},
+			},
+			repoUpdateFilesUsageInformation: []queue.Item[provisioning.UsageInformation]{
+				// global check
+				{
+					Value: usageInfoGiB(50, 10),
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
+			name:                 "error - toRefreshUpdates - filesRepo.Exist",
+			ctx:                  t.Context(),
+			filterExpression:     `true`,
+			fileFilterExpression: `true`,
+			sourceGetLatestUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusUnknown,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+						},
+					},
+				},
+			},
+			repoGetAllUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusReady,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+						},
+					},
+				},
+			},
+			repoUpsert: []queue.Item[struct{}]{
+				{},
+			},
+			repoUpdateFilesUsageInformation: []queue.Item[provisioning.UsageInformation]{
+				// global check
+				{
+					Value: usageInfoGiB(50, 10),
+				},
+			},
+			repoUpdateFilesExist: []queue.Item[bool]{
+				{
+					Err: boom.Error,
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
+			name:                 "error - toRefreshUpdates - downloadFile",
+			ctx:                  t.Context(),
+			filterExpression:     `true`,
+			fileFilterExpression: `true`,
+			sourceGetLatestUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusUnknown,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+						},
+					},
+				},
+			},
+			repoGetAllUpdates: provisioning.Updates{
+				{
+					UUID:        updatePresentUUID,
+					Status:      api.UpdateStatusReady,
+					PublishedAt: dateTime1,
+					Channels:    []string{"stable"},
+					Files: provisioning.UpdateFiles{
+						{
+							Component: images.UpdateFileComponentOS,
+						},
+					},
+				},
+			},
+			repoUpsert: []queue.Item[struct{}]{
+				{},
+			},
+			repoUpdateFilesUsageInformation: []queue.Item[provisioning.UsageInformation]{
+				// global check
+				{
+					Value: usageInfoGiB(50, 10),
+				},
+			},
+			repoUpdateFilesExist: []queue.Item[bool]{
+				{},
+			},
+			sourceGetUpdateFileByFilename: []queue.Item[struct {
+				stream io.ReadCloser
+				size   int
+			}]{
+				{
+					Err: boom.Error,
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+		},
+		{
+			name:                 "error - toDownloadUpdates - filesRepo.UsageInformation",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2329,7 +2708,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name:                 "error - filesRepo.UsageInformation - invalid total size",
+			name:                 "error - toDownloadUpdates - filesRepo.UsageInformation - invalid total size",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2360,7 +2739,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			},
 		},
 		{
-			name:                 "error - not enough space available global",
+			name:                 "error - toDownloadUpdates - not enough space available global",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2391,7 +2770,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			},
 		},
 		{
-			name:                 "error - Validate",
+			name:                 "error - toDownloadUpdates - Validate",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2423,7 +2802,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			},
 		},
 		{
-			name:                 "error - repo.Upsert pending",
+			name:                 "error - toDownloadUpdates - repo.Upsert pending",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2458,7 +2837,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name:                 "error - not enough space available before download",
+			name:                 "error - toDownloadUpdates - not enough space available before download",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2497,7 +2876,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			},
 		},
 		{
-			name: "error - context cancelled",
+			name: "error - toDownloadUpdates - context cancelled",
 			ctx: func() context.Context {
 				ctx, cancel := context.WithCancelCause(t.Context())
 				cancel(boom.Error)
@@ -2538,7 +2917,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name:                 "error - source.GetUpdateFileByFilename",
+			name:                 "error - toDownloadUpdates - source.GetUpdateFileByFilename",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2583,7 +2962,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name:                 "error - filesRepo.Put",
+			name:                 "error - toDownloadUpdates - filesRepo.Put",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2645,7 +3024,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name:                 "error - filesRepo.Put - invalid sha256",
+			name:                 "error - toDownloadUpdates - filesRepo.Put - invalid sha256",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2706,7 +3085,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			},
 		},
 		{
-			name:                 "error - filesRepo.Put - commit",
+			name:                 "error - toDownloadUpdates - filesRepo.Put - commit",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2770,7 +3149,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name:                 "error - filesRepo.Put - cancel",
+			name:                 "error - toDownloadUpdates - filesRepo.Put - cancel",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2834,7 +3213,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name:                 "error - repo.Upsert",
+			name:                 "error - toDownloadUpdates - repo.Upsert",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2895,7 +3274,7 @@ func TestUpdateService_Refresh(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name:                 "error - repo.Upsert",
+			name:                 "error - toDownloadUpdates - repo.AssignChannels",
 			ctx:                  t.Context(),
 			filterExpression:     `true`,
 			fileFilterExpression: `true`,
@@ -2988,6 +3367,9 @@ func TestUpdateService_Refresh(t *testing.T) {
 			}
 
 			repoUpdateFiles := &repoMock.UpdateFilesRepoMock{
+				ExistsFunc: func(ctx context.Context, update provisioning.Update, filename string) (bool, error) {
+					return queue.Pop(t, &tc.repoUpdateFilesExist)
+				},
 				PutFunc: func(ctx context.Context, update provisioning.Update, filename string, content io.ReadCloser) (provisioning.CommitFunc, provisioning.CancelFunc, error) {
 					_, err := io.ReadAll(content)
 					require.NoError(t, err)
@@ -3003,6 +3385,9 @@ func TestUpdateService_Refresh(t *testing.T) {
 				DeleteFunc: func(ctx context.Context, update provisioning.Update) error {
 					_, err := queue.Pop(t, &tc.repoUpdateFilesDelete)
 					return err
+				},
+				PruneFilesFunc: func(ctx context.Context, update provisioning.Update) error {
+					return tc.repoUpdateFilesPruneFiles.PopOrNil(t)
 				},
 				UsageInformationFunc: func(ctx context.Context) (provisioning.UsageInformation, error) {
 					return queue.Pop(t, &tc.repoUpdateFilesUsageInformation)
@@ -3060,8 +3445,11 @@ func TestUpdateService_Refresh(t *testing.T) {
 			// Ensure queues are completely drained.
 			require.Empty(t, tc.repoUpsert)
 			require.Empty(t, tc.repoDeleteByUUID)
+			require.Empty(t, tc.repoUpdateFilesExist)
+			require.Empty(t, tc.repoUpdateFilesUsageInformation)
 			require.Empty(t, tc.repoUpdateFilesPut)
 			require.Empty(t, tc.repoUpdateFilesDelete)
+			require.Empty(t, tc.repoUpdateFilesPruneFiles)
 			require.Empty(t, tc.sourceGetUpdateFileByFilename)
 		})
 	}

--- a/internal/provisioning/update_ports.go
+++ b/internal/provisioning/update_ports.go
@@ -52,9 +52,11 @@ type (
 )
 
 type UpdateFilesRepo interface {
+	Exists(ctx context.Context, update Update, filename string) (bool, error)
 	Get(ctx context.Context, update Update, filename string) (_ io.ReadCloser, size int, _ error)
 	Put(ctx context.Context, update Update, filename string, content io.ReadCloser) (CommitFunc, CancelFunc, error)
 	Delete(ctx context.Context, update Update) error
+	PruneFiles(ctx context.Context, update Update) (_ error)
 	UsageInformation(ctx context.Context) (UsageInformation, error)
 	CleanupAll(ctx context.Context) error
 	CreateFromArchive(ctx context.Context, tarReader *tar.Reader) (*Update, error)


### PR DESCRIPTION
For existing updates, which are kept, it is ensured, that the files on disk do match with the expected files from the source while applying the file filter expression. Obsolete files are removed, missing files are downloaded.

Resolves: #825