### PR TITLE
ui: Increase bottom spacing for footer

### DIFF
--- a/ui/src/css/index.css
+++ b/ui/src/css/index.css
@@ -31,8 +31,8 @@ tr.overview-table-header th {
 
 .scroll-container {
   overflow-y: auto;
-  min-height: calc(100vh - 100px);
-  max-height: calc(100vh - 100px);
+  min-height: calc(100vh - 140px);
+  max-height: calc(100vh - 140px);
 }
 
 .fixed-footer {


### PR DESCRIPTION
Adding breadcrumbs pushed the footer out of view in some layouts. This adds extra bottom spacing to keep the footer visible on screen.