### PR TITLE
environment: Fix decoding of auth token

### DIFF
--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -208,5 +208,11 @@ func (e environment) GetToken(ctx context.Context) (string, error) {
 		return "", api.StatusErrorf(resp.StatusCode, "%v", response.Error)
 	}
 
-	return string(response.Metadata), nil
+	var token string
+	err = json.Unmarshal(response.Metadata, &token)
+	if err != nil {
+		return "", fmt.Errorf("Invalid response for IncusOS token: %w", err)
+	}
+
+	return token, nil
 }


### PR DESCRIPTION
The Metadata is JSON encoded. We need to decode it to avoid having the string be quoted.