### PR TITLE
Fix cluster update progress monotonic

### DIFF
--- a/e2e_tests/create_cluster_and_then_cluster_update_test.go
+++ b/e2e_tests/create_cluster_and_then_cluster_update_test.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -93,9 +95,16 @@ func createClusterAndThenClusterUpdate(t *testing.T, tmpDir string) {
 	defer cancel()
 
 	previousUpdateStatusDescription := ""
+	previousStep := 0
+	previousTotalSteps := 0
 
 	for {
-		resp := mustRun(t, `../bin/operations-center.linux.%s provisioning cluster list -f json | jq -r '.[] | select(.name == "%s") | .update_status.in_progress_status.in_progress'`, cpuArch, clusterName)
+		resp := mustRun(t, `../bin/operations-center.linux.%s provisioning cluster list -f json | jq -r '.[] | select(.name == "%s") | .update_status.in_progress_status.error'`, cpuArch, clusterName)
+		if resp.OutputTrimmed() != "" {
+			t.Fatalf("Update cluster failed: %s", resp.OutputTrimmed())
+		}
+
+		resp = mustRun(t, `../bin/operations-center.linux.%s provisioning cluster list -f json | jq -r '.[] | select(.name == "%s") | .update_status.in_progress_status.in_progress'`, cpuArch, clusterName)
 		if resp.OutputTrimmed() == "" {
 			break
 		}
@@ -108,6 +117,25 @@ func createClusterAndThenClusterUpdate(t *testing.T, tmpDir string) {
 		}
 
 		previousUpdateStatusDescription = statusDescription
+
+		// The progress reported to the user must never move backwards.
+		match := clusterUpdateStateRegexp.FindStringSubmatch(statusDescription)
+		if match != nil {
+			step, err := strconv.Atoi(match[1])
+			require.NoError(t, err)
+
+			totalSteps, err := strconv.Atoi(match[2])
+			require.NoError(t, err)
+
+			require.GreaterOrEqualf(t, step, previousStep, "Update cluster: progress moved backwards from %d to %d of %d", previousStep, step, totalSteps)
+
+			if previousTotalSteps != 0 {
+				require.Equalf(t, previousTotalSteps, totalSteps, "Update cluster: total number of steps changed from %d to %d", previousTotalSteps, totalSteps)
+			}
+
+			previousStep = step
+			previousTotalSteps = totalSteps
+		}
 
 		if debug {
 			resp = mustRun(t, `../bin/operations-center.linux.%s provisioning server list -f json | jq '[ .[] | { "server_status": .server_status, "server_status_detail": .server_status_detail, "version_data": .version_data } ]'`, cpuArch)
@@ -123,8 +151,20 @@ func createClusterAndThenClusterUpdate(t *testing.T, tmpDir string) {
 		}
 	}
 
+	// The progress has to have reached the last step and the cluster has to be fully
+	// updated.
+	require.NotZero(t, previousTotalSteps, "Update cluster: no progress has been reported at all")
+	require.Equal(t, previousTotalSteps, previousStep, "Update cluster: the last reported progress is not the last step")
+
+	resp := mustRun(t, `../bin/operations-center.linux.%s provisioning cluster list -f json | jq -r '.[] | select(.name == "%s") | (.update_status.needs_update // []) + (.update_status.needs_reboot // []) | join(",")'`, cpuArch, clusterName)
+	require.Emptyf(t, resp.OutputTrimmed(), "Update cluster: servers still need an update or a reboot: %s", resp.OutputTrimmed())
+
 	t.Log("Update cluster - update completed")
 }
+
+// clusterUpdateStateRegexp matches the step and the total number of steps of the
+// progress description of a rolling cluster update, e.g. "[ 2/27] ...".
+var clusterUpdateStateRegexp = regexp.MustCompile(`\[\s*(\d+)/\s*(\d+)\]`)
 
 func prodChannelCleanup(t *testing.T) func() {
 	t.Helper()

--- a/internal/provisioning/cluster/cluster_service.go
+++ b/internal/provisioning/cluster/cluster_service.go
@@ -14,8 +14,6 @@ import (
 	"net/http"
 	"reflect"
 	"slices"
-	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -71,6 +69,8 @@ type clusterService struct {
 
 	clusterUpdateControlLoopMu        sync.Mutex
 	clusterUpdateControlLoopClusterMu map[string]*sync.Mutex
+
+	clusterUpdateProgress *clusterUpdateProgressLatch
 }
 
 var _ provisioning.ClusterService = &clusterService{}
@@ -158,6 +158,7 @@ func New(
 		removeServerDeleteClusterMemberRetryDelay: 5 * time.Second,
 
 		clusterUpdateControlLoopClusterMu: map[string]*sync.Mutex{},
+		clusterUpdateProgress:             newClusterUpdateProgressLatch(),
 	}
 
 	for _, opt := range opts {
@@ -1411,7 +1412,13 @@ func (s *clusterService) getClusterUpdateStatus(ctx context.Context, name string
 	}
 
 	if clusterUpdateStatus.InProgressStatus.InProgress != api.ClusterUpdateInProgressInactive {
-		clusterUpdateStatus.InProgressStatus.StatusDescription = ptr.To(clusterUpdateState(clusterUpdateStatus.InProgressStatus, servers))
+		// The progress is calculated from a live snapshot of the server states, which
+		// are updated asynchronously from several sources. Pass it through the latch,
+		// so the progress reported to the user never moves backwards.
+		progress := s.clusterUpdateProgress.apply(name, clusterUpdateState(clusterUpdateStatus.InProgressStatus, servers))
+		clusterUpdateStatus.InProgressStatus.StatusDescription = ptr.To(progress.String())
+	} else {
+		s.clusterUpdateProgress.reset(name)
 	}
 
 	return nil
@@ -1501,6 +1508,8 @@ func (s *clusterService) Rename(ctx context.Context, oldName string, newName str
 		return err
 	}
 
+	s.clusterUpdateProgress.reset(oldName)
+
 	lifecycle.ClusterUpdateSignal.Emit(ctx, lifecycle.ClusterUpdateMessage{
 		Operation: lifecycle.ClusterUpdateOperationRename,
 		Name:      newName,
@@ -1521,6 +1530,8 @@ func (s *clusterService) DeleteByName(ctx context.Context, name string, force bo
 		if err != nil {
 			return fmt.Errorf("Failed to delete cluster: %w", err)
 		}
+
+		s.clusterUpdateProgress.reset(name)
 
 		lifecycle.ClusterUpdateSignal.Emit(ctx, lifecycle.ClusterUpdateMessage{
 			Operation: lifecycle.ClusterUpdateOperationDelete,
@@ -1569,6 +1580,8 @@ func (s *clusterService) DeleteByName(ctx context.Context, name string, force bo
 	if err != nil {
 		return fmt.Errorf("Failed to delete cluster: %w", err)
 	}
+
+	s.clusterUpdateProgress.reset(name)
 
 	lifecycle.ClusterUpdateSignal.Emit(ctx, lifecycle.ClusterUpdateMessage{
 		Operation: lifecycle.ClusterUpdateOperationDelete,
@@ -1668,6 +1681,8 @@ func (s *clusterService) DeleteAndFactoryResetByName(ctx context.Context, name s
 	if err != nil {
 		return fmt.Errorf("Failed to delete cluster: %w", err)
 	}
+
+	s.clusterUpdateProgress.reset(name)
 
 	lifecycle.ClusterUpdateSignal.Emit(ctx, lifecycle.ClusterUpdateMessage{
 		Operation: lifecycle.ClusterUpdateOperationDelete,
@@ -1793,6 +1808,8 @@ func (s *clusterService) LaunchClusterUpdate(ctx context.Context, name string, r
 	if err != nil {
 		return err
 	}
+
+	s.clusterUpdateProgress.reset(name)
 
 	if updateDone {
 		return nil
@@ -1974,7 +1991,7 @@ func (s *clusterService) executeRollingUpdate(ctx context.Context, cluster provi
 
 		// To get a consistent log, print the current state before triggering the next action, since
 		// it will likely update the state.
-		updateState := clusterUpdateState(cluster.UpdateStatus.InProgressStatus, servers)
+		updateState := clusterUpdateState(cluster.UpdateStatus.InProgressStatus, servers).String()
 		if updateState != "" {
 			log.InfoContext(ctx, "Cluster rolling update next step", slog.String("cluster_update_state", updateState))
 		}
@@ -2061,21 +2078,24 @@ func (s *clusterService) executeRollingRestartNextStep(ctx context.Context, clus
 	}
 
 	for _, server := range servers {
-		// We intentionally ignore pending updates during during the rolling restart
-		// phase. All servers of a cluster have been updated to the same version
-		// before entering the rolling restart. This procedure should not be
-		// interrupted by new updates appearing while a rolling update is processed.
-		server.VersionData.NeedsUpdate = ptr.To(false)
+		// serverUpdateStateForRollingUpdate intentionally ignores pending updates
+		// during the rolling restart phase. All servers of a cluster have been updated
+		// to the same version before entering the rolling restart. This procedure
+		// should not be interrupted by new updates appearing while a rolling update is
+		// processed. The same state is used to report the progress to the user, so the
+		// reported progress can not disagree with the action taken here.
+		serverUpdateState := serverUpdateStateForRollingUpdate(cluster.UpdateStatus.InProgressStatus.InProgress, server)
 
 		if nextAction == nil {
-			switch server.UpdateState() {
+			switch serverUpdateState {
 			case api.ServerUpdateStateUndefined:
 				return fmt.Errorf("Server update state for %q (%s) is undefined", server.Name, server.ConnectionURL)
 
 			case api.ServerUpdateStateUpToDate:
 				continue
 
-			// Since we set NeedsUpdate = false above, this state is not possible.
+			// Since serverUpdateStateForRollingUpdate reports NeedsUpdate = false, this
+			// state is not possible.
 			// case api.ServerUpdateStateUpdatePending:
 			//
 			case api.ServerUpdateStateUpdating:
@@ -2124,7 +2144,7 @@ func (s *clusterService) executeRollingRestartNextStep(ctx context.Context, clus
 				}
 
 			default:
-				return fmt.Errorf("Server update state %q for %q (%s) is not supported", server.UpdateState(), server.Name, server.ConnectionURL)
+				return fmt.Errorf("Server update state %q for %q (%s) is not supported", serverUpdateState, server.Name, server.ConnectionURL)
 			}
 
 			continue
@@ -2132,7 +2152,7 @@ func (s *clusterService) executeRollingRestartNextStep(ctx context.Context, clus
 
 		// We know the next action so we need to determine, if we are allowed
 		// to perform this action as well as the number of steps, that are pending.
-		switch server.UpdateState() {
+		switch serverUpdateState {
 		case api.ServerUpdateStateUpToDate,
 			api.ServerUpdateStateEvacuationPending:
 			continue
@@ -2140,7 +2160,8 @@ func (s *clusterService) executeRollingRestartNextStep(ctx context.Context, clus
 		case api.ServerUpdateStateUndefined:
 			return fmt.Errorf("Rolling update blocked, server %q (%s) is in unknown state", server.Name, server.ConnectionURL)
 
-		// Since we set NeedsUpdate = false above, this state is not possible.
+		// Since serverUpdateStateForRollingUpdate reports NeedsUpdate = false, this
+		// state is not possible.
 		// case api.ServerUpdateStateUpdatePending:
 		//
 		case api.ServerUpdateStateUpdating:
@@ -2162,13 +2183,13 @@ func (s *clusterService) executeRollingRestartNextStep(ctx context.Context, clus
 			api.ServerUpdateStateInMaintenancePostRestore,
 			api.ServerUpdateStateRebootPending,
 			api.ServerUpdateStateRebooting:
-			return fmt.Errorf("Rolling update blocked, out of order update for server %q (%s) is ongoing, state %v", server.Name, server.ConnectionURL, server.UpdateState())
+			return fmt.Errorf("Rolling update blocked, out of order update for server %q (%s) is ongoing, state %v", server.Name, server.ConnectionURL, serverUpdateState)
 		}
 	}
 
 	// To get a consistent log, print the current state before triggering the next action, since
 	// it will likely update the state.
-	updateState := clusterUpdateState(cluster.UpdateStatus.InProgressStatus, servers)
+	updateState := clusterUpdateState(cluster.UpdateStatus.InProgressStatus, servers).String()
 	if updateState != "" {
 		log.InfoContext(ctx, "Cluster rolling update next step", slog.String("cluster_update_state", updateState))
 	}
@@ -2196,9 +2217,11 @@ func (s *clusterService) executeRollingRestartNextStep(ctx context.Context, clus
 			}
 
 			if errors.Is(err, domain.ErrTerminal) {
-				updateErr := s.updateInProgressStatus(ctx, cluster.Name, api.ClusterUpdateInProgressStatus{
-					Error: err.Error(),
-				})
+				inProgressStatus := cluster.UpdateStatus.InProgressStatus
+				inProgressStatus.InProgress = api.ClusterUpdateInProgressError
+				inProgressStatus.Error = err.Error()
+
+				updateErr := s.updateInProgressStatus(ctx, cluster.Name, inProgressStatus)
 				if updateErr != nil {
 					err = errors.Join(err, updateErr)
 				}
@@ -2241,142 +2264,6 @@ func (s *clusterService) updateInProgressStatus(ctx context.Context, clusterName
 	})
 }
 
-func clusterUpdateState(clusterUpdateInProgressStatus api.ClusterUpdateInProgressStatus, servers provisioning.Servers) string {
-	perServerUpdateSteps := len([]api.ServerUpdateState{
-		api.ServerUpdateStateUpdatePending,
-		api.ServerUpdateStateUpdating,
-	})
-
-	perServerRestartSteps := len([]api.ServerUpdateState{
-		api.ServerUpdateStateEvacuationPending,
-		api.ServerUpdateStateEvacuating,
-		api.ServerUpdateStateInMaintenanceRebootPending,
-		api.ServerUpdateStateInMaintenanceRebooting,
-		api.ServerUpdateStateInMaintenanceRestorePending,
-		api.ServerUpdateStateInMaintenanceRestoring,
-		api.ServerUpdateStateInMaintenancePostRestore,
-	})
-
-	totalSteps := 0
-	pendingSteps := 0
-	currentStep := ""
-	currentServer := ""
-
-	if clusterUpdateInProgressStatus.InProgress == api.ClusterUpdateInProgressError {
-		return clusterUpdateInProgressStatus.Error
-	}
-
-	sort.SliceStable(servers, func(i, j int) bool {
-		return servers[i].Name < servers[j].Name
-	})
-
-	// Check the update states first, since the whole process is applied
-	// in two iterations, first updates and then reboots.
-	switch clusterUpdateInProgressStatus.InProgress {
-	case api.ClusterUpdateInProgressApplyUpdate,
-		api.ClusterUpdateInProgressApplyUpdateWithReboot:
-		withReboot := clusterUpdateInProgressStatus.InProgress == api.ClusterUpdateInProgressApplyUpdateWithReboot
-		perServerSteps := perServerUpdateSteps
-		if withReboot {
-			perServerSteps += perServerRestartSteps
-		}
-
-		firstEvacuationPendingServer := ""
-		for _, server := range servers {
-			totalSteps += perServerSteps
-
-			switch server.UpdateState() {
-			case api.ServerUpdateStateUpdatePending:
-				pendingSteps += perServerSteps
-				if currentServer == "" {
-					currentStep = server.UpdateState().String()
-					currentServer = server.Name
-				}
-
-			case api.ServerUpdateStateUpdating:
-				pendingSteps += perServerSteps - 1
-				currentStep = server.UpdateState().String()
-				currentServer = server.Name
-
-			case api.ServerUpdateStateEvacuationPending,
-				api.ServerUpdateStateEvacuating:
-				if !withReboot {
-					continue
-				}
-
-				pendingSteps += perServerSteps - 2
-				// Don't set the currentServer here, since these servers are ready for evacuation, but we might still have
-				// servers, which are not yet done with updating.
-				if firstEvacuationPendingServer == "" {
-					currentStep = server.UpdateState().String()
-					firstEvacuationPendingServer = server.Name
-				}
-			}
-		}
-
-		// If all servers are properly updated, but we have not yet updated the cluster's
-		// update in progress status, then currentServer might be empty here, so we take
-		// the first server, which is in state evacuation pending.
-		if withReboot && currentServer == "" {
-			currentServer = firstEvacuationPendingServer
-			currentStep = api.ServerUpdateStateEvacuationPending.String()
-		}
-
-	case api.ClusterUpdateInProgressRollingRestart:
-		perServerSteps := perServerUpdateSteps + perServerRestartSteps
-
-		for _, server := range servers {
-			totalSteps += perServerSteps
-
-			switch server.UpdateState() {
-			case api.ServerUpdateStateEvacuationPending:
-				pendingSteps += perServerSteps - 2
-				if currentServer == "" {
-					currentStep = server.UpdateState().String()
-					currentServer = server.Name
-				}
-
-			case api.ServerUpdateStateEvacuating:
-				pendingSteps += perServerSteps - 3
-				currentStep = server.UpdateState().String()
-				currentServer = server.Name
-
-			case api.ServerUpdateStateInMaintenanceRebootPending:
-				pendingSteps += perServerSteps - 4
-				currentStep = server.UpdateState().String()
-				currentServer = server.Name
-
-			case api.ServerUpdateStateInMaintenanceRebooting:
-				pendingSteps += perServerSteps - 5
-				currentStep = server.UpdateState().String()
-				currentServer = server.Name
-
-			case api.ServerUpdateStateInMaintenanceRestorePending:
-				pendingSteps += perServerSteps - 6
-				currentStep = server.UpdateState().String()
-				currentServer = server.Name
-
-			case api.ServerUpdateStateInMaintenanceRestoring:
-				pendingSteps += perServerSteps - 7
-				currentStep = server.UpdateState().String()
-				currentServer = server.Name
-
-			case api.ServerUpdateStateInMaintenancePostRestore:
-				pendingSteps += perServerSteps - 8
-				currentStep = server.UpdateState().String()
-				currentServer = server.Name
-			}
-		}
-	}
-
-	if pendingSteps > 0 {
-		format := fmt.Sprintf("[%%%[1]dd/%%%[1]dd] %%s server %%q", len(strconv.Itoa(totalSteps)))
-		return fmt.Sprintf(format, totalSteps-pendingSteps+1, totalSteps, currentStep, currentServer)
-	}
-
-	return ""
-}
-
 func (s *clusterService) AbortClusterUpdate(ctx context.Context, name string) error {
 	err := transaction.Do(ctx, func(ctx context.Context) error {
 		cluster, err := s.repo.GetByName(ctx, name)
@@ -2398,6 +2285,8 @@ func (s *clusterService) AbortClusterUpdate(ctx context.Context, name string) er
 	if err != nil {
 		return err
 	}
+
+	s.clusterUpdateProgress.reset(name)
 
 	return nil
 }

--- a/internal/provisioning/cluster/cluster_service_internal_test.go
+++ b/internal/provisioning/cluster/cluster_service_internal_test.go
@@ -1,13 +1,16 @@
 package cluster
 
 import (
+	"context"
 	"testing"
 
 	incusosapi "github.com/lxc/incus-os/incus-osd/api"
 	"github.com/stretchr/testify/require"
 
 	"github.com/FuturFusion/operations-center/internal/provisioning"
+	serviceMock "github.com/FuturFusion/operations-center/internal/provisioning/mock"
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
+	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/shared/api"
 )
 
@@ -192,6 +195,7 @@ func Test_clusterUpdateState(t *testing.T) {
 		name                          string
 		clusterUpdateInProgressStatus api.ClusterUpdateInProgressStatus
 		serverStates                  []api.ServerUpdateState
+		newUpdateAvailable            bool
 
 		want string
 	}{
@@ -380,6 +384,110 @@ func Test_clusterUpdateState(t *testing.T) {
 
 			want: `[27/27] post restore server "serverC"`,
 		},
+
+		// Servers, which have been evacuated before the update was triggered, are kept
+		// evacuated and therefore have no restore step ahead of them.
+		{
+			name: "apply update with reboot - server evacuated before is not restored",
+			clusterUpdateInProgressStatus: api.ClusterUpdateInProgressStatus{
+				InProgress:      api.ClusterUpdateInProgressApplyUpdateWithReboot,
+				EvacuatedBefore: []string{"serverA"},
+			},
+			serverStates: []api.ServerUpdateState{
+				api.ServerUpdateStateInMaintenanceRestorePending,
+				api.ServerUpdateStateEvacuationPending,
+				api.ServerUpdateStateEvacuationPending,
+			},
+
+			want: `[14/27] evacuation pending server "serverB"`,
+		},
+		{
+			name: "rolling restart - server evacuated before is not restored",
+			clusterUpdateInProgressStatus: api.ClusterUpdateInProgressStatus{
+				InProgress:      api.ClusterUpdateInProgressRollingRestart,
+				EvacuatedBefore: []string{"serverA"},
+			},
+			serverStates: []api.ServerUpdateState{
+				api.ServerUpdateStateInMaintenanceRestorePending,
+				api.ServerUpdateStateEvacuationPending,
+				api.ServerUpdateStateEvacuationPending,
+			},
+
+			// Identical to the apply update phase above, the phase transition must not
+			// change the reported progress.
+			want: `[14/27] evacuation pending server "serverB"`,
+		},
+		{
+			name: "rolling restart - all servers done, server evacuated before stays evacuated",
+			clusterUpdateInProgressStatus: api.ClusterUpdateInProgressStatus{
+				InProgress:      api.ClusterUpdateInProgressRollingRestart,
+				EvacuatedBefore: []string{"serverA"},
+			},
+			serverStates: []api.ServerUpdateState{
+				api.ServerUpdateStateInMaintenanceRestorePending,
+				api.ServerUpdateStateUpToDate,
+				api.ServerUpdateStateUpToDate,
+			},
+
+			want: "",
+		},
+
+		// States, which are not part of the rolling update, are counted as not started.
+		{
+			name: "rolling restart - undefined state counts as not started",
+			clusterUpdateInProgressStatus: api.ClusterUpdateInProgressStatus{
+				InProgress: api.ClusterUpdateInProgressRollingRestart,
+			},
+			serverStates: []api.ServerUpdateState{
+				api.ServerUpdateStateUndefined,
+				api.ServerUpdateStateUpToDate,
+				api.ServerUpdateStateUpToDate,
+			},
+
+			want: `[19/27] undefined server "serverA"`,
+		},
+		{
+			name: "rolling restart - rebooting outside of maintenance counts as not started",
+			clusterUpdateInProgressStatus: api.ClusterUpdateInProgressStatus{
+				InProgress: api.ClusterUpdateInProgressRollingRestart,
+			},
+			serverStates: []api.ServerUpdateState{
+				api.ServerUpdateStateUpToDate,
+				api.ServerUpdateStateUpToDate,
+				api.ServerUpdateStateRebooting,
+			},
+
+			want: `[19/27] rebooting server "serverC"`,
+		},
+		{
+			name: "apply update with reboot - server updating applications is reported as updating",
+			clusterUpdateInProgressStatus: api.ClusterUpdateInProgressStatus{
+				InProgress: api.ClusterUpdateInProgressApplyUpdateWithReboot,
+			},
+			serverStates: []api.ServerUpdateState{
+				serverUpdateStateUpdatingApplication,
+				api.ServerUpdateStateUpdatePending,
+				api.ServerUpdateStateUpdatePending,
+			},
+
+			want: `[ 2/27] updating server "serverA"`,
+		},
+
+		// A newly published update must not interrupt an ongoing rolling restart.
+		{
+			name: "rolling restart - newly available update does not rewind the progress",
+			clusterUpdateInProgressStatus: api.ClusterUpdateInProgressStatus{
+				InProgress: api.ClusterUpdateInProgressRollingRestart,
+			},
+			serverStates: []api.ServerUpdateState{
+				api.ServerUpdateStateInMaintenanceRebootPending,
+				api.ServerUpdateStateEvacuationPending,
+				api.ServerUpdateStateEvacuationPending,
+			},
+			newUpdateAvailable: true,
+
+			want: `[ 9/27] in maintenance, reboot pending server "serverA"`,
+		},
 	}
 
 	serverNames := []string{"serverA", "serverB", "serverC"}
@@ -388,18 +496,75 @@ func Test_clusterUpdateState(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			servers := make(provisioning.Servers, 0, len(tc.serverStates))
 			for i, state := range tc.serverStates {
-				servers = append(servers, clusterUpdateStateTestServer(t, serverNames[i], state))
+				server := clusterUpdateStateTestServer(t, serverNames[i], state)
+				if tc.newUpdateAvailable {
+					server.VersionData.NeedsUpdate = ptr.To(true)
+				}
+
+				servers = append(servers, server)
 			}
 
-			got := clusterUpdateState(tc.clusterUpdateInProgressStatus, servers)
+			got := clusterUpdateState(tc.clusterUpdateInProgressStatus, servers).String()
 
 			require.Equal(t, tc.want, got)
 		})
 	}
 }
 
+func Test_clusterUpdateState_phaseTransitionKeepsProgress(t *testing.T) {
+	// The rolling update advances from the apply update phase to the rolling restart
+	// phase once all servers are updated. Both phases have to report the same
+	// progress for a given server state, otherwise the progress reported to the user
+	// jumps at the moment the phase changes.
+	serverNames := []string{"serverA", "serverB", "serverC"}
+
+	// Only the restart states are relevant, the phase does not change before all
+	// servers have passed the update states.
+	for _, state := range clusterUpdateSteps[clusterUpdateUpdateSteps:] {
+		t.Run(string(state), func(t *testing.T) {
+			servers := make(provisioning.Servers, 0, len(serverNames))
+			for _, name := range serverNames {
+				servers = append(servers, clusterUpdateStateTestServer(t, name, state))
+			}
+
+			applyUpdate := clusterUpdateState(api.ClusterUpdateInProgressStatus{
+				InProgress: api.ClusterUpdateInProgressApplyUpdateWithReboot,
+			}, servers)
+
+			rollingRestart := clusterUpdateState(api.ClusterUpdateInProgressStatus{
+				InProgress: api.ClusterUpdateInProgressRollingRestart,
+			}, servers)
+
+			require.Equal(t, applyUpdate, rollingRestart)
+		})
+	}
+}
+
+func Test_clusterUpdateState_doesNotReorderServers(t *testing.T) {
+	// clusterUpdateState is called with the servers of a cluster while the caller is
+	// iterating over them, so it must not reorder the slice it is given.
+	servers := provisioning.Servers{
+		clusterUpdateStateTestServer(t, "serverC", api.ServerUpdateStateUpdatePending),
+		clusterUpdateStateTestServer(t, "serverA", api.ServerUpdateStateUpdatePending),
+		clusterUpdateStateTestServer(t, "serverB", api.ServerUpdateStateUpdatePending),
+	}
+
+	got := clusterUpdateState(api.ClusterUpdateInProgressStatus{
+		InProgress: api.ClusterUpdateInProgressApplyUpdateWithReboot,
+	}, servers).String()
+
+	require.Equal(t, `[ 1/27] update pending server "serverA"`, got)
+	require.Equal(t, []string{"serverC", "serverA", "serverB"}, []string{servers[0].Name, servers[1].Name, servers[2].Name})
+}
+
+// serverUpdateStateUpdatingApplication is a test only marker for a server, which is
+// updating its applications. api.Server.UpdateState reports "undefined" for it.
+const serverUpdateStateUpdatingApplication = api.ServerUpdateState("updating application")
+
 func clusterUpdateStateTestServer(t *testing.T, name string, state api.ServerUpdateState) provisioning.Server {
 	t.Helper()
+
+	wantState := state
 
 	server := provisioning.Server{
 		Name:         name,
@@ -453,11 +618,112 @@ func clusterUpdateStateTestServer(t *testing.T, name string, state api.ServerUpd
 	case api.ServerUpdateStateInMaintenancePostRestore:
 		server.StatusDetail = api.ServerStatusDetailReadyRestoring
 
+	case api.ServerUpdateStateRebootPending:
+		// A reboot is only pending outside of maintenance for servers, which are not
+		// part of an Incus cluster.
+		server.Cluster = nil
+		server.VersionData.NeedsReboot = ptr.To(true)
+
+	case api.ServerUpdateStateRebooting:
+		server.Status = api.ServerStatusOffline
+		server.StatusDetail = api.ServerStatusDetailOfflineRebooting
+
+	case api.ServerUpdateStateUndefined:
+		server.Status = api.ServerStatusUnknown
+
+	case serverUpdateStateUpdatingApplication:
+		server.StatusDetail = api.ServerStatusDetailReadyUpdatingApplication
+		wantState = api.ServerUpdateStateUndefined
+
 	default:
 		t.Fatalf("unsupported server update state %q", state)
 	}
 
-	require.Equal(t, state, server.UpdateState())
+	require.Equal(t, wantState, server.UpdateState())
 
 	return server
+}
+
+func TestClusterService_getClusterUpdateStatus_progressOnlyMovesForward(t *testing.T) {
+	// The update state of a server is derived from data, which is refreshed
+	// asynchronously from several sources, so a server can briefly fall back to an
+	// earlier state.
+	serverStates := []api.ServerUpdateState{
+		api.ServerUpdateStateUpdating,
+		api.ServerUpdateStateUpdatePending, // Falls back, the version data is not refreshed yet.
+		api.ServerUpdateStateEvacuationPending,
+	}
+
+	serverSvcGetAllWithFilter := make([]queue.Item[provisioning.Servers], 0, len(serverStates))
+	for _, state := range serverStates {
+		serverSvcGetAllWithFilter = append(serverSvcGetAllWithFilter, queue.Item[provisioning.Servers]{
+			Value: provisioning.Servers{
+				clusterUpdateStateTestServer(t, "serverA", state),
+				clusterUpdateStateTestServer(t, "serverB", api.ServerUpdateStateUpdatePending),
+				clusterUpdateStateTestServer(t, "serverC", api.ServerUpdateStateUpdatePending),
+			},
+		})
+	}
+
+	serverSvc := &serviceMock.ServerServiceMock{
+		GetAllWithFilterFunc: func(ctx context.Context, filter provisioning.ServerFilter) (provisioning.Servers, error) {
+			return queue.Pop(t, &serverSvcGetAllWithFilter)
+		},
+	}
+
+	clusterSvc := New(nil, nil, nil, serverSvc, nil, nil, nil, nil)
+
+	ctx := context.Background()
+
+	got := make([]string, 0, len(serverStates))
+	for range serverStates {
+		clusterUpdateStatus := api.ClusterUpdateStatus{
+			InProgressStatus: api.ClusterUpdateInProgressStatus{
+				InProgress: api.ClusterUpdateInProgressApplyUpdateWithReboot,
+			},
+		}
+
+		err := clusterSvc.getClusterUpdateStatus(ctx, "clusterA", &clusterUpdateStatus)
+		require.NoError(t, err)
+
+		got = append(got, ptr.From(clusterUpdateStatus.InProgressStatus.StatusDescription))
+	}
+
+	require.Equal(t, []string{
+		`[ 2/27] updating server "serverA"`,
+		`[ 2/27] updating server "serverA"`, // Held back, the calculated progress would be 1/27.
+		`[ 3/27] update pending server "serverB"`,
+	}, got)
+
+	// Once the update is done, the recorded progress is dropped, so the next rolling
+	// update of this cluster starts reporting from the beginning again.
+	serverSvcGetAllWithFilter = []queue.Item[provisioning.Servers]{
+		{
+			Value: provisioning.Servers{
+				clusterUpdateStateTestServer(t, "serverA", api.ServerUpdateStateUpToDate),
+			},
+		},
+		{
+			Value: provisioning.Servers{
+				clusterUpdateStateTestServer(t, "serverA", api.ServerUpdateStateUpdatePending),
+				clusterUpdateStateTestServer(t, "serverB", api.ServerUpdateStateUpdatePending),
+				clusterUpdateStateTestServer(t, "serverC", api.ServerUpdateStateUpdatePending),
+			},
+		},
+	}
+
+	inactive := api.ClusterUpdateStatus{}
+	err := clusterSvc.getClusterUpdateStatus(ctx, "clusterA", &inactive)
+	require.NoError(t, err)
+	require.Nil(t, inactive.InProgressStatus.StatusDescription)
+
+	relaunched := api.ClusterUpdateStatus{
+		InProgressStatus: api.ClusterUpdateInProgressStatus{
+			InProgress: api.ClusterUpdateInProgressApplyUpdateWithReboot,
+		},
+	}
+
+	err = clusterSvc.getClusterUpdateStatus(ctx, "clusterA", &relaunched)
+	require.NoError(t, err)
+	require.Equal(t, `[ 1/27] update pending server "serverA"`, ptr.From(relaunched.InProgressStatus.StatusDescription))
 }

--- a/internal/provisioning/cluster/cluster_service_update_control_loop_test.go
+++ b/internal/provisioning/cluster/cluster_service_update_control_loop_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -32,8 +31,6 @@ import (
 	"github.com/FuturFusion/operations-center/internal/util/logger"
 	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
-	"github.com/FuturFusion/operations-center/internal/util/testing/flaky"
-	"github.com/FuturFusion/operations-center/internal/util/testing/log"
 	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
 	"github.com/FuturFusion/operations-center/internal/util/testing/uuidgen"
 	"github.com/FuturFusion/operations-center/shared/api"
@@ -62,7 +59,7 @@ func TestClusterService_ClusterUpdateControlLoopSingleNodeCluster(t *testing.T) 
 		Channel:       "stable",
 		Config: api.ClusterConfig{
 			RollingRestart: api.ClusterConfigRollingRestart{
-				PostRestoreDelay: (4 * asyncActionsDelay).String(),
+				PostRestoreDelay: (2 * controlLoopInterval).String(),
 			},
 		},
 	}
@@ -98,24 +95,24 @@ func TestClusterService_ClusterUpdateControlLoopSingleNodeCluster(t *testing.T) 
 		Channel:      "stable",
 	}
 
-	serverVersionDataMu := sync.Mutex{}
-	serverVersionData := api.ServerVersionData{
-		OS: api.OSVersionData{
-			Name:        "incusos",
-			Version:     "1",
-			VersionNext: "1",
-			NeedsReboot: false,
-		},
-		Applications: []api.ApplicationVersionData{
-			{
-				Name:          "incus",
-				Version:       "1",
-				InMaintenance: api.NotInMaintenance,
+	world := newServerWorld(map[string]api.ServerVersionData{
+		"one": {
+			OS: api.OSVersionData{
+				Name:        "incusos",
+				Version:     "1",
+				VersionNext: "1",
+				NeedsReboot: false,
 			},
+			Applications: []api.ApplicationVersionData{
+				{
+					Name:          "incus",
+					Version:       "1",
+					InMaintenance: api.NotInMaintenance,
+				},
+			},
+			UpdateChannel: "stable",
 		},
-		UpdateChannel: "stable",
-	}
-	serverRebooting := false
+	})
 
 	// Setup
 	ctx, cancel := context.WithTimeout(t.Context(), asyncActionsDelay*50)
@@ -185,10 +182,7 @@ func TestClusterService_ClusterUpdateControlLoopSingleNodeCluster(t *testing.T) 
 			return nil
 		},
 		PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
-			serverVersionDataMu.Lock()
-			defer serverVersionDataMu.Unlock()
-
-			if serverRebooting {
+			if world.isRebooting(endpoint.GetName()) {
 				return domain.NewRetryableErr(errors.New("rebooting"))
 			}
 
@@ -219,207 +213,46 @@ func TestClusterService_ClusterUpdateControlLoopSingleNodeCluster(t *testing.T) 
 			}, nil
 		},
 		GetVersionDataFunc: func(ctx context.Context, server provisioning.Server) (api.ServerVersionData, error) {
-			serverVersionDataMu.Lock()
-			defer serverVersionDataMu.Unlock()
-
-			return serverVersionData, nil
+			return world.getVersionData(server.Name), nil
 		},
 		GetServerTypeFunc: func(ctx context.Context, endpoint provisioning.Endpoint) (api.ServerType, error) {
 			return api.ServerTypeIncus, nil
 		},
 		UpdateOSFunc: func(ctx context.Context, server provisioning.Server) error {
-			go func() {
-				time.Sleep(asyncActionsDelay)
-
-				serverVersionDataMu.Lock()
-				defer serverVersionDataMu.Unlock()
-
-				serverVersionData = api.ServerVersionData{
-					OS: api.OSVersionData{
-						Name:        "incusos",
-						Version:     "1",
-						VersionNext: "2",
-						NeedsReboot: true,
-					},
-					Applications: []api.ApplicationVersionData{
-						{
-							Name:          "incus",
-							Version:       "2",
-							InMaintenance: api.NotInMaintenance,
-						},
-					},
-					UpdateChannel: "stable",
-				}
-			}()
-
-			serverVersionDataMu.Lock()
-			defer serverVersionDataMu.Unlock()
-
-			serverVersionData = api.ServerVersionData{
-				OS: api.OSVersionData{
-					Name:        "incusos",
-					Version:     "1",
-					VersionNext: "1",
-					NeedsReboot: false,
-				},
-				Applications: []api.ApplicationVersionData{
-					{
-						Name:          "incus",
-						Version:       "1",
-						InMaintenance: api.NotInMaintenance,
-					},
-				},
-				UpdateChannel: "stable",
-			}
+			world.set(server.Name, versionDataUpdating, false)
+			world.deferTransition(serverWorldTransition{
+				server:      server.Name,
+				versionData: versionDataUpdated,
+			})
 
 			return nil
 		},
 		EvacuateFunc: func(ctx context.Context, server provisioning.Server, callback func(ctx context.Context, err error)) error {
-			go func() {
-				time.Sleep(asyncActionsDelay)
-
-				serverVersionDataMu.Lock()
-				defer serverVersionDataMu.Unlock()
-
-				serverVersionData = api.ServerVersionData{
-					OS: api.OSVersionData{
-						Name:        "incusos",
-						Version:     "1",
-						VersionNext: "2",
-						NeedsReboot: true,
-					},
-					Applications: []api.ApplicationVersionData{
-						{
-							Name:          "incus",
-							Version:       "2",
-							InMaintenance: api.InMaintenanceEvacuated,
-						},
-					},
-					UpdateChannel: "stable",
-				}
-
-				callback(t.Context(), nil)
-			}()
-
-			serverVersionDataMu.Lock()
-			defer serverVersionDataMu.Unlock()
-
-			serverVersionData = api.ServerVersionData{
-				OS: api.OSVersionData{
-					Name:        "incusos",
-					Version:     "1",
-					VersionNext: "2",
-					NeedsReboot: true,
-				},
-				Applications: []api.ApplicationVersionData{
-					{
-						Name:          "incus",
-						Version:       "2",
-						InMaintenance: api.InMaintenanceEvacuating,
-					},
-				},
-				UpdateChannel: "stable",
-			}
+			world.set(server.Name, versionDataEvacuating, false)
+			world.deferTransition(serverWorldTransition{
+				server:      server.Name,
+				versionData: versionDataEvacuated,
+				callback:    callback,
+			})
 
 			return nil
 		},
 		RebootFunc: func(ctx context.Context, server provisioning.Server) error {
-			go func() {
-				time.Sleep(asyncActionsDelay)
-
-				serverVersionDataMu.Lock()
-				defer serverVersionDataMu.Unlock()
-
-				serverVersionData = api.ServerVersionData{
-					OS: api.OSVersionData{
-						Name:        "incusos",
-						Version:     "2",
-						VersionNext: "2",
-						NeedsReboot: false,
-					},
-					Applications: []api.ApplicationVersionData{
-						{
-							Name:          "incus",
-							Version:       "2",
-							InMaintenance: api.InMaintenanceEvacuated,
-						},
-					},
-					UpdateChannel: "stable",
-				}
-
-				serverRebooting = false
-			}()
-
-			serverVersionDataMu.Lock()
-			defer serverVersionDataMu.Unlock()
-
-			serverVersionData = api.ServerVersionData{
-				OS: api.OSVersionData{
-					Name:        "incusos",
-					Version:     "2",
-					VersionNext: "2",
-					NeedsReboot: true,
-				},
-				Applications: []api.ApplicationVersionData{
-					{
-						Name:          "incus",
-						Version:       "2",
-						InMaintenance: api.InMaintenanceEvacuated,
-					},
-				},
-				UpdateChannel: "stable",
-			}
-
-			serverRebooting = true
+			world.set(server.Name, versionDataRebooting, true)
+			world.deferTransition(serverWorldTransition{
+				server:      server.Name,
+				versionData: versionDataRebooted,
+			})
 
 			return nil
 		},
 		RestoreFunc: func(ctx context.Context, server provisioning.Server, restoreModeSkip bool, callback func(ctx context.Context, err error)) error {
-			go func() {
-				time.Sleep(asyncActionsDelay)
-
-				serverVersionDataMu.Lock()
-				defer serverVersionDataMu.Unlock()
-
-				serverVersionData = api.ServerVersionData{
-					OS: api.OSVersionData{
-						Name:        "incusos",
-						Version:     "2",
-						VersionNext: "2",
-						NeedsReboot: false,
-					},
-					Applications: []api.ApplicationVersionData{
-						{
-							Name:          "incus",
-							Version:       "2",
-							InMaintenance: api.NotInMaintenance,
-						},
-					},
-					UpdateChannel: "stable",
-				}
-
-				callback(t.Context(), nil)
-			}()
-
-			serverVersionDataMu.Lock()
-			defer serverVersionDataMu.Unlock()
-
-			serverVersionData = api.ServerVersionData{
-				OS: api.OSVersionData{
-					Name:        "incusos",
-					Version:     "2",
-					VersionNext: "2",
-					NeedsReboot: false,
-				},
-				Applications: []api.ApplicationVersionData{
-					{
-						Name:          "incus",
-						Version:       "2",
-						InMaintenance: api.InMaintenanceRestoring,
-					},
-				},
-				UpdateChannel: "stable",
-			}
+			world.set(server.Name, versionDataRestoring, false)
+			world.deferTransition(serverWorldTransition{
+				server:      server.Name,
+				versionData: versionDataRestored,
+				callback:    callback,
+			})
 
 			return nil
 		},
@@ -455,6 +288,8 @@ func TestClusterService_ClusterUpdateControlLoopSingleNodeCluster(t *testing.T) 
 	err = clusterSvc.LaunchClusterUpdate(ctx, "clusterA", true)
 	require.NoError(t, err)
 
+	var observed []string
+
 	success := false
 	for range 100 {
 		c, err := clusterSvc.GetByName(ctx, "clusterA")
@@ -464,28 +299,43 @@ func TestClusterService_ClusterUpdateControlLoopSingleNodeCluster(t *testing.T) 
 			break
 		}
 
+		require.Empty(t, c.UpdateStatus.InProgressStatus.Error)
+
+		// Observe the progress the same way a user does.
+		observed = append(observed, ptr.From(c.UpdateStatus.InProgressStatus.StatusDescription))
+
+		// A server completes an action, which has been triggered on it, asynchronously.
+		// Let it complete only if it was already running before this iteration, so that
+		// the state, the action leads to, is reported at least once.
+		pending := world.pendingCount()
+
 		err = clusterSvc.ClusterUpdateControlLoop(ctx, nil)
 		if !domain.IsRetryableError(err) {
 			require.NoError(t, err)
+		}
+
+		if pending > 0 {
+			world.release(ctx)
 		}
 
 		time.Sleep(controlLoopInterval)
 	}
 
 	require.True(t, success)
-	log.Contains(`[1/9] update pending server \"one\"`)(t, logBuf)
 
-	log.Contains(`[3/9] evacuation pending server \"one\"`)(t, logBuf)
-	log.Contains(`[5/9] in maintenance, reboot pending server \"one\"`)(t, logBuf)
-	log.Contains(`[6/9] in maintenance, rebooting server \"one\"`)(t, logBuf)
-	log.Contains(`[7/9] in maintenance, restore pending server \"one\"`)(t, logBuf)
-	log.Contains(`[8/9] restoring server \"one\"`)(t, logBuf)
-	log.Contains(`[9/9] post restore server \"one\"`)(t, logBuf)
+	requireProgressOnlyMovesForward(t, observed)
 
-	// "updating server" might be skipped in some occations.
-	log.Contains(`[2/9] updating server \"one\"`)(flaky.SkipOnFail(t, `"updating server" does not always appear in the logs`), logBuf)
-	// "evacuating server" might be skipped in some occations.
-	log.Contains(`[4/9] evacuating server \"one\"`)(flaky.SkipOnFail(t, `"evacuating server" does not always appear in the logs`), logBuf)
+	require.Equal(t, []string{
+		`[1/9] update pending server "one"`,
+		`[2/9] updating server "one"`,
+		`[3/9] evacuation pending server "one"`,
+		`[4/9] evacuating server "one"`,
+		`[5/9] in maintenance, reboot pending server "one"`,
+		`[6/9] in maintenance, rebooting server "one"`,
+		`[7/9] in maintenance, restore pending server "one"`,
+		`[8/9] restoring server "one"`,
+		`[9/9] post restore server "one"`,
+	}, clusterUpdateStatesFromLog(t, logBuf.String()))
 }
 
 func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
@@ -518,7 +368,7 @@ func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
 		Channel:       "stable",
 		Config: api.ClusterConfig{
 			RollingRestart: api.ClusterConfigRollingRestart{
-				PostRestoreDelay: (4 * asyncActionsDelay).String(),
+				PostRestoreDelay: (2 * controlLoopInterval).String(),
 			},
 		},
 	}
@@ -616,62 +466,11 @@ func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
 		Channel:      "stable",
 	}
 
-	serverVersionDataMu := sync.Mutex{}
-	serverVersionData := map[string]api.ServerVersionData{
-		"serverA": {
-			OS: api.OSVersionData{
-				Name:        "incusos",
-				Version:     "1",
-				VersionNext: "1",
-				NeedsReboot: false,
-			},
-			Applications: []api.ApplicationVersionData{
-				{
-					Name:          "incus",
-					Version:       "1",
-					InMaintenance: api.NotInMaintenance,
-				},
-			},
-			UpdateChannel: "stable",
-		},
-		"serverB": {
-			OS: api.OSVersionData{
-				Name:        "incusos",
-				Version:     "1",
-				VersionNext: "1",
-				NeedsReboot: false,
-			},
-			Applications: []api.ApplicationVersionData{
-				{
-					Name:          "incus",
-					Version:       "1",
-					InMaintenance: api.NotInMaintenance,
-				},
-			},
-			UpdateChannel: "stable",
-		},
-		"serverC": {
-			OS: api.OSVersionData{
-				Name:        "incusos",
-				Version:     "1",
-				VersionNext: "1",
-				NeedsReboot: false,
-			},
-			Applications: []api.ApplicationVersionData{
-				{
-					Name:          "incus",
-					Version:       "1",
-					InMaintenance: api.NotInMaintenance,
-				},
-			},
-			UpdateChannel: "stable",
-		},
-	}
-	serverRebooting := map[string]bool{
-		"serverA": false,
-		"serverB": false,
-		"serverC": false,
-	}
+	world := newServerWorld(map[string]api.ServerVersionData{
+		"serverA": versionDataInitial,
+		"serverB": versionDataInitial,
+		"serverC": versionDataInitial,
+	})
 
 	// Setup
 	ctx, cancel := context.WithTimeout(t.Context(), asyncActionsDelay*75)
@@ -745,10 +544,7 @@ func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
 			return nil
 		},
 		PingFunc: func(ctx context.Context, endpoint provisioning.Endpoint) error {
-			serverVersionDataMu.Lock()
-			defer serverVersionDataMu.Unlock()
-
-			if serverRebooting[endpoint.GetName()] {
+			if world.isRebooting(endpoint.GetName()) {
 				return domain.NewRetryableErr(errors.New("rebooting"))
 			}
 
@@ -779,207 +575,46 @@ func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
 			}, nil
 		},
 		GetVersionDataFunc: func(ctx context.Context, server provisioning.Server) (api.ServerVersionData, error) {
-			serverVersionDataMu.Lock()
-			defer serverVersionDataMu.Unlock()
-
-			return serverVersionData[server.Name], nil
+			return world.getVersionData(server.Name), nil
 		},
 		GetServerTypeFunc: func(ctx context.Context, endpoint provisioning.Endpoint) (api.ServerType, error) {
 			return api.ServerTypeIncus, nil
 		},
 		UpdateOSFunc: func(ctx context.Context, server provisioning.Server) error {
-			go func() {
-				time.Sleep(asyncActionsDelay)
-
-				serverVersionDataMu.Lock()
-				defer serverVersionDataMu.Unlock()
-
-				serverVersionData[server.Name] = api.ServerVersionData{
-					OS: api.OSVersionData{
-						Name:        "incusos",
-						Version:     "1",
-						VersionNext: "2",
-						NeedsReboot: true,
-					},
-					Applications: []api.ApplicationVersionData{
-						{
-							Name:          "incus",
-							Version:       "2",
-							InMaintenance: api.NotInMaintenance,
-						},
-					},
-					UpdateChannel: "stable",
-				}
-			}()
-
-			serverVersionDataMu.Lock()
-			defer serverVersionDataMu.Unlock()
-
-			serverVersionData[server.Name] = api.ServerVersionData{
-				OS: api.OSVersionData{
-					Name:        "incusos",
-					Version:     "1",
-					VersionNext: "1",
-					NeedsReboot: false,
-				},
-				Applications: []api.ApplicationVersionData{
-					{
-						Name:          "incus",
-						Version:       "1",
-						InMaintenance: api.NotInMaintenance,
-					},
-				},
-				UpdateChannel: "stable",
-			}
+			world.set(server.Name, versionDataUpdating, false)
+			world.deferTransition(serverWorldTransition{
+				server:      server.Name,
+				versionData: versionDataUpdated,
+			})
 
 			return nil
 		},
 		EvacuateFunc: func(ctx context.Context, server provisioning.Server, callback func(ctx context.Context, err error)) error {
-			go func() {
-				time.Sleep(asyncActionsDelay)
-
-				serverVersionDataMu.Lock()
-				defer serverVersionDataMu.Unlock()
-
-				serverVersionData[server.Name] = api.ServerVersionData{
-					OS: api.OSVersionData{
-						Name:        "incusos",
-						Version:     "1",
-						VersionNext: "2",
-						NeedsReboot: true,
-					},
-					Applications: []api.ApplicationVersionData{
-						{
-							Name:          "incus",
-							Version:       "2",
-							InMaintenance: api.InMaintenanceEvacuated,
-						},
-					},
-					UpdateChannel: "stable",
-				}
-
-				callback(t.Context(), nil)
-			}()
-
-			serverVersionDataMu.Lock()
-			defer serverVersionDataMu.Unlock()
-
-			serverVersionData[server.Name] = api.ServerVersionData{
-				OS: api.OSVersionData{
-					Name:        "incusos",
-					Version:     "1",
-					VersionNext: "2",
-					NeedsReboot: true,
-				},
-				Applications: []api.ApplicationVersionData{
-					{
-						Name:          "incus",
-						Version:       "2",
-						InMaintenance: api.InMaintenanceEvacuating,
-					},
-				},
-				UpdateChannel: "stable",
-			}
+			world.set(server.Name, versionDataEvacuating, false)
+			world.deferTransition(serverWorldTransition{
+				server:      server.Name,
+				versionData: versionDataEvacuated,
+				callback:    callback,
+			})
 
 			return nil
 		},
 		RebootFunc: func(ctx context.Context, server provisioning.Server) error {
-			go func() {
-				time.Sleep(asyncActionsDelay)
-
-				serverVersionDataMu.Lock()
-				defer serverVersionDataMu.Unlock()
-
-				serverVersionData[server.Name] = api.ServerVersionData{
-					OS: api.OSVersionData{
-						Name:        "incusos",
-						Version:     "2",
-						VersionNext: "2",
-						NeedsReboot: false,
-					},
-					Applications: []api.ApplicationVersionData{
-						{
-							Name:          "incus",
-							Version:       "2",
-							InMaintenance: api.InMaintenanceEvacuated,
-						},
-					},
-					UpdateChannel: "stable",
-				}
-
-				serverRebooting[server.Name] = false
-			}()
-
-			serverVersionDataMu.Lock()
-			defer serverVersionDataMu.Unlock()
-
-			serverVersionData[server.Name] = api.ServerVersionData{
-				OS: api.OSVersionData{
-					Name:        "incusos",
-					Version:     "2",
-					VersionNext: "2",
-					NeedsReboot: true,
-				},
-				Applications: []api.ApplicationVersionData{
-					{
-						Name:          "incus",
-						Version:       "2",
-						InMaintenance: api.InMaintenanceEvacuated,
-					},
-				},
-				UpdateChannel: "stable",
-			}
-
-			serverRebooting[server.Name] = true
+			world.set(server.Name, versionDataRebooting, true)
+			world.deferTransition(serverWorldTransition{
+				server:      server.Name,
+				versionData: versionDataRebooted,
+			})
 
 			return nil
 		},
 		RestoreFunc: func(ctx context.Context, server provisioning.Server, restoreModeSkip bool, callback func(ctx context.Context, err error)) error {
-			go func() {
-				time.Sleep(asyncActionsDelay)
-
-				serverVersionDataMu.Lock()
-				defer serverVersionDataMu.Unlock()
-
-				serverVersionData[server.Name] = api.ServerVersionData{
-					OS: api.OSVersionData{
-						Name:        "incusos",
-						Version:     "2",
-						VersionNext: "2",
-						NeedsReboot: false,
-					},
-					Applications: []api.ApplicationVersionData{
-						{
-							Name:          "incus",
-							Version:       "2",
-							InMaintenance: api.NotInMaintenance,
-						},
-					},
-					UpdateChannel: "stable",
-				}
-
-				callback(t.Context(), nil)
-			}()
-
-			serverVersionDataMu.Lock()
-			defer serverVersionDataMu.Unlock()
-
-			serverVersionData[server.Name] = api.ServerVersionData{
-				OS: api.OSVersionData{
-					Name:        "incusos",
-					Version:     "2",
-					VersionNext: "2",
-					NeedsReboot: false,
-				},
-				Applications: []api.ApplicationVersionData{
-					{
-						Name:          "incus",
-						Version:       "2",
-						InMaintenance: api.InMaintenanceRestoring,
-					},
-				},
-				UpdateChannel: "stable",
-			}
+			world.set(server.Name, versionDataRestoring, false)
+			world.deferTransition(serverWorldTransition{
+				server:      server.Name,
+				versionData: versionDataRestored,
+				callback:    callback,
+			})
 
 			return nil
 		},
@@ -1014,6 +649,8 @@ func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
 	err = clusterSvc.LaunchClusterUpdate(ctx, "clusterA", true)
 	require.NoError(t, err)
 
+	var observed []string
+
 	success := false
 	for range 200 {
 		c, err := clusterSvc.GetByName(ctx, "clusterA")
@@ -1023,51 +660,61 @@ func TestClusterService_ClusterUpdateControlLoopMultiNodeCluster(t *testing.T) {
 			break
 		}
 
+		require.Empty(t, c.UpdateStatus.InProgressStatus.Error)
+
+		// Observe the progress the same way a user does.
+		observed = append(observed, ptr.From(c.UpdateStatus.InProgressStatus.StatusDescription))
+
+		// A server completes an action, which has been triggered on it, asynchronously.
+		// Let it complete only if it was already running before this iteration, so that
+		// the state, the action leads to, is reported at least once.
+		pending := world.pendingCount()
+
 		err = clusterSvc.ClusterUpdateControlLoop(ctx, nil)
 		if !domain.IsRetryableError(err) {
 			require.NoError(t, err)
+		}
+
+		if pending > 0 {
+			world.release(ctx)
 		}
 
 		time.Sleep(controlLoopInterval)
 	}
 
 	require.True(t, success)
-	log.Contains(`[ 1/27] update pending server \"serverA\"`)(t, logBuf)
 
-	log.Contains(`[ 3/27] update pending server \"serverB\"`)(t, logBuf)
+	requireProgressOnlyMovesForward(t, observed)
 
-	log.Contains(`[ 5/27] update pending server \"serverC\"`)(t, logBuf)
-
-	log.Contains(`[ 7/27] evacuation pending server \"serverA\"`)(t, logBuf)
-	log.Contains(`[ 9/27] in maintenance, reboot pending server \"serverA\"`)(t, logBuf)
-	log.Contains(`[10/27] in maintenance, rebooting server \"serverA\"`)(t, logBuf)
-	log.Contains(`[11/27] in maintenance, restore pending server \"serverA\"`)(t, logBuf)
-	log.Contains(`[12/27] restoring server \"serverA\"`)(t, logBuf)
-	log.Contains(`[13/27] post restore server \"serverA\"`)(t, logBuf)
-
-	log.Contains(`[14/27] evacuation pending server \"serverB\"`)(t, logBuf)
-	log.Contains(`[16/27] in maintenance, reboot pending server \"serverB\"`)(t, logBuf)
-	log.Contains(`[17/27] in maintenance, rebooting server \"serverB\"`)(t, logBuf)
-	log.Contains(`[18/27] in maintenance, restore pending server \"serverB\"`)(t, logBuf)
-	log.Contains(`[19/27] restoring server \"serverB\"`)(t, logBuf)
-	log.Contains(`[20/27] post restore server \"serverB\"`)(t, logBuf)
-
-	log.Contains(`[21/27] evacuation pending server \"serverC\"`)(t, logBuf)
-	log.Contains(`[23/27] in maintenance, reboot pending server \"serverC\"`)(t, logBuf)
-	log.Contains(`[24/27] in maintenance, rebooting server \"serverC\"`)(t, logBuf)
-	log.Contains(`[25/27] in maintenance, restore pending server \"serverC\"`)(t, logBuf)
-	log.Contains(`[26/27] restoring server \"serverC\"`)(t, logBuf)
-	log.Contains(`[27/27] post restore server \"serverC\"`)(t, logBuf)
-
-	// "updating server" might be skipped in some occations.
-	log.Contains(`[ 2/27] updating server \"serverA\"`)(flaky.SkipOnFail(t, `"updating server" does not always appear in the logs`), logBuf)
-	log.Contains(`[ 4/27] updating server \"serverB\"`)(flaky.SkipOnFail(t, `"updating server" does not always appear in the logs`), logBuf)
-	log.Contains(`[ 6/27] updating server \"serverC\"`)(flaky.SkipOnFail(t, `"updating server" does not always appear in the logs`), logBuf)
-
-	// "evacuating server" might be skipped in some occations.
-	log.Contains(`[ 8/27] evacuating server \"serverA\"`)(flaky.SkipOnFail(t, `"evacuating server" does not always appear in the logs`), logBuf)
-	log.Contains(`[15/27] evacuating server \"serverB\"`)(flaky.SkipOnFail(t, `"evacuating server" does not always appear in the logs`), logBuf)
-	log.Contains(`[22/27] evacuating server \"serverC\"`)(flaky.SkipOnFail(t, `"evacuating server" does not always appear in the logs`), logBuf)
+	require.Equal(t, []string{
+		`[ 1/27] update pending server "serverA"`,
+		`[ 2/27] updating server "serverA"`,
+		`[ 3/27] update pending server "serverB"`,
+		`[ 4/27] updating server "serverB"`,
+		`[ 5/27] update pending server "serverC"`,
+		`[ 6/27] updating server "serverC"`,
+		`[ 7/27] evacuation pending server "serverA"`,
+		`[ 8/27] evacuating server "serverA"`,
+		`[ 9/27] in maintenance, reboot pending server "serverA"`,
+		`[10/27] in maintenance, rebooting server "serverA"`,
+		`[11/27] in maintenance, restore pending server "serverA"`,
+		`[12/27] restoring server "serverA"`,
+		`[13/27] post restore server "serverA"`,
+		`[14/27] evacuation pending server "serverB"`,
+		`[15/27] evacuating server "serverB"`,
+		`[16/27] in maintenance, reboot pending server "serverB"`,
+		`[17/27] in maintenance, rebooting server "serverB"`,
+		`[18/27] in maintenance, restore pending server "serverB"`,
+		`[19/27] restoring server "serverB"`,
+		`[20/27] post restore server "serverB"`,
+		`[21/27] evacuation pending server "serverC"`,
+		`[22/27] evacuating server "serverC"`,
+		`[23/27] in maintenance, reboot pending server "serverC"`,
+		`[24/27] in maintenance, rebooting server "serverC"`,
+		`[25/27] in maintenance, restore pending server "serverC"`,
+		`[26/27] restoring server "serverC"`,
+		`[27/27] post restore server "serverC"`,
+	}, clusterUpdateStatesFromLog(t, logBuf.String()))
 }
 
 func TestClusterService_ClusterUpdateControlLoop(t *testing.T) {

--- a/internal/provisioning/cluster/cluster_update_progress.go
+++ b/internal/provisioning/cluster/cluster_update_progress.go
@@ -1,0 +1,285 @@
+package cluster
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/FuturFusion/operations-center/internal/provisioning"
+	"github.com/FuturFusion/operations-center/internal/util/ptr"
+	"github.com/FuturFusion/operations-center/shared/api"
+)
+
+// clusterUpdateSteps is the ordered sequence of per server update states, that a
+// server passes through during a rolling cluster update. The position of a state
+// in this slice defines how much of the work for the respective server is done,
+// which is the basis for the progress reported to the user.
+var clusterUpdateSteps = []api.ServerUpdateState{
+	api.ServerUpdateStateUpdatePending,
+	api.ServerUpdateStateUpdating,
+	api.ServerUpdateStateEvacuationPending,
+	api.ServerUpdateStateEvacuating,
+	api.ServerUpdateStateInMaintenanceRebootPending,
+	api.ServerUpdateStateInMaintenanceRebooting,
+	api.ServerUpdateStateInMaintenanceRestorePending,
+	api.ServerUpdateStateInMaintenanceRestoring,
+	api.ServerUpdateStateInMaintenancePostRestore,
+}
+
+// clusterUpdateUpdateSteps is the number of leading entries of clusterUpdateSteps,
+// which belong to the update phase, as opposed to the restart phase. A cluster
+// update without reboot only passes through these states.
+const clusterUpdateUpdateSteps = 2
+
+// clusterUpdateProgress is the progress of an ongoing rolling cluster update.
+// A step of 0 means, that there is nothing to report.
+type clusterUpdateProgress struct {
+	step       int
+	totalSteps int
+	state      api.ServerUpdateState
+	serverName string
+
+	// text, if set, is reported verbatim instead of the step based description.
+	// It is used for the terminal error case.
+	text string
+}
+
+func (p clusterUpdateProgress) String() string {
+	if p.text != "" {
+		return p.text
+	}
+
+	if p.step == 0 {
+		return ""
+	}
+
+	format := fmt.Sprintf("[%%%[1]dd/%%%[1]dd] %%s server %%q", len(strconv.Itoa(p.totalSteps)))
+
+	return fmt.Sprintf(format, p.step, p.totalSteps, p.state, p.serverName)
+}
+
+// serverPendingSteps returns the number of the perServerSteps steps, that the
+// server in the given state still has ahead of it.
+//
+// States, which are not part of clusterUpdateSteps and which are not "up to date"
+// are deliberately counted as not started at all. Under reporting the progress is
+// harmless, since clusterUpdateProgressLatch keeps the last reported value in
+// place, while over reporting would leave the reported progress ahead of reality
+// for the rest of the run.
+func serverPendingSteps(state api.ServerUpdateState, perServerSteps int) int {
+	if state == api.ServerUpdateStateUpToDate {
+		return 0
+	}
+
+	idx := slices.Index(clusterUpdateSteps, state)
+	if idx < 0 {
+		return perServerSteps
+	}
+
+	return min(max(perServerSteps-idx, 0), perServerSteps)
+}
+
+// serverUpdateStateForRollingUpdate returns the update state of the server as the
+// rolling cluster update in the given phase sees it.
+//
+// During the rolling restart phase, pending updates are intentionally ignored. All
+// servers of a cluster have been updated to the same version before entering the
+// rolling restart, so a newly published update must not interrupt the ongoing
+// restart cycle.
+//
+// During the update phase, a server updating its applications is reported as
+// updating instead of the undefined state, api.Server.UpdateState reports for it,
+// since applications are updated as part of the OS update.
+func serverUpdateStateForRollingUpdate(inProgress api.ClusterUpdateInProgress, server provisioning.Server) api.ServerUpdateState {
+	switch inProgress {
+	case api.ClusterUpdateInProgressRollingRestart:
+		server.VersionData.NeedsUpdate = ptr.To(false)
+
+	case api.ClusterUpdateInProgressApplyUpdate,
+		api.ClusterUpdateInProgressApplyUpdateWithReboot:
+		if server.StatusDetail == api.ServerStatusDetailReadyUpdatingApplication {
+			return api.ServerUpdateStateUpdating
+		}
+	}
+
+	return server.UpdateState()
+}
+
+// clusterUpdateState calculates the progress of the rolling update of a cluster
+// from the current state of its servers.
+func clusterUpdateState(clusterUpdateInProgressStatus api.ClusterUpdateInProgressStatus, servers provisioning.Servers) clusterUpdateProgress {
+	if clusterUpdateInProgressStatus.InProgress == api.ClusterUpdateInProgressError {
+		return clusterUpdateProgress{
+			text: clusterUpdateInProgressStatus.Error,
+		}
+	}
+
+	var perServerSteps int
+	switch clusterUpdateInProgressStatus.InProgress {
+	case api.ClusterUpdateInProgressApplyUpdate:
+		perServerSteps = clusterUpdateUpdateSteps
+
+	case api.ClusterUpdateInProgressApplyUpdateWithReboot,
+		api.ClusterUpdateInProgressRollingRestart:
+		perServerSteps = len(clusterUpdateSteps)
+
+	default:
+		return clusterUpdateProgress{}
+	}
+
+	// Sort a copy, the caller's slice must not be reordered.
+	servers = slices.Clone(servers)
+	slices.SortStableFunc(servers, func(a provisioning.Server, b provisioning.Server) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	// The server, the update is currently working on, is reported to the user. The
+	// control loop updates all servers before it restarts any of them, so a server,
+	// which is still being updated, takes precedence over a server, which is waiting
+	// for its restart. A server in an unclassified state is only reported, if there
+	// is nothing else left to report.
+	var inUpdatePhase, inRestartPhase, unclassified *clusterUpdateProgress
+
+	totalSteps := 0
+	pendingSteps := 0
+
+	for _, server := range servers {
+		totalSteps += perServerSteps
+
+		state := serverUpdateStateForRollingUpdate(clusterUpdateInProgressStatus.InProgress, server)
+
+		// Servers, which have been evacuated before the update was triggered, are kept
+		// in the evacuated state and therefore have no restore step ahead of them.
+		if state == api.ServerUpdateStateInMaintenanceRestorePending &&
+			slices.Contains(clusterUpdateInProgressStatus.EvacuatedBefore, server.Name) {
+			continue
+		}
+
+		serverSteps := serverPendingSteps(state, perServerSteps)
+		if serverSteps == 0 {
+			continue
+		}
+
+		pendingSteps += serverSteps
+
+		candidate := &clusterUpdateProgress{
+			state:      state,
+			serverName: server.Name,
+		}
+
+		idx := slices.Index(clusterUpdateSteps, state)
+
+		switch {
+		case idx < 0:
+			if unclassified == nil {
+				unclassified = candidate
+			}
+
+		case idx < clusterUpdateUpdateSteps:
+			if inUpdatePhase == nil {
+				inUpdatePhase = candidate
+			}
+
+		default:
+			if inRestartPhase == nil {
+				inRestartPhase = candidate
+			}
+		}
+	}
+
+	if pendingSteps == 0 {
+		return clusterUpdateProgress{
+			totalSteps: totalSteps,
+		}
+	}
+
+	progress := firstProgress(inUpdatePhase, inRestartPhase, unclassified)
+	progress.step = totalSteps - pendingSteps + 1
+	progress.totalSteps = totalSteps
+
+	return *progress
+}
+
+// firstProgress returns the first non nil progress candidate.
+func firstProgress(candidates ...*clusterUpdateProgress) *clusterUpdateProgress {
+	for _, candidate := range candidates {
+		if candidate != nil {
+			return candidate
+		}
+	}
+
+	return &clusterUpdateProgress{}
+}
+
+// clusterUpdateProgressLatch keeps the highest progress observed per cluster, so
+// that the progress reported to the user never moves backwards.
+//
+// The progress is recomputed from a live snapshot of the server states on every
+// read, while the server states themselves are updated asynchronously from
+// several sources (control loop, background polling, status updates pushed by
+// IncusOS). A single server briefly falling back to an earlier state therefore
+// makes the calculated progress go backwards, which is confusing for the user.
+type clusterUpdateProgressLatch struct {
+	mu       sync.Mutex
+	progress map[string]clusterUpdateProgress
+}
+
+func newClusterUpdateProgressLatch() *clusterUpdateProgressLatch {
+	return &clusterUpdateProgressLatch{
+		progress: map[string]clusterUpdateProgress{},
+	}
+}
+
+// apply returns the progress to report for the cluster, which is the highest
+// progress observed for the current run of the rolling update so far.
+func (l *clusterUpdateProgressLatch) apply(clusterName string, progress clusterUpdateProgress) clusterUpdateProgress {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// The terminal error is reported as is and ends the current run.
+	if progress.text != "" {
+		delete(l.progress, clusterName)
+		return progress
+	}
+
+	// Nothing in progress, e.g. because the cluster has no servers.
+	if progress.totalSteps == 0 {
+		delete(l.progress, clusterName)
+		return progress
+	}
+
+	previous, ok := l.progress[clusterName]
+
+	// A different number of total steps means, this is not the same run anymore,
+	// e.g. because a server has been added to or removed from the cluster.
+	if !ok || previous.totalSteps != progress.totalSteps {
+		l.progress[clusterName] = progress
+		return progress
+	}
+
+	// All servers are done, but the update in progress status has not been advanced
+	// to the next phase yet. Keep reporting the last known progress instead of
+	// letting the description disappear for a moment.
+	if progress.step == 0 {
+		return previous
+	}
+
+	if progress.step < previous.step {
+		return previous
+	}
+
+	l.progress[clusterName] = progress
+
+	return progress
+}
+
+// reset drops the progress recorded for the cluster, so that the next rolling
+// update of this cluster starts reporting from the beginning again.
+func (l *clusterUpdateProgressLatch) reset(clusterName string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	delete(l.progress, clusterName)
+}

--- a/internal/provisioning/cluster/cluster_update_test_world_test.go
+++ b/internal/provisioning/cluster/cluster_update_test_world_test.go
@@ -1,0 +1,230 @@
+package cluster_test
+
+import (
+	"context"
+	"regexp"
+	"slices"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/FuturFusion/operations-center/shared/api"
+)
+
+// The version data, the fake servers report while passing through a rolling
+// cluster update. Version "1" is installed initially, version "2" is available.
+func versionData(osVersion string, osVersionNext string, needsReboot bool, incusVersion string, inMaintenance api.InMaintenanceState) api.ServerVersionData {
+	return api.ServerVersionData{
+		OS: api.OSVersionData{
+			Name:        "incusos",
+			Version:     osVersion,
+			VersionNext: osVersionNext,
+			NeedsReboot: needsReboot,
+		},
+		Applications: []api.ApplicationVersionData{
+			{
+				Name:          "incus",
+				Version:       incusVersion,
+				InMaintenance: inMaintenance,
+			},
+		},
+		UpdateChannel: "stable",
+	}
+}
+
+var (
+	versionDataInitial    = versionData("1", "1", false, "1", api.NotInMaintenance)
+	versionDataUpdating   = versionData("1", "1", false, "1", api.NotInMaintenance)
+	versionDataUpdated    = versionData("1", "2", true, "2", api.NotInMaintenance)
+	versionDataEvacuating = versionData("1", "2", true, "2", api.InMaintenanceEvacuating)
+	versionDataEvacuated  = versionData("1", "2", true, "2", api.InMaintenanceEvacuated)
+	versionDataRebooting  = versionData("2", "2", true, "2", api.InMaintenanceEvacuated)
+	versionDataRebooted   = versionData("2", "2", false, "2", api.InMaintenanceEvacuated)
+	versionDataRestoring  = versionData("2", "2", false, "2", api.InMaintenanceRestoring)
+	versionDataRestored   = versionData("2", "2", false, "2", api.NotInMaintenance)
+)
+
+// serverWorld is the state of the fake servers, the ServerClientPortMock serves.
+//
+// State transitions, which a real server completes asynchronously, are released
+// explicitly by the test.
+type serverWorld struct {
+	mu          sync.Mutex
+	versionData map[string]api.ServerVersionData
+	rebooting   map[string]bool
+	pending     []serverWorldTransition
+}
+
+// serverWorldTransition is the state a server reaches once it has completed an
+// action, that has been triggered on it.
+type serverWorldTransition struct {
+	server      string
+	versionData api.ServerVersionData
+	rebooting   bool
+
+	// callback, if set, is invoked after the transition has been applied. It is
+	// invoked without holding the lock, since it queries the server again.
+	callback func(ctx context.Context, err error)
+}
+
+func newServerWorld(versionData map[string]api.ServerVersionData) *serverWorld {
+	return &serverWorld{
+		versionData: versionData,
+		rebooting:   map[string]bool{},
+	}
+}
+
+func (w *serverWorld) getVersionData(name string) api.ServerVersionData {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Return a copy, the caller enriches the version data with calculated fields.
+	versionData := w.versionData[name]
+	versionData.Applications = slices.Clone(versionData.Applications)
+
+	return versionData
+}
+
+func (w *serverWorld) isRebooting(name string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.rebooting[name]
+}
+
+// set applies the state, a server reaches immediately when an action is triggered
+// on it.
+func (w *serverWorld) set(name string, versionData api.ServerVersionData, rebooting bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.versionData[name] = versionData
+	w.rebooting[name] = rebooting
+}
+
+// deferTransition records the state, the server reaches once it has completed the action.
+func (w *serverWorld) deferTransition(transition serverWorldTransition) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.pending = append(w.pending, transition)
+}
+
+// pendingCount returns the number of actions, that have been triggered but not yet
+// completed.
+func (w *serverWorld) pendingCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return len(w.pending)
+}
+
+// release completes the action, that has been triggered first.
+func (w *serverWorld) release(ctx context.Context) {
+	w.mu.Lock()
+
+	if len(w.pending) == 0 {
+		w.mu.Unlock()
+		return
+	}
+
+	transition := w.pending[0]
+	w.pending = w.pending[1:]
+
+	w.versionData[transition.server] = transition.versionData
+	w.rebooting[transition.server] = transition.rebooting
+
+	w.mu.Unlock()
+
+	if transition.callback != nil {
+		transition.callback(ctx, nil)
+	}
+}
+
+var clusterUpdateStateRegexp = regexp.MustCompile(`\[\s*(\d+)/\s*(\d+)\]`)
+
+// requireProgressOnlyMovesForward asserts, that the progress reported to the user
+// never moves backwards and that the total number of steps stays constant.
+func requireProgressOnlyMovesForward(t *testing.T, observed []string) {
+	t.Helper()
+
+	require.NotEmpty(t, observed)
+
+	previousStep := 0
+	previousTotalSteps := 0
+
+	for i, description := range observed {
+		if description == "" {
+			continue
+		}
+
+		match := clusterUpdateStateRegexp.FindStringSubmatch(description)
+		require.Len(t, match, 3, "observation %d (%q) does not report a step", i, description)
+
+		step, err := strconv.Atoi(match[1])
+		require.NoError(t, err)
+
+		totalSteps, err := strconv.Atoi(match[2])
+		require.NoError(t, err)
+
+		require.GreaterOrEqual(t, step, previousStep, "progress moved backwards at observation %d, observed: %v", i, observed)
+
+		if previousTotalSteps != 0 {
+			require.Equal(t, previousTotalSteps, totalSteps, "total number of steps changed at observation %d, observed: %v", i, observed)
+		}
+
+		previousStep = step
+		previousTotalSteps = totalSteps
+	}
+
+	require.NotZero(t, previousStep, "no progress observed at all, observed: %v", observed)
+}
+
+// dedupe removes consecutive duplicates and empty entries, so that a sequence of
+// observations can be compared against the sequence of states, that is expected to
+// be passed through.
+func dedupe(in []string) []string {
+	out := make([]string, 0, len(in))
+
+	for _, value := range in {
+		if value == "" {
+			continue
+		}
+
+		if len(out) > 0 && out[len(out)-1] == value {
+			continue
+		}
+
+		out = append(out, value)
+	}
+
+	return out
+}
+
+var clusterUpdateStateLogRegexp = regexp.MustCompile(`cluster_update_state=(?:"((?:[^"\\]|\\.)*)"|(\S+))`)
+
+// clusterUpdateStatesFromLog extracts the sequence of cluster update states, that
+// the control loop reported while acting on the cluster, with consecutive
+// duplicates removed.
+func clusterUpdateStatesFromLog(t *testing.T, logOutput string) []string {
+	t.Helper()
+
+	matches := clusterUpdateStateLogRegexp.FindAllStringSubmatch(logOutput, -1)
+
+	states := make([]string, 0, len(matches))
+	for _, match := range matches {
+		value := match[1]
+		if value == "" {
+			value = match[2]
+		}
+
+		unquoted, err := strconv.Unquote(`"` + value + `"`)
+		require.NoError(t, err)
+
+		states = append(states, unquoted)
+	}
+
+	return dedupe(states)
+}

--- a/internal/provisioning/server/server_service.go
+++ b/internal/provisioning/server/server_service.go
@@ -846,8 +846,9 @@ func (s *serverService) SelfUpdate(ctx context.Context, serverUpdate provisionin
 			triggerBackgroundPolling = true
 
 		case api.ServerSelfUpdateCauseOSUpdateApplied:
-			server.StatusDetail = api.ServerStatusDetailNone
-			server.LastStatusUpdated = s.now()
+			// Intentionally keep the status detail as is to prevent state from
+			// falling back. Update polling triggered below will update the state
+			// correctly.
 			triggerBackgroundPolling = true
 
 		case api.ServerSelfUpdateCauseApplicationUpdateApplied:
@@ -2149,7 +2150,22 @@ func (s *serverService) PollServer(ctx context.Context, server provisioning.Serv
 		// If an update has been triggered, check if an update is still needed.
 		// If not, updating is done.
 		if server.StatusDetail == api.ServerStatusDetailReadyUpdatingOS {
-			if !ptr.From(server.VersionData.NeedsUpdate) {
+			needsUpdate := ptr.From(server.VersionData.NeedsUpdate)
+
+			if updateServerConfiguration {
+				freshServer := *server
+				freshServer.VersionData = versionData
+				freshServer.VersionData.Applications = slices.Clone(versionData.Applications)
+
+				err := s.enrichServerWithVersionDetails(ctx, &freshServer)
+				if err != nil {
+					return fmt.Errorf("Failed to enrich version data of server %q: %w", server.Name, err)
+				}
+
+				needsUpdate = ptr.From(freshServer.VersionData.NeedsUpdate)
+			}
+
+			if !needsUpdate {
 				server.StatusDetail = api.ServerStatusDetailNone
 				server.LastStatusUpdated = s.now()
 			}

--- a/internal/provisioning/server/server_service_test.go
+++ b/internal/provisioning/server/server_service_test.go
@@ -3007,7 +3007,7 @@ func TestServerService_SelfUpdate(t *testing.T) {
 			wantServerStatusDetail: api.ServerStatusDetailNone,
 		},
 		{
-			name: "success - cause OS update applied",
+			name: "success - cause OS update applied keeps updating state",
 			serverSelfUpdate: provisioning.ServerSelfUpdate{
 				ConnectionURL:             "http://one-new/",
 				Cause:                     api.ServerSelfUpdateCauseOSUpdateApplied,
@@ -3026,7 +3026,7 @@ func TestServerService_SelfUpdate(t *testing.T) {
 			assertErr:              require.NoError,
 			assertLog:              log.EmptyWithIgnorePattern(log.IgnorePatternDebugLines),
 			wantServerStatus:       api.ServerStatusReady,
-			wantServerStatusDetail: api.ServerStatusDetailNone,
+			wantServerStatusDetail: api.ServerStatusDetailReadyUpdatingOS,
 		},
 		{
 			name: "success - cause application update applied",
@@ -4529,8 +4529,9 @@ func TestServerService_PollServer(t *testing.T) {
 		updateSvcGetAllWithFilter      provisioning.Updates
 		updateSvcGetAllWithFilterErr   error
 
-		assertErr require.ErrorAssertionFunc
-		assertLog log.MatcherFunc
+		assertErr              require.ErrorAssertionFunc
+		assertLog              log.MatcherFunc
+		wantServerStatusDetail *api.ServerStatusDetail
 	}{
 		{
 			name: "success",
@@ -4625,6 +4626,110 @@ func TestServerService_PollServer(t *testing.T) {
 
 			assertErr: require.NoError,
 			assertLog: log.EmptyWithIgnorePattern(log.IgnorePatternDebugLines),
+		},
+		{
+			name: "success - updating, update has been applied",
+			serverArg: provisioning.Server{
+				Name:    "one",
+				Status:  api.ServerStatusReady,
+				Channel: "stable",
+			},
+			updateServerConfigArg: true,
+			repoGetByName: &provisioning.Server{
+				Name:         "one",
+				Status:       api.ServerStatusReady,
+				StatusDetail: api.ServerStatusDetailReadyUpdatingOS,
+				Channel:      "stable",
+				VersionData:  pollServerVersionData("1"),
+			},
+			clientGetOSData: api.OSData{
+				Network: incusosapi.SystemNetwork{
+					State: incusosapi.SystemNetworkState{
+						Interfaces: map[string]incusosapi.SystemNetworkInterfaceState{
+							"eth0": {
+								Addresses: []string{
+									"192.168.0.100",
+								},
+								Roles: []string{
+									"management",
+								},
+							},
+						},
+					},
+				},
+			},
+			clientGetVersionData: pollServerVersionData("2"),
+			updateSvcGetAllWithFilter: provisioning.Updates{
+				{
+					ID:      2,
+					UUID:    uuidgen.FromPattern(t, "2"),
+					Version: "2",
+					Files: provisioning.UpdateFiles{
+						{
+							Filename: "x86_64/IncusOS_20260610.img.gz",
+						},
+						{
+							Filename: "x86_64/incus.raw.gz",
+						},
+					},
+				},
+			},
+
+			assertErr:              require.NoError,
+			assertLog:              log.EmptyWithIgnorePattern(log.IgnorePatternDebugLines),
+			wantServerStatusDetail: ptr.To(api.ServerStatusDetailNone),
+		},
+		{
+			name: "success - updating, update is still pending",
+			serverArg: provisioning.Server{
+				Name:    "one",
+				Status:  api.ServerStatusReady,
+				Channel: "stable",
+			},
+			updateServerConfigArg: true,
+			repoGetByName: &provisioning.Server{
+				Name:         "one",
+				Status:       api.ServerStatusReady,
+				StatusDetail: api.ServerStatusDetailReadyUpdatingOS,
+				Channel:      "stable",
+				VersionData:  pollServerVersionData("1"),
+			},
+			clientGetOSData: api.OSData{
+				Network: incusosapi.SystemNetwork{
+					State: incusosapi.SystemNetworkState{
+						Interfaces: map[string]incusosapi.SystemNetworkInterfaceState{
+							"eth0": {
+								Addresses: []string{
+									"192.168.0.100",
+								},
+								Roles: []string{
+									"management",
+								},
+							},
+						},
+					},
+				},
+			},
+			clientGetVersionData: pollServerVersionData("1"),
+			updateSvcGetAllWithFilter: provisioning.Updates{
+				{
+					ID:      2,
+					UUID:    uuidgen.FromPattern(t, "2"),
+					Version: "2",
+					Files: provisioning.UpdateFiles{
+						{
+							Filename: "x86_64/IncusOS_20260610.img.gz",
+						},
+						{
+							Filename: "x86_64/incus.raw.gz",
+						},
+					},
+				},
+			},
+
+			assertErr:              require.NoError,
+			assertLog:              log.EmptyWithIgnorePattern(log.IgnorePatternDebugLines),
+			wantServerStatusDetail: ptr.To(api.ServerStatusDetailReadyUpdatingOS),
 		},
 		{
 			name: "success - pending registration",
@@ -5134,6 +5239,10 @@ func TestServerService_PollServer(t *testing.T) {
 				UpdateFunc: func(ctx context.Context, server provisioning.Server) error {
 					require.Equal(t, api.ServerStatusReady, server.Status)
 					require.Equal(t, fixedDate, server.LastSeen)
+					if tc.wantServerStatusDetail != nil {
+						require.Equal(t, *tc.wantServerStatusDetail, server.StatusDetail)
+					}
+
 					return tc.repoUpdateErr
 				},
 			}
@@ -10041,5 +10150,22 @@ func TestServerService_BMCRefreshByName(t *testing.T) {
 			// Assert
 			tc.assertErr(t, err)
 		})
+	}
+}
+
+func pollServerVersionData(incusVersion string) api.ServerVersionData {
+	return api.ServerVersionData{
+		OS: api.OSVersionData{
+			Name:        "IncusOS",
+			Version:     "1",
+			VersionNext: incusVersion,
+		},
+		Applications: []api.ApplicationVersionData{
+			{
+				Name:    "incus",
+				Version: incusVersion,
+			},
+		},
+		UpdateChannel: "stable",
 	}
 }

--- a/shared/api/provisioning_server.go
+++ b/shared/api/provisioning_server.go
@@ -838,7 +838,7 @@ const (
 	ServerUpdateStateInMaintenanceRebootPending  ServerUpdateState = "in maintenance, reboot pending"  // ServerStatusReady, NeedsUpdate: false, NeedsReboot: true, InMaintenance: InMaintenanceEvacuated
 	ServerUpdateStateInMaintenanceRebooting      ServerUpdateState = "in maintenance, rebooting"       // ServerStatusOffline, ServerStatusDetailOfflineRebooting, InMaintenance: InMaintenanceEvacuated
 	ServerUpdateStateInMaintenanceRestorePending ServerUpdateState = "in maintenance, restore pending" // ServerStatusReady, NeedsUpdate: false, InMaintenance: InMaintenanceEvacuated
-	ServerUpdateStateInMaintenanceRestoring      ServerUpdateState = "restoring"                       // ServerStatusReady, ServerStatusDetailReadyRestoring, NeedsUpdate: false, InMaintenance: InMaintenanceRestoring
+	ServerUpdateStateInMaintenanceRestoring      ServerUpdateState = "restoring"                       // ServerStatusReady, ServerStatusDetailReadyRestoring, NeedsUpdate: false, InMaintenance: InMaintenanceRestoring or InMaintenanceEvacuated
 	ServerUpdateStateInMaintenancePostRestore    ServerUpdateState = "post restore"                    // ServerStatusReady, ServerStatusDetailReadyRestoring, NeedsUpdate: false, InMaintenance: NotInMaintenance
 	ServerUpdateStateRebootPending               ServerUpdateState = "reboot pending"                  // ServerStatusReady, NeedsUpdate: false, NeedsReboot: true, IsIncusCluster: false, InMaintenance: NotInMaintenance
 	ServerUpdateStateRebooting                   ServerUpdateState = "rebooting"                       // ServerStatusOffline, ServerStatusDetailOfflineRebooting
@@ -894,9 +894,12 @@ func (s Server) UpdateState() ServerUpdateState {
 		return ServerUpdateStateInMaintenanceRestoring
 	}
 
-	if s.StatusDetail == ServerStatusDetailReadyRestoring &&
-		ptr.From(s.VersionData.InMaintenance) == NotInMaintenance {
-		return ServerUpdateStateInMaintenancePostRestore
+	if s.StatusDetail == ServerStatusDetailReadyRestoring {
+		if ptr.From(s.VersionData.InMaintenance) == NotInMaintenance {
+			return ServerUpdateStateInMaintenancePostRestore
+		}
+
+		return ServerUpdateStateInMaintenanceRestoring
 	}
 
 	if ptr.From(s.VersionData.NeedsReboot) {

--- a/shared/api/provisioning_server.go
+++ b/shared/api/provisioning_server.go
@@ -894,7 +894,8 @@ func (s Server) UpdateState() ServerUpdateState {
 		return ServerUpdateStateInMaintenanceRestoring
 	}
 
-	if s.StatusDetail == ServerStatusDetailReadyRestoring {
+	if s.StatusDetail == ServerStatusDetailReadyRestoring &&
+		ptr.From(s.VersionData.InMaintenance) == NotInMaintenance {
 		return ServerUpdateStateInMaintenancePostRestore
 	}
 

--- a/shared/api/provisioning_server_test.go
+++ b/shared/api/provisioning_server_test.go
@@ -188,6 +188,17 @@ func TestServerVersionData_UpdateState(t *testing.T) {
 		},
 		{
 			status:        api.ServerStatusReady,
+			statusDetail:  api.ServerStatusDetailReadyRestoring,
+			cluster:       "one",
+			needsUpdate:   false,
+			needsReboot:   false,
+			inMaintenance: api.InMaintenanceEvacuated,
+			isTypeIncus:   true,
+
+			wantServerUpdateState: api.ServerUpdateStateInMaintenanceRestorePending,
+		},
+		{
+			status:        api.ServerStatusReady,
 			statusDetail:  api.ServerStatusDetailNone,
 			cluster:       "",
 			needsUpdate:   false,

--- a/shared/api/provisioning_server_test.go
+++ b/shared/api/provisioning_server_test.go
@@ -195,7 +195,7 @@ func TestServerVersionData_UpdateState(t *testing.T) {
 			inMaintenance: api.InMaintenanceEvacuated,
 			isTypeIncus:   true,
 
-			wantServerUpdateState: api.ServerUpdateStateInMaintenanceRestorePending,
+			wantServerUpdateState: api.ServerUpdateStateInMaintenanceRestoring,
 		},
 		{
 			status:        api.ServerStatusReady,


### PR DESCRIPTION
The main change here is the added latch, which prevents the overall rolling update state to move backwards. This is combined with defensive state update (prefer under reporting).

Additionally, the tests are changed to use event driven mocks instead of time driven to fix the flaky-nes.

End 2 end test `TestE2E_WithTokenAndUpdateChannel_CreateAndUpdateCluster` successfully passed with the refactored rolling update logic.