### PR TITLE
doc: tutorials/deploy-incusos-cluster: fix broken page

### DIFF
--- a/doc/tutorials/deploy-incusos-cluster.md
+++ b/doc/tutorials/deploy-incusos-cluster.md
@@ -321,11 +321,12 @@ By default, IncusOS will prefer IPv6 connectivity if available and after the
 installation, Incus will only be available on the IPv6 address by default. If
 you want to use IPv4 or both instead, you can create a seed file with network
 configuration to enable Incus management an all IP addresses.
+```
 
 Create a seed file `pre-seed.yaml` for the pre-seeded installation ISO with the
 following content:
 
-````yaml
+```yaml
 network:
   version: "1"
   interfaces:
@@ -341,11 +342,11 @@ incus:
   preseed:
     config:
       core.https_address: ":8443"
-````
+```
 
 Optionally add the OIDC client configuration in the `incus.preseed.config` section:
 
-````yaml
+```yaml
 incus:
   preseed:
     config:
@@ -353,7 +354,6 @@ incus:
       oidc.client.id: "<your_client_id>"
       oidc.issuer: "https://sso.linuxcontainers.org"
       oidc.scopes: "openid,offline_access"
-````
 ```
 
 Now get the pre-seeded installation ISO (this process may take a while):


### PR DESCRIPTION
The `Prepare for IncusOS Installation` section of the `Deploy IncusOS Cluster page` is broken.

####  Before and after comparison video.

https://github.com/user-attachments/assets/9d562f69-e4fe-4090-814a-55ea90127dbb

