### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -65,13 +65,13 @@ jobs:
           node-version: 22.x
 
       - name: Install UI dependencies
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: install
           dir: ui
 
       - name: Build UI
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: build
           dir: ui

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -32,19 +32,19 @@ jobs:
           make operations-center
 
       - name: Upload client (Linux)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Linux
           path: bin/*linux*
 
       - name: Upload client (MacOS)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos
           path: bin/*macos*
 
       - name: Upload client (Windows)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Windows
           path: bin/*windows*
@@ -77,7 +77,7 @@ jobs:
           dir: ui
 
       - name: Upload UI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: UI
           path: ui/dist/

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -23,7 +23,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
 
       - name: Build binaries
         run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Go
         uses: actions/setup-go@v5
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set Node.js 22.x
         uses: actions/setup-node@v4
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-tags: true
 

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -14,4 +14,4 @@ jobs:
     name: Signed-off-by (DCO)
     runs-on: ubuntu-24.04
     steps:
-    - uses: KineticCafe/actions-dco@v1
+    - uses: KineticCafe/actions-dco@v3.1.0

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -22,7 +22,7 @@ jobs:
       - image-debian-13
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -25,9 +25,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 'oldstable'
+          go-version: 'stable'
 
       - name: Setup Incus
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Client - Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "stable"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: UI - Install dependencies
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: install
           dir: ui
 
       - name: UI - Build
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: build
           dir: ui

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
           # - tip
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Currently the repository is not yet setup for dependency review.
       # Setup: Enable Dependency graph along with GitHub Advanced Security on

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,13 +40,13 @@ jobs:
       #   if: github.event_name == 'pull_request'
 
       - name: Install Go (${{ matrix.go }})
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
         if: matrix.go != 'tip'
 
       - name: Install Go (stable)
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
         if: matrix.go == 'tip'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           make build
 
-      - uses: opentofu/setup-opentofu@v1
+      - uses: opentofu/setup-opentofu@v2
 
       - name: Run static analysis
         env:

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: govulncheck
         uses: golang/govulncheck-action@v1


### PR DESCRIPTION
Node.js 20 actions are deprecated. Update all actions to their most recent version.
Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.