### PR TITLE
provisioning/server: decouple connection test with certificate update from server status update in PollServer

### DIFF
--- a/internal/provisioning/server/server_service.go
+++ b/internal/provisioning/server/server_service.go
@@ -1760,7 +1760,7 @@ func (s *serverService) PollServer(ctx context.Context, server provisioning.Serv
 		Entity:     server.Name,
 	}
 
-	updatedServerCertificate, connTestErr := s.connectionTestWithCertificateUpdate(ctx, server, log)
+	connTestErr := s.connectionTestWithCertificateUpdate(ctx, server, log)
 	if connTestErr != nil {
 		var retryableErr domain.ErrRetryable
 		if errors.As(connTestErr, &retryableErr) {
@@ -1908,10 +1908,6 @@ func (s *serverService) PollServer(ctx context.Context, server provisioning.Serv
 
 		server.LastSeen = s.now()
 
-		if updatedServerCertificate != "" {
-			server.Certificate = updatedServerCertificate
-		}
-
 		// Clear status detail, if previous state was not ready, e.g. because
 		// of reboot or reconfiguration.
 		if server.Status != api.ServerStatusReady {
@@ -2018,7 +2014,7 @@ func (s *serverService) PollServer(ctx context.Context, server provisioning.Serv
 	return nil
 }
 
-func (s *serverService) connectionTestWithCertificateUpdate(ctx context.Context, server provisioning.Server, log *slog.Logger) (updatedServerCertificate string, _ error) {
+func (s *serverService) connectionTestWithCertificateUpdate(ctx context.Context, server provisioning.Server, log *slog.Logger) error {
 	// Since we re-try frequently, we only grant a short timeout for the
 	// connection attept.
 	ctxWithTimeout, cancelFunc := context.WithTimeout(ctx, 1*time.Second)
@@ -2099,7 +2095,7 @@ func (s *serverService) connectionTestWithCertificateUpdate(ctx context.Context,
 				if retryErr != nil {
 					// The clusters certificate has passed validation against system root
 					// certificates but we failed to update the cluster record in the DB.
-					return "", retryErr
+					return retryErr
 				}
 
 			case isStandaloneNonIncusServerWithPublicConnectionURL: // case 2, standalone non Incus server
@@ -2138,9 +2134,20 @@ func (s *serverService) connectionTestWithCertificateUpdate(ctx context.Context,
 					Bytes: resp.TLS.PeerCertificates[0].Raw,
 				})
 
-				// Only set the certificate here, the Update in the DB happens at the
-				// end of the function.
-				updatedServerCertificate = string(serverCert)
+				retryErr = transaction.Do(ctx, func(ctx context.Context) error {
+					updateServer, err := s.repo.GetByName(ctx, server.Name)
+					if err != nil {
+						return err
+					}
+
+					updateServer.Certificate = string(serverCert)
+					updateServer.LastSeen = s.now()
+
+					return s.repo.Update(ctx, *updateServer)
+				})
+				if retryErr != nil {
+					return retryErr
+				}
 
 			default:
 				// neither case 1 nor case 2, don't attempt to refresh certificate
@@ -2153,7 +2160,7 @@ func (s *serverService) connectionTestWithCertificateUpdate(ctx context.Context,
 		}
 	}
 
-	return updatedServerCertificate, domain.NewRetryableErr(err)
+	return domain.NewRetryableErr(err)
 }
 
 func (s *serverService) SyncCluster(ctx context.Context, clusterName string) error {

--- a/internal/provisioning/server/server_service.go
+++ b/internal/provisioning/server/server_service.go
@@ -22,6 +22,7 @@ import (
 	incusosapi "github.com/lxc/incus-os/incus-osd/api"
 	"github.com/lxc/incus-os/incus-osd/api/images"
 	"github.com/lxc/incus/v6/shared/revert"
+	incustls "github.com/lxc/incus/v6/shared/tls"
 	"github.com/maniartech/signals"
 
 	config "github.com/FuturFusion/operations-center/internal/config/daemon"
@@ -721,7 +722,7 @@ func (s *serverService) SelfUpdate(ctx context.Context, serverUpdate provisionin
 		server, err = s.repo.GetByCertificate(ctx, string(authenticationCertificatePEM))
 		if err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
-				return fmt.Errorf("Failed to find server (%s) with cause %q by certificate: %w", serverUpdate.ConnectionURL, serverUpdate.Cause, domain.ErrNotAuthorized)
+				return fmt.Errorf("Failed to find server (%s) with cause %q by certificate (fingerprint: %s): %w", serverUpdate.ConnectionURL, serverUpdate.Cause, incustls.CertFingerprint(serverUpdate.AuthenticationCertificate), domain.ErrNotAuthorized)
 			}
 
 			return fmt.Errorf("Failed to get server (%s) with cause %q by certificate: %w", serverUpdate.ConnectionURL, serverUpdate.Cause, err)

--- a/internal/provisioning/server/server_service_test.go
+++ b/internal/provisioning/server/server_service_test.go
@@ -3686,6 +3686,7 @@ foobar
 			assertErr: boom.ErrorIs,
 			assertLog: log.EmptyWithIgnorePattern(log.IgnorePatternDebugLines),
 		},
+
 		{
 			name: "success - standalone server now has publicly valid certificate",
 			serverArg: provisioning.Server{
@@ -3705,13 +3706,28 @@ foobar
 						Status: api.ServerStatusReady,
 					},
 				},
+				{
+					Value: &provisioning.Server{
+						Name:   "one",
+						Status: api.ServerStatusReady,
+						Certificate: string(
+							pem.EncodeToMemory(
+								&pem.Block{
+									Type:  "CERTIFICATE",
+									Bytes: httpsServer.TLS.Certificates[0].Leaf.Raw,
+								},
+							),
+						),
+					},
+				},
 			},
 			repoUpdate: []queue.Item[struct{}]{
 				{},
+				{},
 			},
 			clientPing: []queue.Item[struct{}]{
-				// Simulate failing connection with pinned certificate, because cluster
-				// now has a publicly valid certificate (e.g. ACME).
+				// Simulate failing connection with pinned certificate, because
+				// standalone server now has a publicly valid certificate (e.g. ACME).
 				{
 					Err: &url.Error{
 						Err: &tls.CertificateVerificationError{},
@@ -3755,8 +3771,8 @@ foobar
 				{},
 			},
 			clientPing: []queue.Item[struct{}]{
-				// Simulate failing connection with pinned certificate, because cluster
-				// now has a publicly valid certificate (e.g. ACME).
+				// Simulate failing connection with pinned certificate, because
+				// standalone server now has a publicly valid certificate (e.g. ACME).
 				{
 					Err: &url.Error{
 						Err: &tls.CertificateVerificationError{},
@@ -3789,8 +3805,8 @@ foobar
 				{},
 			},
 			clientPing: []queue.Item[struct{}]{
-				// Simulate failing connection with pinned certificate, because cluster
-				// now has a publicly valid certificate (e.g. ACME).
+				// Simulate failing connection with pinned certificate, because
+				// standalone server now has a publicly valid certificate (e.g. ACME).
 				{
 					Err: &url.Error{
 						Err: &tls.CertificateVerificationError{},
@@ -3823,8 +3839,8 @@ foobar
 				{},
 			},
 			clientPing: []queue.Item[struct{}]{
-				// Simulate failing connection with pinned certificate, because cluster
-				// now has a publicly valid certificate (e.g. ACME).
+				// Simulate failing connection with pinned certificate, because
+				// standalone server now has a publicly valid certificate (e.g. ACME).
 				{
 					Err: &url.Error{
 						Err: &tls.CertificateVerificationError{},
@@ -3859,8 +3875,8 @@ foobar
 				},
 			},
 			clientPing: []queue.Item[struct{}]{
-				// Simulate failing connection with pinned certificate, because cluster
-				// now has a publicly valid certificate (e.g. ACME).
+				// Simulate failing connection with pinned certificate, because
+				// standalone server now has a publicly valid certificate (e.g. ACME).
 				{
 					Err: &url.Error{
 						Err: &tls.CertificateVerificationError{},
@@ -3871,6 +3887,36 @@ foobar
 			assertErr:        boom.ErrorIs,
 			assertLog:        log.Match("(?ms)Refresh certificate connection attempt did not return TLS connection or no peer certificates.*Server connection test failed"),
 			wantServerStatus: api.ServerStatusOffline,
+		},
+		{
+			name: "error - standalone server - repo.GetByName",
+			serverArg: provisioning.Server{
+				Name: "one",
+				Certificate: `-----BEGIN CERTIFICATE-----
+foobar
+-----END CERTIFICATE-----`,
+				Status:              api.ServerStatusReady,
+				Type:                api.ServerTypeMigrationManager,
+				ConnectionURL:       "https:/127.0.0.1:7443",
+				PublicConnectionURL: httpsServer.URL,
+			},
+			repoGetByName: []queue.Item[*provisioning.Server]{
+				{
+					Err: boom.Error,
+				},
+			},
+			clientPing: []queue.Item[struct{}]{
+				// Simulate failing connection with pinned certificate, because
+				// standalone server now has a publicly valid certificate (e.g. ACME).
+				{
+					Err: &url.Error{
+						Err: &tls.CertificateVerificationError{},
+					},
+				},
+			},
+
+			assertErr: boom.ErrorIs,
+			assertLog: log.EmptyWithIgnorePattern(log.IgnorePatternDebugLines),
 		},
 	}
 


### PR DESCRIPTION
* log certificate fingerprint on not authorized error
* decouple connection test with certificate update from server status update in PollServer