### PR TITLE
Replace yaml package from gopkg.in/yaml.v3 to go.yaml.in/yaml/v4

### DIFF
--- a/cmd/generate-inventory/config.go
+++ b/cmd/generate-inventory/config.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type Config map[string]*Entity

--- a/e2e_tests/basic_operations_center_interactions_test.go
+++ b/e2e_tests/basic_operations_center_interactions_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func basicOperationsCenterInteractions(t *testing.T, tmpDir string) {

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
@@ -185,12 +186,12 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/brianvoe/gofakeit/v7 v7.15.0
-	github.com/docker/go-connections v0.7.0
 	github.com/dsnet/golib/memfile v1.0.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/expr-lang/expr v1.17.8
@@ -229,5 +230,4 @@ require (
 	golang.org/x/sync v0.21.0
 	golang.org/x/text v0.38.0
 	golang.org/x/tools v0.46.0
-	gopkg.in/yaml.v3 v3.0.1
 )

--- a/internal/cli/cmds/image/incus.go
+++ b/internal/cli/cmds/image/incus.go
@@ -13,7 +13,7 @@ import (
 	"github.com/lxc/incus/v7/shared/termios"
 	"github.com/lxc/incus/v7/shared/units"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/image/incus_source.go
+++ b/internal/cli/cmds/image/incus_source.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/lxc/incus/v7/shared/termios"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/provisioning/channel.go
+++ b/internal/cli/cmds/provisioning/channel.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/provisioning/cluster.go
+++ b/internal/cli/cmds/provisioning/cluster.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/lxc/incus/v7/shared/termios"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/provisioning/cluster_template.go
+++ b/internal/cli/cmds/provisioning/cluster_template.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/provisioning/server.go
+++ b/internal/cli/cmds/provisioning/server.go
@@ -15,7 +15,7 @@ import (
 	"github.com/lxc/incus-os/incus-osd/cli"
 	"github.com/lxc/incus/v7/shared/termios"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/provisioning/server_system_network.go
+++ b/internal/cli/cmds/provisioning/server_system_network.go
@@ -9,7 +9,7 @@ import (
 	incusosapi "github.com/lxc/incus-os/incus-osd/api"
 	"github.com/lxc/incus/v7/shared/termios"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/provisioning/server_system_storage.go
+++ b/internal/cli/cmds/provisioning/server_system_storage.go
@@ -9,7 +9,7 @@ import (
 	incusosapi "github.com/lxc/incus-os/incus-osd/api"
 	"github.com/lxc/incus/v7/shared/termios"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/provisioning/token.go
+++ b/internal/cli/cmds/provisioning/token.go
@@ -10,7 +10,7 @@ import (
 	"github.com/lxc/incus-os/incus-osd/api/images"
 	"github.com/lxc/incus/v7/shared/units"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/provisioning/token_seed.go
+++ b/internal/cli/cmds/provisioning/token_seed.go
@@ -13,7 +13,7 @@ import (
 	"github.com/lxc/incus/v7/shared/termios"
 	"github.com/lxc/incus/v7/shared/units"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/provisioning/update.go
+++ b/internal/cli/cmds/provisioning/update.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lxc/incus-os/incus-osd/api/images"
 	"github.com/lxc/incus/v7/shared/units"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/system/network.go
+++ b/internal/cli/cmds/system/network.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/lxc/incus/v7/shared/termios"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/system/security.go
+++ b/internal/cli/cmds/system/security.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/lxc/incus/v7/shared/termios"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/system/settings.go
+++ b/internal/cli/cmds/system/settings.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/lxc/incus/v7/shared/termios"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/cli/cmds/system/updates.go
+++ b/internal/cli/cmds/system/updates.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/lxc/incus/v7/shared/termios"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/cli/validate"
 	"github.com/FuturFusion/operations-center/internal/client"

--- a/internal/config/cli/config.go
+++ b/internal/config/cli/config.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	incusTLS "github.com/lxc/incus/v7/shared/tls"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/shared/api"
 )

--- a/internal/config/daemon/config.go
+++ b/internal/config/daemon/config.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"sync"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/domain"
 	"github.com/FuturFusion/operations-center/internal/environment"

--- a/internal/config/daemon/config_testing.go
+++ b/internal/config/daemon/config_testing.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func InitTest(t *testing.T, testEnv enver, saveErr error, internalConfig ...InternalConfig) {

--- a/internal/provisioning/adapter/flasher/flasher.go
+++ b/internal/provisioning/adapter/flasher/flasher.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/uuid"
 	incusosapi "github.com/lxc/incus-os/incus-osd/api"
 	"github.com/lxc/incus-os/incus-osd/api/seed"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/provisioning"
 	"github.com/FuturFusion/operations-center/shared/api"

--- a/internal/provisioning/adapter/terraform/terraform_test.go
+++ b/internal/provisioning/adapter/terraform/terraform_test.go
@@ -9,7 +9,7 @@ import (
 
 	incusosapi "github.com/lxc/incus-os/incus-osd/api"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/provisioning"
 	"github.com/FuturFusion/operations-center/internal/provisioning/adapter/terraform"

--- a/internal/provisioning/cluster_template/cluster_template_service.go
+++ b/internal/provisioning/cluster_template/cluster_template_service.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/FuturFusion/operations-center/internal/domain"
 	"github.com/FuturFusion/operations-center/internal/provisioning"

--- a/internal/util/render/table.go
+++ b/internal/util/render/table.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Table list format.

--- a/shared/api/config_map_test.go
+++ b/shared/api/config_map_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/lxc/incus/v7/shared/api"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestConfigMap_UnmarshalJSON(t *testing.T) {


### PR DESCRIPTION
@stgraber since Operations Center is pre v1.0, I decided to not care about "to the letter" compatibility of the generated yaml output and therefore skipped the `yaml.v2` compatibility flag.

Resolves: #830