### PR TITLE
provisioning/token: return not found error

### DIFF
--- a/internal/provisioning/token/token_service.go
+++ b/internal/provisioning/token/token_service.go
@@ -349,7 +349,7 @@ func (s *tokenService) getPreSeedImage(ctx context.Context, id uuid.UUID, imageT
 	}
 
 	if filename == "" {
-		return nil, fmt.Errorf("Failed to find image file of type %q for architecture %q in latest update %q", imageType, architecture, latestUpdate.UUID.String())
+		return nil, fmt.Errorf("Failed to find image file of type %q for architecture %q in latest update %q: %w", imageType, architecture, latestUpdate.UUID.String(), domain.ErrNotFound)
 	}
 
 	filereader, _, err := s.updateSvc.GetUpdateFileByFilename(ctx, latestUpdate.UUID, filename)

--- a/internal/provisioning/token/token_service_test.go
+++ b/internal/provisioning/token/token_service_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/provisioning/repo/mock"
 	provisioningToken "github.com/FuturFusion/operations-center/internal/provisioning/token"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
+	"github.com/FuturFusion/operations-center/internal/util/testing/errassert"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 	"github.com/FuturFusion/operations-center/shared/api"
 )
@@ -1801,9 +1802,7 @@ func TestTokenService_GetTokenImageFromTokenSeed(t *testing.T) {
 			},
 			updateSvcGetUpdateAllFilesUpdateFiles: provisioning.UpdateFiles{},
 
-			assertErr: func(tt require.TestingT, err error, a ...any) {
-				require.ErrorContains(tt, err, `Failed to find image file of type "iso" for architecture "x86_64" in latest update "00219aa8-ae44-4306-927e-728a2f780836"`)
-			},
+			assertErr:   errassert.NotFoundErrorContains(`Failed to find image file of type "iso" for architecture "x86_64" in latest update "00219aa8-ae44-4306-927e-728a2f780836"`),
 			wantChannel: "stable", // default value
 		},
 		{


### PR DESCRIPTION
Second attempt, based on https://github.com/FuturFusion/operations-center/issues/910#issuecomment-4768864068, this is the correct fix to return the correct "not found" error.

Resolves: #910 