### PR TITLE
Fix version data enrichment

### DIFF
--- a/internal/provisioning/cluster/cluster_service_update_control_loop_test.go
+++ b/internal/provisioning/cluster/cluster_service_update_control_loop_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	incusosapi "github.com/lxc/incus-os/incus-osd/api"
-	"github.com/lxc/incus-os/incus-osd/api/images"
 	incustls "github.com/lxc/incus/v7/shared/tls"
 	"github.com/stretchr/testify/require"
 
@@ -170,12 +169,10 @@ func TestClusterService_ClusterUpdateControlLoopSingleNodeCluster(t *testing.T) 
 					Version: "2",
 					Files: provisioning.UpdateFiles{
 						{
-							Filename:  "os",
-							Component: images.UpdateFileComponentOS,
+							Filename: "x86_64/IncusOS_20260610.img.gz",
 						},
 						{
-							Filename:  "incus",
-							Component: images.UpdateFileComponentIncus,
+							Filename: "x86_64/incus.raw.gz",
 						},
 					},
 				},
@@ -730,12 +727,10 @@ func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
 					Version: "2",
 					Files: provisioning.UpdateFiles{
 						{
-							Filename:  "os",
-							Component: images.UpdateFileComponentOS,
+							Filename: "x86_64/IncusOS_20260610.img.gz",
 						},
 						{
-							Filename:  "incus",
-							Component: images.UpdateFileComponentIncus,
+							Filename: "x86_64/incus.raw.gz",
 						},
 					},
 				},

--- a/internal/provisioning/server/server_service.go
+++ b/internal/provisioning/server/server_service.go
@@ -357,14 +357,14 @@ func (s *serverService) enrichServerWithVersionDetails(ctx context.Context, serv
 
 	if len(updates) == 0 {
 		// No updates found, enrich without update version information.
-		server.VersionData.Compute(nil)
+		server.VersionData.Compute("", nil)
 		return nil
 	}
 
-	serverComponents := make([]string, 0, len(server.VersionData.Applications)+1) // All applications + OS
-	serverComponents = append(serverComponents, string(images.UpdateFileComponentOS))
+	serverOSAndApplications := make([]string, 0, len(server.VersionData.Applications)+1) // All applications + OS
+	serverOSAndApplications = append(serverOSAndApplications, server.VersionData.OS.Name)
 	for i, app := range server.VersionData.Applications {
-		serverComponents = append(serverComponents, app.Name)
+		serverOSAndApplications = append(serverOSAndApplications, app.Name)
 		server.VersionData.Applications[i].NeedsUpdate = ptr.To(false)
 	}
 
@@ -377,16 +377,16 @@ func (s *serverService) enrichServerWithVersionDetails(ctx context.Context, serv
 	// latestAvailableVersions map and remove the component from
 	// `serverComponents`. We are done with the work, if `serverComponents` is
 	// empty.
-	latestAvailableVersions := make(map[images.UpdateFileComponent]string, len(updates))
+	latestAvailableVersions := make(map[string]string, len(updates))
 	for _, update := range updates {
-		if len(serverComponents) == 0 {
+		if len(serverOSAndApplications) == 0 {
 			break
 		}
 
-		for _, updateComponent := range update.Components() {
-			serverComponents = slices.DeleteFunc(serverComponents, func(serverComponent string) bool {
-				if serverComponent == updateComponent.String() {
-					latestAvailableVersions[updateComponent] = update.Version
+		for _, updateApplication := range update.Applications() {
+			serverOSAndApplications = slices.DeleteFunc(serverOSAndApplications, func(application string) bool {
+				if application == updateApplication {
+					latestAvailableVersions[updateApplication] = update.Version
 					return true
 				}
 
@@ -401,7 +401,7 @@ func (s *serverService) enrichServerWithVersionDetails(ctx context.Context, serv
 		Entity:     server.Name,
 	}
 
-	if len(serverComponents) != 0 {
+	if len(serverOSAndApplications) != 0 {
 		// This indicates, that for some components, we have not found any update.
 		// This is a possible case, e.g. if someone clears and refreshes all the
 		// updates and then queries servers, registered in Operations Center, before
@@ -410,14 +410,14 @@ func (s *serverService) enrichServerWithVersionDetails(ctx context.Context, serv
 			warning.NewWarning(
 				api.WarningTypeVersionDatailsMissing,
 				scope,
-				fmt.Sprintf("Failed to find updates for some components while enriching server record with update version information: %v", serverComponents),
+				fmt.Sprintf("Failed to find updates for some components while enriching server record with update version information: %v", serverOSAndApplications),
 			),
 		)
 	} else {
 		s.warning.RemoveStale(ctx, scope, nil)
 	}
 
-	server.VersionData.Compute(latestAvailableVersions)
+	server.VersionData.Compute(server.VersionData.OS.Name, latestAvailableVersions)
 
 	return nil
 }

--- a/internal/provisioning/server/server_service_test.go
+++ b/internal/provisioning/server/server_service_test.go
@@ -767,7 +767,7 @@ func TestServerService_GetByName(t *testing.T) {
 				ConnectionURL: "http://one/",
 				VersionData: api.ServerVersionData{
 					OS: api.OSVersionData{
-						Name:        "os",
+						Name:        "IncusOS",
 						Version:     "2",
 						VersionNext: "2",
 					},
@@ -788,13 +788,13 @@ func TestServerService_GetByName(t *testing.T) {
 					Version: "2",
 					Files: provisioning.UpdateFiles{
 						{
-							Component: images.UpdateFileComponentOS,
+							Filename: "x86_64/IncusOS_20260610.img.gz",
 						},
 						{
-							Component: images.UpdateFileComponentIncus,
+							Filename: "x86_64/incus.raw.gz",
 						},
 						{
-							Component: images.UpdateFileComponentIncusCeph,
+							Filename: "x86_64/incus-ceph.raw.gz",
 						},
 					},
 				},
@@ -802,13 +802,13 @@ func TestServerService_GetByName(t *testing.T) {
 					Version: "1",
 					Files: provisioning.UpdateFiles{
 						{
-							Component: images.UpdateFileComponentOS,
+							Filename: "x86_64/IncusOS_20260610.img.gz",
 						},
 						{
-							Component: images.UpdateFileComponentIncus,
+							Filename: "x86_64/incus.raw.gz",
 						},
 						{
-							Component: images.UpdateFileComponentIncusCeph,
+							Filename: "x86_64/incus-ceph.raw.gz",
 						},
 					},
 				},
@@ -821,7 +821,7 @@ func TestServerService_GetByName(t *testing.T) {
 				ConnectionURL: "http://one/",
 				VersionData: api.ServerVersionData{
 					OS: api.OSVersionData{
-						Name:             "os",
+						Name:             "IncusOS",
 						Version:          "2",
 						VersionNext:      "2",
 						AvailableVersion: ptr.To("2"),
@@ -856,7 +856,7 @@ func TestServerService_GetByName(t *testing.T) {
 				ConnectionURL: "http://one/",
 				VersionData: api.ServerVersionData{
 					OS: api.OSVersionData{
-						Name:        "os",
+						Name:        "IncusOS",
 						Version:     "2",
 						VersionNext: "2",
 					},
@@ -877,13 +877,13 @@ func TestServerService_GetByName(t *testing.T) {
 					Version: "3",
 					Files: provisioning.UpdateFiles{
 						{
-							Component: images.UpdateFileComponentOS,
+							Filename: "x86_64/IncusOS_20260610.img.gz",
 						},
 						{
-							Component: images.UpdateFileComponentIncus,
+							Filename: "x86_64/incus.raw.gz",
 						},
 						{
-							Component: images.UpdateFileComponentIncusCeph,
+							Filename: "x86_64/incus-ceph.raw.gz",
 						},
 					},
 				},
@@ -891,13 +891,13 @@ func TestServerService_GetByName(t *testing.T) {
 					Version: "2",
 					Files: provisioning.UpdateFiles{
 						{
-							Component: images.UpdateFileComponentOS,
+							Filename: "x86_64/IncusOS_20260610.img.gz",
 						},
 						{
-							Component: images.UpdateFileComponentIncus,
+							Filename: "x86_64/incus.raw.gz",
 						},
 						{
-							Component: images.UpdateFileComponentIncusCeph,
+							Filename: "x86_64/incus-ceph.raw.gz",
 						},
 					},
 				},
@@ -905,13 +905,13 @@ func TestServerService_GetByName(t *testing.T) {
 					Version: "1",
 					Files: provisioning.UpdateFiles{
 						{
-							Component: images.UpdateFileComponentOS,
+							Filename: "x86_64/IncusOS_20260610.img.gz",
 						},
 						{
-							Component: images.UpdateFileComponentIncus,
+							Filename: "x86_64/incus.raw.gz",
 						},
 						{
-							Component: images.UpdateFileComponentIncusCeph,
+							Filename: "x86_64/incus-ceph.raw.gz",
 						},
 					},
 				},
@@ -924,7 +924,7 @@ func TestServerService_GetByName(t *testing.T) {
 				ConnectionURL: "http://one/",
 				VersionData: api.ServerVersionData{
 					OS: api.OSVersionData{
-						Name:             "os",
+						Name:             "IncusOS",
 						Version:          "2",
 						VersionNext:      "2",
 						AvailableVersion: ptr.To("3"),
@@ -959,7 +959,7 @@ func TestServerService_GetByName(t *testing.T) {
 				ConnectionURL: "http://one/",
 				VersionData: api.ServerVersionData{
 					OS: api.OSVersionData{
-						Name:        "os",
+						Name:        "IncusOS",
 						Version:     "2",
 						VersionNext: "2",
 					},
@@ -980,10 +980,10 @@ func TestServerService_GetByName(t *testing.T) {
 					Version: "2",
 					Files: provisioning.UpdateFiles{
 						{
-							Component: images.UpdateFileComponentOS,
+							Filename: "x86_64/IncusOS_20260610.img.gz",
 						},
 						{
-							Component: images.UpdateFileComponentIncus,
+							Filename: "x86_64/incus.raw.gz",
 						},
 						// incus-ceph missing here
 					},
@@ -992,10 +992,10 @@ func TestServerService_GetByName(t *testing.T) {
 					Version: "1",
 					Files: provisioning.UpdateFiles{
 						{
-							Component: images.UpdateFileComponentOS,
+							Filename: "x86_64/IncusOS_20260610.img.gz",
 						},
 						{
-							Component: images.UpdateFileComponentIncus,
+							Filename: "x86_64/incus.raw.gz",
 						},
 						// incus-ceph missing here
 					},
@@ -1009,7 +1009,7 @@ func TestServerService_GetByName(t *testing.T) {
 				ConnectionURL: "http://one/",
 				VersionData: api.ServerVersionData{
 					OS: api.OSVersionData{
-						Name:             "os",
+						Name:             "IncusOS",
 						Version:          "2",
 						VersionNext:      "2",
 						AvailableVersion: ptr.To("2"),
@@ -4137,6 +4137,10 @@ func TestServerService_PollServer(t *testing.T) {
 				Status:       api.ServerStatusReady,
 				StatusDetail: api.ServerStatusDetailReadyEvacuating,
 				VersionData: api.ServerVersionData{
+					OS: api.OSVersionData{
+						Name:    "IncusOS",
+						Version: "1",
+					},
 					Applications: []api.ApplicationVersionData{
 						{
 							Name:          "incus",
@@ -4163,6 +4167,10 @@ func TestServerService_PollServer(t *testing.T) {
 				},
 			},
 			clientGetVersionData: api.ServerVersionData{
+				OS: api.OSVersionData{
+					Name:    "IncusOS",
+					Version: "1",
+				},
 				Applications: []api.ApplicationVersionData{
 					{
 						Name:          "incus",
@@ -4178,10 +4186,10 @@ func TestServerService_PollServer(t *testing.T) {
 					Channels: []string{"stable"},
 					Files: provisioning.UpdateFiles{
 						{
-							Component: images.UpdateFileComponentOS,
+							Filename: "x86_64/IncusOS_20260610.img.gz",
 						},
 						{
-							Component: images.UpdateFileComponentIncus,
+							Filename: "x86_64/incus.raw.gz",
 						},
 					},
 				},
@@ -5009,7 +5017,7 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 						Channel: "stable",
 						VersionData: api.ServerVersionData{
 							OS: api.OSVersionData{
-								Name:    "os",
+								Name:    "IncusOS",
 								Version: "1",
 							},
 							Applications: []api.ApplicationVersionData{
@@ -5032,10 +5040,10 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 							Channels: []string{"stable"},
 							Files: provisioning.UpdateFiles{
 								{
-									Component: images.UpdateFileComponentOS,
+									Filename: "x86_64/IncusOS_20260610.img.gz",
 								},
 								{
-									Component: images.UpdateFileComponentIncus,
+									Filename: "x86_64/incus.raw.gz",
 								},
 							},
 						},
@@ -5045,10 +5053,10 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 							Channels: []string{"stable"},
 							Files: provisioning.UpdateFiles{
 								{
-									Component: images.UpdateFileComponentOS,
+									Filename: "x86_64/IncusOS_20260610.img.gz",
 								},
 								{
-									Component: images.UpdateFileComponentIncus,
+									Filename: "x86_64/incus.raw.gz",
 								},
 							},
 						},
@@ -5063,10 +5071,10 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 							Channels: []string{"stable"},
 							Files: provisioning.UpdateFiles{
 								{
-									Component: images.UpdateFileComponentOS,
+									Filename: "x86_64/IncusOS_20260610.img.gz",
 								},
 								{
-									Component: images.UpdateFileComponentIncus,
+									Filename: "x86_64/incus.raw.gz",
 								},
 							},
 						},
@@ -5076,10 +5084,10 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 							Channels: []string{"stable"},
 							Files: provisioning.UpdateFiles{
 								{
-									Component: images.UpdateFileComponentOS,
+									Filename: "x86_64/IncusOS_20260610.img.gz",
 								},
 								{
-									Component: images.UpdateFileComponentIncus,
+									Filename: "x86_64/incus.raw.gz",
 								},
 							},
 						},
@@ -5090,7 +5098,7 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 				CurrentVersion: "2",
 				PriorVersion:   "1",
 				Components: map[string]images.ChangelogEntries{
-					"os": {
+					"IncusOS": {
 						Updated: []string{"file version 1 to version 2"},
 					},
 					"incus": {
@@ -5105,7 +5113,7 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 				PriorVersion:   "1",
 				Channel:        "stable",
 				Components: map[string]images.ChangelogEntries{
-					"os": {
+					"IncusOS": {
 						Updated: []string{"file version 1 to version 2"},
 					},
 					"incus": {
@@ -5124,7 +5132,7 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 						Channel: "stable",
 						VersionData: api.ServerVersionData{
 							OS: api.OSVersionData{
-								Name:    "os",
+								Name:    "IncusOS",
 								Version: "1",
 							},
 							Applications: []api.ApplicationVersionData{
@@ -5148,10 +5156,10 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 							Channels: []string{"stable"},
 							Files: provisioning.UpdateFiles{
 								{
-									Component: images.UpdateFileComponentOS,
+									Filename: "x86_64/IncusOS_20260610.img.gz",
 								},
 								{
-									Component: images.UpdateFileComponentIncus,
+									Filename: "x86_64/incus.raw.gz",
 								},
 							},
 						},
@@ -5183,7 +5191,7 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 						Channel: "stable",
 						VersionData: api.ServerVersionData{
 							OS: api.OSVersionData{
-								Name:    "os",
+								Name:    "IncusOS",
 								Version: "1",
 							},
 							Applications: []api.ApplicationVersionData{
@@ -5206,10 +5214,10 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 							Channels: []string{"stable"},
 							Files: provisioning.UpdateFiles{
 								{
-									Component: images.UpdateFileComponentOS,
+									Filename: "x86_64/IncusOS_20260610.img.gz",
 								},
 								{
-									Component: images.UpdateFileComponentIncus,
+									Filename: "x86_64/incus.raw.gz",
 								},
 							},
 						},
@@ -5219,10 +5227,10 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 							Channels: []string{"stable"},
 							Files: provisioning.UpdateFiles{
 								{
-									Component: images.UpdateFileComponentOS,
+									Filename: "x86_64/IncusOS_20260610.img.gz",
 								},
 								{
-									Component: images.UpdateFileComponentIncus,
+									Filename: "x86_64/incus.raw.gz",
 								},
 							},
 						},
@@ -5246,7 +5254,7 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 						Channel: "stable",
 						VersionData: api.ServerVersionData{
 							OS: api.OSVersionData{
-								Name:    "os",
+								Name:    "IncusOS",
 								Version: "1",
 							},
 							Applications: []api.ApplicationVersionData{
@@ -5269,10 +5277,10 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 							Channels: []string{"stable"},
 							Files: provisioning.UpdateFiles{
 								{
-									Component: images.UpdateFileComponentOS,
+									Filename: "x86_64/IncusOS_20260610.img.gz",
 								},
 								{
-									Component: images.UpdateFileComponentIncus,
+									Filename: "x86_64/incus.raw.gz",
 								},
 							},
 						},
@@ -5282,10 +5290,10 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 							Channels: []string{"stable"},
 							Files: provisioning.UpdateFiles{
 								{
-									Component: images.UpdateFileComponentOS,
+									Filename: "x86_64/IncusOS_20260610.img.gz",
 								},
 								{
-									Component: images.UpdateFileComponentIncus,
+									Filename: "x86_64/incus.raw.gz",
 								},
 							},
 						},
@@ -5300,10 +5308,10 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 							Channels: []string{"stable"},
 							Files: provisioning.UpdateFiles{
 								{
-									Component: images.UpdateFileComponentOS,
+									Filename: "x86_64/IncusOS_20260610.img.gz",
 								},
 								{
-									Component: images.UpdateFileComponentIncus,
+									Filename: "x86_64/incus.raw.gz",
 								},
 							},
 						},
@@ -5313,10 +5321,10 @@ func TestServerService_GetChangelogByName(t *testing.T) {
 							Channels: []string{"stable"},
 							Files: provisioning.UpdateFiles{
 								{
-									Component: images.UpdateFileComponentOS,
+									Filename: "x86_64/IncusOS_202606100326.img.gz",
 								},
 								{
-									Component: images.UpdateFileComponentIncus,
+									Filename: "x86_64/incus.raw.gz",
 								},
 							},
 						},

--- a/internal/provisioning/update_model.go
+++ b/internal/provisioning/update_model.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -64,6 +65,29 @@ func (u Update) Components() []images.UpdateFileComponent {
 	}
 
 	return components
+}
+
+func (u Update) Applications() []string {
+	applicationsSet := make(map[string]struct{})
+	for _, file := range u.Files {
+		osNameVersion, ok := strings.CutSuffix(filepath.Base(file.Filename), ".img.gz")
+		if ok {
+			osNameVersionParts := strings.Split(osNameVersion, "_")
+			applicationsSet[osNameVersionParts[0]] = struct{}{}
+		}
+
+		applicationName, ok := strings.CutSuffix(filepath.Base(file.Filename), ".raw.gz")
+		if ok {
+			applicationsSet[applicationName] = struct{}{}
+		}
+	}
+
+	applications := make([]string, 0, len(applicationsSet))
+	for application := range applicationsSet {
+		applications = append(applications, application)
+	}
+
+	return applications
 }
 
 type Updates []Update

--- a/internal/provisioning/update_model_test.go
+++ b/internal/provisioning/update_model_test.go
@@ -133,6 +133,54 @@ func TestUpdate_Components(t *testing.T) {
 	}
 }
 
+func TestUpdate_Applications(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "success",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			update := provisioning.Update{
+				Files: provisioning.UpdateFiles{
+					{
+						Filename: "x86_64/IncusOS_202605310326.img.gz",
+					},
+					{
+						Filename: "x86_64/incus.raw.gz",
+					},
+					{
+						Filename: "x86_64/incus.manifest.json.gz",
+					},
+					{
+						Filename: "aarch64/incus.raw.gz",
+					},
+					{
+						Filename: "x86_64/incus-lts-7.0.raw.gz",
+					},
+					{
+						Filename: "x86_64/debug.raw.gz",
+					},
+				},
+			}
+
+			got := update.Applications()
+
+			want := []string{
+				"IncusOS",
+				"incus",
+				"incus-lts-7.0",
+				"debug",
+			}
+
+			require.ElementsMatch(t, want, got)
+		})
+	}
+}
+
 func TestUpdate_Filter(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/shared/api/provisioning_server.go
+++ b/shared/api/provisioning_server.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	incusosapi "github.com/lxc/incus-os/incus-osd/api"
-	"github.com/lxc/incus-os/incus-osd/api/images"
 	incusapi "github.com/lxc/incus/v7/shared/api"
 
 	"github.com/FuturFusion/operations-center/internal/domain"
@@ -477,7 +476,7 @@ func (s *ServerVersionData) Scan(value any) error {
 // Compute the calculated fields of the ServerVersionData. The argument is
 // expected to be a lookup map for the most recent available version
 // for each component.
-func (s *ServerVersionData) Compute(latestAvailableVersions map[images.UpdateFileComponent]string) {
+func (s *ServerVersionData) Compute(osName string, latestAvailableVersions map[string]string) {
 	// Init calculated fields with default values, if no value is currently set.
 	s.NeedsReboot = ptr.To(false)
 	s.InMaintenance = ptr.To(NotInMaintenance)
@@ -499,7 +498,7 @@ func (s *ServerVersionData) Compute(latestAvailableVersions map[images.UpdateFil
 	}
 
 	// Set OS AvailableVersion and NeedUpdate.
-	osLatestAvailableVersion, ok := latestAvailableVersions[images.UpdateFileComponentOS]
+	osLatestAvailableVersion, ok := latestAvailableVersions[osName]
 	if ok {
 		s.OS.AvailableVersion = &osLatestAvailableVersion
 
@@ -513,7 +512,7 @@ func (s *ServerVersionData) Compute(latestAvailableVersions map[images.UpdateFil
 
 	// Set per application AvailableVersion and NeedsUpdate.
 	for i := range s.Applications {
-		appLatestAvailableVersion, ok := latestAvailableVersions[images.UpdateFileComponent(s.Applications[i].Name)]
+		appLatestAvailableVersion, ok := latestAvailableVersions[s.Applications[i].Name]
 		if ok {
 			s.Applications[i].AvailableVersion = &appLatestAvailableVersion
 			s.Applications[i].NeedsUpdate = ptr.To(availableVersionGreaterThan(s.Applications[i].Version, appLatestAvailableVersion))

--- a/shared/api/provisioning_server_test.go
+++ b/shared/api/provisioning_server_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/lxc/incus-os/incus-osd/api/images"
 	"github.com/stretchr/testify/require"
 
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
@@ -488,7 +487,7 @@ func TestServerVersionData_Compute(t *testing.T) {
 	tests := []struct {
 		name                    string
 		serverVersionData       api.ServerVersionData
-		latestAvailableVersions map[images.UpdateFileComponent]string
+		latestAvailableVersions map[string]string
 
 		wantServerVersionData api.ServerVersionData
 	}{
@@ -507,9 +506,9 @@ func TestServerVersionData_Compute(t *testing.T) {
 					},
 				},
 			},
-			latestAvailableVersions: map[images.UpdateFileComponent]string{
-				images.UpdateFileComponentOS:    "202602230000",
-				images.UpdateFileComponentIncus: "202602230000",
+			latestAvailableVersions: map[string]string{
+				"IncusOS": "202602230000",
+				"incus":   "202602230000",
 			},
 			wantServerVersionData: api.ServerVersionData{
 				OS: api.OSVersionData{
@@ -549,9 +548,9 @@ func TestServerVersionData_Compute(t *testing.T) {
 					},
 				},
 			},
-			latestAvailableVersions: map[images.UpdateFileComponent]string{
-				images.UpdateFileComponentOS:    "202602230001",
-				images.UpdateFileComponentIncus: "202602230001",
+			latestAvailableVersions: map[string]string{
+				"IncusOS": "202602230001",
+				"incus":   "202602230001",
 			},
 			wantServerVersionData: api.ServerVersionData{
 				OS: api.OSVersionData{
@@ -592,9 +591,9 @@ func TestServerVersionData_Compute(t *testing.T) {
 					},
 				},
 			},
-			latestAvailableVersions: map[images.UpdateFileComponent]string{
-				images.UpdateFileComponentOS:    "202602230001",
-				images.UpdateFileComponentIncus: "202602230001",
+			latestAvailableVersions: map[string]string{
+				"IncusOS": "202602230001",
+				"incus":   "202602230001",
 			},
 			wantServerVersionData: api.ServerVersionData{
 				OS: api.OSVersionData{
@@ -634,9 +633,9 @@ func TestServerVersionData_Compute(t *testing.T) {
 					},
 				},
 			},
-			latestAvailableVersions: map[images.UpdateFileComponent]string{
-				images.UpdateFileComponentOS:    "202602230000",
-				images.UpdateFileComponentIncus: "202602230001",
+			latestAvailableVersions: map[string]string{
+				"IncusOS": "202602230000",
+				"incus":   "202602230001",
 			},
 			wantServerVersionData: api.ServerVersionData{
 				OS: api.OSVersionData{
@@ -666,7 +665,7 @@ func TestServerVersionData_Compute(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.serverVersionData
-			got.Compute(tc.latestAvailableVersions)
+			got.Compute("IncusOS", tc.latestAvailableVersions)
 
 			require.Equal(t, tc.wantServerVersionData, got)
 		})


### PR DESCRIPTION
Instead of relying on the file component, use the filename to match applications. Otherwise incus-lts-7.0 as well as OS other then IncusOS are not detected properly.