### PR TITLE
provisioning: Use proposed authentication mode when validating update…

### DIFF
--- a/internal/api/daemon.go
+++ b/internal/api/daemon.go
@@ -593,14 +593,15 @@ func (d *Daemon) setupUpdatesService(ctx context.Context, db dbdriver.DBTX) (pro
 	updateServer := updateserver.New(
 		config.GetUpdates().Source,
 		config.GetUpdates().SignatureVerificationRootCA,
+		config.GetUpdates().ImageServerAuthenticationByQueryParam,
 		d.env,
 	)
 	listenerKey := uuid.New().String()
 	lifecycle.UpdatesValidateSignal.AddListenerWithErr(func(ctx context.Context, su apisystem.Updates) error {
-		return updateServer.SourceConnectionTest(ctx, su.Source, su.SignatureVerificationRootCA)
+		return updateServer.SourceConnectionTest(ctx, su.Source, su.SignatureVerificationRootCA, su.ImageServerAuthenticationByQueryParam)
 	}, listenerKey)
 	lifecycle.UpdatesUpdateSignal.AddListener(func(ctx context.Context, cfg apisystem.Updates) {
-		updateServer.UpdateConfig(ctx, cfg.Source, cfg.SignatureVerificationRootCA)
+		updateServer.UpdateConfig(ctx, cfg.Source, cfg.SignatureVerificationRootCA, cfg.ImageServerAuthenticationByQueryParam)
 	}, listenerKey)
 	runtime.AddCleanup(d, func(listenerKey string) {
 		// config.UpdatesValidateSignal.RemoveListener(listenerKey)

--- a/internal/provisioning/adapter/updateserver/updateserver.go
+++ b/internal/provisioning/adapter/updateserver/updateserver.go
@@ -16,7 +16,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/lxc/incus-os/incus-osd/api/images"
 
-	config "github.com/FuturFusion/operations-center/internal/config/daemon"
 	"github.com/FuturFusion/operations-center/internal/provisioning"
 	"github.com/FuturFusion/operations-center/internal/security/signature"
 	"github.com/FuturFusion/operations-center/internal/util/logger"
@@ -33,6 +32,7 @@ type updateServer struct {
 	configUpdateMu              *sync.Mutex
 	baseURL                     string
 	signatureVerificationRootCA string
+	authenticationByQueryParam  bool
 	verifier                    signature.Verifier
 
 	client        *http.Client
@@ -41,13 +41,14 @@ type updateServer struct {
 
 var _ provisioning.UpdateSourcePort = &updateServer{}
 
-func New(baseURL string, signatureVerificationRootCA string, tokenProvider tokenProvider) *updateServer {
+func New(baseURL string, signatureVerificationRootCA string, authenticationByQueryParam bool, tokenProvider tokenProvider) *updateServer {
 	return &updateServer{
 		configUpdateMu: &sync.Mutex{},
 
 		// Normalize URL, remove trailing slash.
 		baseURL:                     strings.TrimSuffix(baseURL, "/"),
 		signatureVerificationRootCA: signatureVerificationRootCA,
+		authenticationByQueryParam:  authenticationByQueryParam,
 		client:                      http.DefaultClient,
 		verifier:                    signature.NewVerifier([]byte(signatureVerificationRootCA)),
 
@@ -138,6 +139,7 @@ func (u *updateServer) GetLatest(ctx context.Context, limit int) (provisioning.U
 func (u *updateServer) fetchAndVerifyIndexSJSON(ctx context.Context) ([]byte, error) {
 	u.configUpdateMu.Lock()
 	baseURL := u.baseURL
+	authenticationByQueryParam := u.authenticationByQueryParam
 	u.configUpdateMu.Unlock()
 
 	indexURL := baseURL + "/index.sjson"
@@ -148,7 +150,7 @@ func (u *updateServer) fetchAndVerifyIndexSJSON(ctx context.Context) ([]byte, er
 
 	token, err := u.tokenProvider.GetToken(ctx)
 	if err == nil {
-		if config.GetUpdates().ImageServerAuthenticationByQueryParam {
+		if authenticationByQueryParam {
 			q := req.URL.Query()
 			q.Set("token", token)
 			req.URL.RawQuery = q.Encode()
@@ -207,6 +209,7 @@ func uuidFromUpdateServer(update Update) uuid.UUID {
 func (u *updateServer) GetUpdateFileByFilenameUnverified(ctx context.Context, inUpdate provisioning.Update, filename string) (io.ReadCloser, int, error) {
 	u.configUpdateMu.Lock()
 	baseURL := u.baseURL
+	authenticationByQueryParam := u.authenticationByQueryParam
 	u.configUpdateMu.Unlock()
 
 	updateURL := baseURL + path.Join(inUpdate.URL, filename)
@@ -217,7 +220,7 @@ func (u *updateServer) GetUpdateFileByFilenameUnverified(ctx context.Context, in
 
 	token, err := u.tokenProvider.GetToken(ctx)
 	if err == nil {
-		if config.GetUpdates().ImageServerAuthenticationByQueryParam {
+		if authenticationByQueryParam {
 			q := req.URL.Query()
 			q.Set("token", token)
 			req.URL.RawQuery = q.Encode()
@@ -240,27 +243,28 @@ func (u *updateServer) GetUpdateFileByFilenameUnverified(ctx context.Context, in
 	return resp.Body, int(resp.ContentLength), nil
 }
 
-func (u *updateServer) UpdateConfig(_ context.Context, baseURL string, signatureVerificationRootCA string) {
+func (u *updateServer) UpdateConfig(_ context.Context, baseURL string, signatureVerificationRootCA string, authenticationByQueryParam bool) {
 	u.configUpdateMu.Lock()
 	defer u.configUpdateMu.Unlock()
 
 	u.baseURL = strings.TrimSuffix(baseURL, "/")
 	u.signatureVerificationRootCA = signatureVerificationRootCA
+	u.authenticationByQueryParam = authenticationByQueryParam
 	u.verifier = signature.NewVerifier([]byte(signatureVerificationRootCA))
 }
 
-func (u *updateServer) SourceConnectionTest(ctx context.Context, newBaseURL string, newSignatureVerificationRootCA string) error {
+func (u *updateServer) SourceConnectionTest(ctx context.Context, newBaseURL string, newSignatureVerificationRootCA string, newAuthenticationByQueryParam bool) error {
 	u.configUpdateMu.Lock()
-	baseURL, signatureVerificationRootCA := u.baseURL, u.signatureVerificationRootCA
+	baseURL, signatureVerificationRootCA, authenticationByQueryParam := u.baseURL, u.signatureVerificationRootCA, u.authenticationByQueryParam
 	u.configUpdateMu.Unlock()
 
-	if strings.TrimSuffix(baseURL, "/") == strings.TrimSuffix(newBaseURL, "/") && signatureVerificationRootCA == newSignatureVerificationRootCA {
+	if strings.TrimSuffix(baseURL, "/") == strings.TrimSuffix(newBaseURL, "/") && signatureVerificationRootCA == newSignatureVerificationRootCA && authenticationByQueryParam == newAuthenticationByQueryParam {
 		return nil
 	}
 
 	// New instance of updateServer with provided baseURL and signatureVerificationCA
 	// used temporarily for the verification only.
-	updateSvr := New(newBaseURL, newSignatureVerificationRootCA, u.tokenProvider)
+	updateSvr := New(newBaseURL, newSignatureVerificationRootCA, newAuthenticationByQueryParam, u.tokenProvider)
 	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 

--- a/internal/provisioning/adapter/updateserver/updateserver_test.go
+++ b/internal/provisioning/adapter/updateserver/updateserver_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/lxc/incus-os/incus-osd/api/images"
 	"github.com/stretchr/testify/require"
 
-	config "github.com/FuturFusion/operations-center/internal/config/daemon"
 	"github.com/FuturFusion/operations-center/internal/environment/mock"
 	"github.com/FuturFusion/operations-center/internal/provisioning"
 	"github.com/FuturFusion/operations-center/internal/provisioning/adapter/updateserver"
@@ -163,12 +162,6 @@ func TestUpdateServer_GetLatest(t *testing.T) {
 				IsIncusOSFunc: func() bool { return true },
 			}
 
-			config.InitTest(t, envMock, nil)
-			updatesConfig := config.GetUpdates()
-			updatesConfig.ImageServerAuthenticationByQueryParam = tc.queryParameterAuthentication
-			err := config.UpdateUpdates(t.Context(), updatesConfig.UpdatesPut)
-			require.NoError(t, err)
-
 			caCert, cert, key := signaturetest.GenerateCertChain(t)
 
 			body, err := json.Marshal(tc.updates)
@@ -196,7 +189,7 @@ func TestUpdateServer_GetLatest(t *testing.T) {
 			)
 			defer svr.Close()
 
-			s := updateserver.New(svr.URL, string(caCert), envMock)
+			s := updateserver.New(svr.URL, string(caCert), tc.queryParameterAuthentication, envMock)
 			updates, err := s.GetLatest(context.Background(), 1)
 			tc.assertErr(t, err)
 
@@ -257,7 +250,7 @@ func TestUpdateServer_GetUpdateFileByFilename(t *testing.T) {
 				},
 			}
 
-			s := updateserver.New(svr.URL, "", envMock)
+			s := updateserver.New(svr.URL, "", false, envMock)
 			stream, n, err := s.GetUpdateFileByFilenameUnverified(context.Background(), provisioning.Update{
 				URL: "/1",
 			}, "one.txt")


### PR DESCRIPTION
… source config

This fixes an issue where the preferred encoding mode for the token wasn't used when doing config validation (SourceConnectionTest).

This would in turn break provisioning by IncusOS...