### PR TITLE
system: skip unregistered servers for provider update on network update

### DIFF
--- a/internal/system/system_service.go
+++ b/internal/system/system_service.go
@@ -230,6 +230,11 @@ func (s *systemService) updateProviderConfigAll(ctx context.Context, cfg map[str
 			continue
 		}
 
+		// Don't update the system provider config for unregistered servers.
+		if server.Status == api.ServerStatusUnregistered {
+			continue
+		}
+
 		oldProviderConfig, err := s.serverSvc.GetSystemProvider(ctx, server.Name)
 		if err != nil {
 			return fmt.Errorf("Failed to get system provider for %q: %w", server.Name, err)

--- a/internal/system/system_service_test.go
+++ b/internal/system/system_service_test.go
@@ -905,6 +905,48 @@ func TestSystemService_UpdateNetworkConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "success - OperationsCenterAddress change - unregistered server skipped",
+			networkConfig: systemapi.Network{
+				NetworkPut: systemapi.NetworkPut{
+					OperationsCenterAddress: "https://new:8443/",
+					RestServerAddress:       "192.168.1.200:8443",
+				},
+			},
+			serverGetAll: provisioning.Servers{
+				{
+					Name: "one",
+					Type: api.ServerTypeIncus,
+				},
+				{
+					Name:   "two",
+					Type:   api.ServerTypeIncus,
+					Status: api.ServerStatusUnregistered,
+				},
+			},
+			serverGetSystemProvider: []queue.Item[incusosapi.SystemProvider]{
+				{
+					Value: incusosapi.SystemProvider{
+						Config: incusosapi.SystemProviderConfig{
+							Config: map[string]string{
+								"server_url": "https://one:8443/",
+							},
+						},
+					},
+				},
+			},
+			serverUpdateSystemProvider: []queue.Item[struct{}]{
+				{},
+			},
+
+			assertErr: require.NoError,
+			wantNetworkConfig: systemapi.Network{
+				NetworkPut: systemapi.NetworkPut{
+					OperationsCenterAddress: "https://new:8443/",
+					RestServerAddress:       "192.168.1.200:8443",
+				},
+			},
+		},
+		{
 			name: "error - NetworkSetDefaults",
 			networkConfig: systemapi.Network{
 				NetworkPut: systemapi.NetworkPut{


### PR DESCRIPTION
Servers in state `pre-register` don't have IncusOS yet, so there is no provider update possible nor do these servers have a an address to connect to.