### PR TITLE
api: make GET /1.0 unauthenticated for auth detection

### DIFF
--- a/internal/api/daemon.go
+++ b/internal/api/daemon.go
@@ -992,6 +992,11 @@ func (d *Daemon) setupAPIRoutes(
 	}
 
 	isAuthenticationRequired := func(r *http.Request) bool {
+		// GET /1.0 signals the available authentication methods
+		if r.Method == http.MethodGet && r.URL.Path == "/1.0" {
+			return false
+		}
+
 		// POST /1.0/provisioning/servers is authenticated using a token.
 		if r.Method == http.MethodPost && r.URL.Path == "/1.0/provisioning/servers" {
 			return false

--- a/internal/api/daemon_authentication_test.go
+++ b/internal/api/daemon_authentication_test.go
@@ -126,7 +126,7 @@ func TestAuthentication(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 		},
 		{
-			name: "plain http GET /1.0 - unauthorized",
+			name: "plain http GET /1.0 - infos for unauthorized client",
 			client: func() *http.Client {
 				return &http.Client{
 					Transport: &http.Transport{
@@ -140,7 +140,7 @@ func TestAuthentication(t *testing.T) {
 			resource: "https://localhost:17443/1.0",
 			body:     http.NoBody,
 
-			wantStatusCode: http.StatusUnauthorized,
+			wantStatusCode: http.StatusOK,
 		},
 		{
 			name: "socket GET /1.0",
@@ -194,6 +194,58 @@ func TestAuthentication(t *testing.T) {
 				"Authorization": "Bearer " + accessTokens[viewer],
 			},
 			body: http.NoBody,
+
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name: "plain http GET /1.0/provisioning/servers - unauthorized",
+			client: func() *http.Client {
+				return &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: &tls.Config{
+							InsecureSkipVerify: true,
+						},
+					},
+				}
+			},
+			method:   http.MethodGet,
+			resource: "https://localhost:17443/1.0/provisioning/servers",
+			body:     http.NoBody,
+
+			wantStatusCode: http.StatusUnauthorized,
+		},
+		{
+			name: "socket GET /1.0/provisioning/servers",
+			client: func() *http.Client {
+				return &http.Client{
+					Transport: &http.Transport{
+						DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+							return net.Dial("unix", filepath.Join(tmpDir, "unix.socket"))
+						},
+					},
+				}
+			},
+			method:   http.MethodGet,
+			resource: "http://unix.socket/1.0/provisioning/servers",
+			body:     http.NoBody,
+
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name: "client cert http GET /1.0/provisioning/servers",
+			client: func() *http.Client {
+				return &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: &tls.Config{
+							Certificates:       []tls.Certificate{cert},
+							InsecureSkipVerify: true,
+						},
+					},
+				}
+			},
+			method:   http.MethodGet,
+			resource: "https://localhost:17443/1.0/provisioning/servers",
+			body:     http.NoBody,
 
 			wantStatusCode: http.StatusOK,
 		},

--- a/internal/api/daemon_system_config_update_test.go
+++ b/internal/api/daemon_system_config_update_test.go
@@ -132,7 +132,7 @@ func TestSystemConfigUpdate(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		// Expect unauthorized over http without trusted credentials.
-		req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/1.0", port), http.NoBody)
+		req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/1.0/provisioning/tokens", port), http.NoBody)
 		require.NoError(t, err)
 		resp, err = tcpClient.Do(req)
 		require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestSystemConfigUpdate(t *testing.T) {
 			},
 		}
 
-		req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/1.0", port), http.NoBody)
+		req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/1.0/provisioning/tokens", port), http.NoBody)
 		require.NoError(t, err)
 		resp, err = tcpClient.Do(req)
 		require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestSystemConfigUpdate(t *testing.T) {
 			},
 		}
 
-		req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/1.0", port), http.NoBody)
+		req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/1.0/provisioning/tokens", port), http.NoBody)
 		require.NoError(t, err)
 		req.Header.Add("Authorization", "Bearer "+accessTokens[admin])
 		resp, err = tcpClient.Do(req)
@@ -210,7 +210,7 @@ func TestSystemConfigUpdate(t *testing.T) {
 			},
 		}
 
-		req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/1.0", port), http.NoBody)
+		req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/1.0/provisioning/tokens", port), http.NoBody)
 		require.NoError(t, err)
 		req.Header.Add("Authorization", "Bearer "+accessTokens[admin])
 		resp, err = tcpClient.Do(req)
@@ -259,7 +259,7 @@ func TestSystemConfigUpdate(t *testing.T) {
 			},
 		}
 
-		req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/1.0", port), http.NoBody)
+		req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/1.0/provisioning/tokens", port), http.NoBody)
 		require.NoError(t, err)
 		req.Header.Add("Authorization", "Bearer "+accessTokens[viewer])
 		resp, err = tcpClient.Do(req)


### PR DESCRIPTION
Currently, adding a new remote with OIDC with the operations-center does not work.