### PR TITLE
Retry OIDC and OpenFGA

### DIFF
--- a/internal/api/daemon.go
+++ b/internal/api/daemon.go
@@ -120,6 +120,10 @@ type Daemon struct {
 	oidcVerifier  *authnoidc.Verifier
 	authorizer    *authz.Authorizer
 
+	// securityRetryCancel stops the background connection retries of the
+	// security infrastructure from the previous configuration.
+	securityRetryCancel context.CancelFunc
+
 	server   *http.Server
 	listener *listener.FancyTLSListener
 
@@ -187,6 +191,28 @@ func (d *Daemon) Start(ctx context.Context) error {
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to load security config", logger.Err(err))
 	}
+
+	// On update of the OIDC or OpenFGA configuration, verify the configured
+	// services are reachable, so a broken configuration update is rejected
+	// right away. Connection failures after a successful update are handled
+	// by background retries.
+	lifecycle.SecurityValidateSignal.AddListenerWithErr(func(ctx context.Context, cfg apisystem.Security) error {
+		if cfg.OIDC.Issuer != "" && cfg.OIDC.ClientID != "" {
+			err := authnoidc.CheckConnectivity(ctx, cfg.OIDC.Issuer)
+			if err != nil {
+				return fmt.Errorf("Failed to reach OIDC issuer %q: %w", cfg.OIDC.Issuer, err)
+			}
+		}
+
+		if cfg.OpenFGA.APIURL != "" && cfg.OpenFGA.APIToken != "" && cfg.OpenFGA.StoreID != "" {
+			err := authzopenfga.CheckConnectivity(ctx, cfg.OpenFGA.APIURL, cfg.OpenFGA.APIToken, cfg.OpenFGA.StoreID)
+			if err != nil {
+				return fmt.Errorf("Failed to reach OpenFGA at %q: %w", cfg.OpenFGA.APIURL, err)
+			}
+		}
+
+		return nil
+	})
 
 	// On update of the security configuration, perform reload of the security
 	// related infrastructure.
@@ -467,6 +493,16 @@ func (d *Daemon) securityConfigReload(ctx context.Context, cfg apisystem.Securit
 	d.configReloadMu.Lock()
 	defer d.configReloadMu.Unlock()
 
+	// Cancel background connection retries from the previous configuration.
+	if d.securityRetryCancel != nil {
+		d.securityRetryCancel()
+	}
+
+	// Detached context for background connection retries, which needs to
+	// outlive ctx, e.g. if the reload is triggered by an API request.
+	retryCtx, retryCancel := context.WithCancel(logger.DetachedContext(ctx))
+	d.securityRetryCancel = retryCancel
+
 	var errs []error
 
 	// UnixSocket authenticator is always available.
@@ -477,7 +513,7 @@ func (d *Daemon) securityConfigReload(ctx context.Context, cfg apisystem.Securit
 	// Setup OIDC authentication.
 	if cfg.OIDC.Issuer != "" && cfg.OIDC.ClientID != "" {
 		var err error
-		newOIDCVerifier, err := authnoidc.NewVerifier(context.TODO(), cfg.OIDC.Issuer, cfg.OIDC.ClientID, cfg.OIDC.Scope, cfg.OIDC.Audience, cfg.OIDC.Claim)
+		newOIDCVerifier, err := authnoidc.NewVerifier(retryCtx, cfg.OIDC.Issuer, cfg.OIDC.ClientID, cfg.OIDC.Scope, cfg.OIDC.Audience, cfg.OIDC.Claim)
 		if err != nil {
 			errs = append(errs, err)
 		} else {
@@ -509,7 +545,7 @@ func (d *Daemon) securityConfigReload(ctx context.Context, cfg apisystem.Securit
 	}
 
 	if cfg.OpenFGA.APIURL != "" && cfg.OpenFGA.APIToken != "" && cfg.OpenFGA.StoreID != "" {
-		openfgaAuthorizer, err := authzopenfga.New(ctx, cfg.OpenFGA.APIURL, cfg.OpenFGA.APIToken, cfg.OpenFGA.StoreID)
+		openfgaAuthorizer, err := authzopenfga.New(retryCtx, cfg.OpenFGA.APIURL, cfg.OpenFGA.APIToken, cfg.OpenFGA.StoreID)
 		if err != nil {
 			errs = append(errs, err)
 		} else {
@@ -1717,6 +1753,13 @@ func (d *Daemon) incusOSSelfPoll(ctx context.Context, serverSvc provisioning.Ser
 }
 
 func (d *Daemon) Stop(ctx context.Context) error {
+	d.configReloadMu.Lock()
+	if d.securityRetryCancel != nil {
+		d.securityRetryCancel()
+	}
+
+	d.configReloadMu.Unlock()
+
 	errs := make([]error, 0, len(d.shutdownFuncs)+1)
 
 	for _, shutdown := range d.shutdownFuncs {
@@ -1732,6 +1775,7 @@ func (d *Daemon) Stop(ctx context.Context) error {
 	// Remove all signal listeners.
 	lifecycle.ServerCertificateUpdateSignal.Reset()
 	lifecycle.NetworkUpdateSignal.Reset()
+	lifecycle.SecurityValidateSignal.Reset()
 	lifecycle.SecurityUpdateSignal.Reset()
 	lifecycle.SecurityTrustedHTTPSProxiesUpdateSignal.Reset()
 	lifecycle.SecurityACMEUpdateSignal.Reset()

--- a/internal/config/daemon/config.go
+++ b/internal/config/daemon/config.go
@@ -466,6 +466,9 @@ func validate(ctx context.Context, cfg config) error {
 		return err
 	}
 
+	isOIDCChanged := globalConfigInstance.Security.OIDC != cfg.Security.OIDC
+	isOpenFGAChanged := globalConfigInstance.Security.OpenFGA != cfg.Security.OpenFGA
+
 	{
 		// This is not ideal, but we can not have a direct dependency from the config
 		// because we get a dependency cycles otherwise.
@@ -482,6 +485,15 @@ func validate(ctx context.Context, cfg config) error {
 		err = lifecycle.SettingsValidateSignal.TryEmit(ctx, cfg.Settings)
 		if err != nil {
 			return err
+		}
+
+		// Only emitted on change, since the connectivity probes performed
+		// during validation should not get in the way of unrelated updates.
+		if isOIDCChanged || isOpenFGAChanged {
+			err = lifecycle.SecurityValidateSignal.TryEmit(ctx, cfg.Security)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -14,6 +14,7 @@ var (
 
 	NetworkUpdateSignal = signals.NewSync[apisystem.Network]()
 
+	SecurityValidateSignal                  = signals.NewSync[apisystem.Security]()
 	SecurityUpdateSignal                    = signals.NewSync[apisystem.Security]()
 	SecurityTrustedHTTPSProxiesUpdateSignal = signals.NewSync[[]string]()
 	SecurityACMEUpdateSignal                = signals.NewSync[apisystem.SecurityACME]()

--- a/internal/security/authn/oidc/verifier.go
+++ b/internal/security/authn/oidc/verifier.go
@@ -3,9 +3,11 @@ package oidc
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -15,11 +17,13 @@ import (
 	httphelper "github.com/zitadel/oidc/v3/pkg/http"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"github.com/zitadel/oidc/v3/pkg/op"
+
+	"github.com/FuturFusion/operations-center/internal/util/logger"
 )
 
 // Verifier holds all information needed to verify an access token offline.
 type Verifier struct {
-	accessTokenVerifier *op.AccessTokenVerifier
+	state *verifierState
 
 	clientID  string
 	issuer    string
@@ -27,6 +31,12 @@ type Verifier struct {
 	audience  string
 	claim     string
 	cookieKey []byte
+}
+
+// verifierState is held through a pointer, so copies of Verifier share it.
+type verifierState struct {
+	mu                  sync.Mutex
+	accessTokenVerifier *op.AccessTokenVerifier
 }
 
 // AuthError represents an authentication error.
@@ -68,15 +78,6 @@ func (o *Verifier) Auth(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		}
 
 		token = cookie.Value
-	}
-
-	if o.accessTokenVerifier == nil {
-		var err error
-
-		o.accessTokenVerifier, err = getAccessTokenVerifier(ctx, o.issuer)
-		if err != nil {
-			return "", &AuthError{err}
-		}
 	}
 
 	claims, err := o.VerifyAccessToken(ctx, token)
@@ -278,16 +279,12 @@ func (o *Verifier) Callback(w http.ResponseWriter, r *http.Request) {
 
 // VerifyAccessToken is a wrapper around op.VerifyAccessToken which avoids having to deal with Go generics elsewhere. It validates the access token (issuer, signature and expiration).
 func (o *Verifier) VerifyAccessToken(ctx context.Context, token string) (*oidc.AccessTokenClaims, error) {
-	var err error
-
-	if o.accessTokenVerifier == nil {
-		o.accessTokenVerifier, err = getAccessTokenVerifier(ctx, o.issuer)
-		if err != nil {
-			return nil, err
-		}
+	accessTokenVerifier, err := o.getAccessTokenVerifierCached(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	claims, err := op.VerifyAccessToken[*oidc.AccessTokenClaims](ctx, token, o.accessTokenVerifier)
+	claims, err := op.VerifyAccessToken[*oidc.AccessTokenClaims](ctx, token, accessTokenVerifier)
 	if err != nil {
 		return nil, err
 	}
@@ -340,6 +337,80 @@ func (o *Verifier) getProvider(r *http.Request) (rp.RelyingParty, error) {
 	return provider, nil
 }
 
+// getAccessTokenVerifierCached returns the cached access token verifier,
+// creating it first if not yet available.
+func (o *Verifier) getAccessTokenVerifierCached(ctx context.Context) (*op.AccessTokenVerifier, error) {
+	if o.state == nil {
+		// Zero value Verifier without shared state, no caching possible.
+		return getAccessTokenVerifier(ctx, o.issuer)
+	}
+
+	o.state.mu.Lock()
+	defer o.state.mu.Unlock()
+
+	if o.state.accessTokenVerifier == nil {
+		accessTokenVerifier, err := getAccessTokenVerifier(ctx, o.issuer)
+		if err != nil {
+			return nil, err
+		}
+
+		o.state.accessTokenVerifier = accessTokenVerifier
+	}
+
+	return o.state.accessTokenVerifier, nil
+}
+
+// retryGetAccessTokenVerifier retries to initialize the access token verifier
+// until it succeeds or ctx is cancelled, e.g. if the OIDC issuer was not
+// reachable when the verifier was created.
+func (o *Verifier) retryGetAccessTokenVerifier(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-ticker.C:
+		}
+
+		o.state.mu.Lock()
+		initialized := o.state.accessTokenVerifier != nil
+		o.state.mu.Unlock()
+
+		if initialized {
+			// Already initialized through a request in the meantime.
+			return
+		}
+
+		accessTokenVerifier, err := getAccessTokenVerifier(ctx, o.issuer)
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to initialize OIDC verifier, retrying", slog.String("issuer", o.issuer), logger.Err(err))
+			continue
+		}
+
+		o.state.mu.Lock()
+		o.state.accessTokenVerifier = accessTokenVerifier
+		o.state.mu.Unlock()
+
+		slog.InfoContext(ctx, "OIDC verifier initialized", slog.String("issuer", o.issuer))
+
+		return
+	}
+}
+
+// CheckConnectivity verifies the OIDC issuer is reachable by calling its
+// discovery endpoint.
+func CheckConnectivity(ctx context.Context, issuer string) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	_, err := getAccessTokenVerifier(ctx, issuer)
+
+	return err
+}
+
 // getAccessTokenVerifier calls the OIDC discovery endpoint in order to get the issuer's remote keys which are needed to create an access token verifier.
 func getAccessTokenVerifier(ctx context.Context, issuer string) (*op.AccessTokenVerifier, error) {
 	discoveryConfig, err := client.Discover(ctx, issuer, http.DefaultClient)
@@ -365,10 +436,11 @@ func NewVerifier(ctx context.Context, issuer string, clientid string, scope stri
 		scopes = defaultOidcScopes
 	}
 
-	verifier := &Verifier{issuer: issuer, clientID: clientid, scopes: scopes, audience: audience, cookieKey: cookieKey, claim: claim}
-	verifier.accessTokenVerifier, err = getAccessTokenVerifier(ctx, issuer)
+	verifier := &Verifier{issuer: issuer, clientID: clientid, scopes: scopes, audience: audience, cookieKey: cookieKey, claim: claim, state: &verifierState{}}
+	verifier.state.accessTokenVerifier, err = getAccessTokenVerifier(ctx, issuer)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to initialize OIDC verifier: %w", err)
+		slog.WarnContext(ctx, "Failed to initialize OIDC verifier, retrying in background", slog.String("issuer", issuer), logger.Err(err))
+		go verifier.retryGetAccessTokenVerifier(ctx)
 	}
 
 	return verifier, nil

--- a/internal/security/authz/openfga/openfga_authorizer.go
+++ b/internal/security/authz/openfga/openfga_authorizer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openfga/go-sdk/credentials"
 
 	"github.com/FuturFusion/operations-center/internal/security/authz"
+	"github.com/FuturFusion/operations-center/internal/util/logger"
 	"github.com/FuturFusion/operations-center/shared/api"
 )
 
@@ -28,6 +29,21 @@ func New(ctx context.Context, apiURL string, apiToken string, storeID string) (*
 	var err error
 	f := &FGA{}
 
+	f.client, err = newClient(apiURL, apiToken, storeID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = f.ensureAuthorizationModel(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to initialize OpenFGA authorization model, retrying in background", logger.Err(err))
+		go f.retryEnsureAuthorizationModel(ctx)
+	}
+
+	return f, nil
+}
+
+func newClient(apiURL string, apiToken string, storeID string) (*client.OpenFgaClient, error) {
 	conf := client.ClientConfiguration{
 		ApiUrl:  apiURL,
 		StoreId: storeID,
@@ -39,17 +55,58 @@ func New(ctx context.Context, apiURL string, apiToken string, storeID string) (*
 		},
 	}
 
-	f.client, err = client.NewSdkClient(&conf)
+	c, err := client.NewSdkClient(&conf)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create OpenFGA client: %w", err)
 	}
 
-	err = f.ensureAuthorizationModel(ctx)
+	return c, nil
+}
+
+// CheckConnectivity verifies OpenFGA is reachable with the given credentials
+// and store.
+func CheckConnectivity(ctx context.Context, apiURL string, apiToken string, storeID string) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	c, err := newClient(apiURL, apiToken, storeID)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return f, nil
+	_, err = c.ReadLatestAuthorizationModel(ctx).Execute()
+	if err != nil {
+		return fmt.Errorf("Failed to connect to OpenFGA: %w", err)
+	}
+
+	return nil
+}
+
+// retryEnsureAuthorizationModel retries to ensure the authorization model
+// until it succeeds or ctx is cancelled, e.g. if OpenFGA was not reachable
+// when the authorizer was created.
+func (f *FGA) retryEnsureAuthorizationModel(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-ticker.C:
+		}
+
+		err := f.ensureAuthorizationModel(ctx)
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to initialize OpenFGA authorization model, retrying", logger.Err(err))
+			continue
+		}
+
+		slog.InfoContext(ctx, "OpenFGA authorization model initialized")
+
+		return
+	}
 }
 
 func (f FGA) ensureAuthorizationModel(ctx context.Context) error {


### PR DESCRIPTION
It's pretty common for Operations Center to restart in the middle of a cluster update when the environment may not be at its most consistent. Currently any failure to interact with the IdP or OpenFGA on startup causes those features to be skipped, preventing login.