### PR TITLE
ui: Remove redundant scroll-container from child views

### DIFF
--- a/ui/src/pages/Channel.tsx
+++ b/ui/src/pages/Channel.tsx
@@ -72,7 +72,7 @@ const Channel = () => {
             </div>
           </div>
         </div>
-        <div className="scroll-container flex-grow-1">
+        <div className="flex-grow-1">
           <DataTable headers={headers} rows={rows} />
         </div>
       </div>

--- a/ui/src/pages/ClusterList.tsx
+++ b/ui/src/pages/ClusterList.tsx
@@ -104,7 +104,7 @@ const Cluster = () => {
             </div>
           </div>
         </div>
-        <div className="scroll-container flex-grow-1">
+        <div className="flex-grow-1">
           <ExtendedDataTable
             headers={headers}
             rows={rows}

--- a/ui/src/pages/ClusterTemplate.tsx
+++ b/ui/src/pages/ClusterTemplate.tsx
@@ -76,7 +76,7 @@ const ClusterTemplate = () => {
             </div>
           </div>
         </div>
-        <div className="scroll-container flex-grow-1">
+        <div className="flex-grow-1">
           <DataTable headers={headers} rows={rows} />
         </div>
       </div>

--- a/ui/src/pages/ServerList.tsx
+++ b/ui/src/pages/ServerList.tsx
@@ -115,7 +115,7 @@ const Server = () => {
         <InventorySearchBox />
       </Container>
       <div className="d-flex flex-column">
-        <div className="scroll-container flex-grow-1">
+        <div className="flex-grow-1">
           <ExtendedDataTable
             headers={headers}
             rows={rows}

--- a/ui/src/pages/Token.tsx
+++ b/ui/src/pages/Token.tsx
@@ -82,7 +82,7 @@ const Token = () => {
             </div>
           </div>
         </div>
-        <div className="scroll-container flex-grow-1">
+        <div className="flex-grow-1">
           <DataTable headers={headers} rows={rows} />
         </div>
       </div>

--- a/ui/src/pages/UpdateList.tsx
+++ b/ui/src/pages/UpdateList.tsx
@@ -136,7 +136,7 @@ const Update = () => {
             </div>
           </div>
         </div>
-        <div className="scroll-container flex-grow-1">
+        <div className="flex-grow-1">
           <DataTable headers={headers} rows={rows} />
         </div>
       </div>


### PR DESCRIPTION
This PR removes the `scroll-container` class from several child components where it was no longer necessary.
The scroll behavior is already handled by a parent-level container, so keeping it in child components was redundant and could lead to unintended layout behavior.