### PR TITLE
provisioning/adapter/bmc/redfish: make detection of reset types defensive

### DIFF
--- a/internal/provisioning/adapter/bmc/redfish/redfish.go
+++ b/internal/provisioning/adapter/bmc/redfish/redfish.go
@@ -778,17 +778,12 @@ func (r redfish) performReset(ctx context.Context, server provisioning.Server, r
 		return nil, fmt.Errorf("Failed get BMC system: %w", err)
 	}
 
-	actionInfo, err := system.ResetActionInfo()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get BMC reset action info: %w", err)
-	}
-
-	allowedResetTypes, err := actionInfo.GetParamValues("ResetType", schemas.StringParameterTypes)
+	allowedResetTypes, err := system.GetSupportedResetTypes()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get supported reset types from BMC: %w", err)
 	}
 
-	if !slices.Contains(allowedResetTypes, string(resetType)) {
+	if len(allowedResetTypes) > 0 && !slices.Contains(allowedResetTypes, resetType) {
 		return nil, fmt.Errorf("Reset type %q is not supported by the BMC, supported types are: %v", resetType, allowedResetTypes)
 	}
 

--- a/internal/provisioning/adapter/bmc/redfish/redfish_test.go
+++ b/internal/provisioning/adapter/bmc/redfish/redfish_test.go
@@ -1190,6 +1190,38 @@ const (
   }
 }`
 
+	resetSystemInlineBody = `{
+  "@odata.id": "/redfish/v1/Systems/1",
+  "Id": "1",
+  "Actions": {
+    "#ComputerSystem.Reset": {
+      "Target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+      "ResetType@Redfish.AllowableValues": ["On", "ForceOn", "ForceOff", "GracefulShutdown", "GracefulRestart", "ForceRestart"]
+    }
+  }
+}`
+
+	resetSystemInlineUnsupportedBody = `{
+  "@odata.id": "/redfish/v1/Systems/1",
+  "Id": "1",
+  "Actions": {
+    "#ComputerSystem.Reset": {
+      "Target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+      "ResetType@Redfish.AllowableValues": ["foobar"]
+    }
+  }
+}`
+
+	resetSystemNoResetTypesBody = `{
+  "@odata.id": "/redfish/v1/Systems/1",
+  "Id": "1",
+  "Actions": {
+    "#ComputerSystem.Reset": {
+      "Target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset"
+    }
+  }
+}`
+
 	// resetActionInfoUnsupportedBody advertises an unused reset type, so the reset type check fails.
 	resetActionInfoUnsupportedBody = `{
   "@odata.id": "/redfish/v1/Systems/1/ResetActionInfo",
@@ -1274,6 +1306,34 @@ func TestRedfish_ServerPowerOn(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
+			name:  "success - reset types advertised inline without action info",
+			force: false,
+
+			serviceRootStatusCode: http.StatusOK,
+			systemsStatusCode:     http.StatusOK,
+			systemsBody:           resetSystemsBody,
+			systemStatusCode:      http.StatusOK,
+			systemBody:            resetSystemInlineBody,
+			resetStatusCode:       http.StatusNoContent,
+
+			wantResetType: "On",
+			assertErr:     require.NoError,
+		},
+		{
+			name:  "success - no reset types advertised",
+			force: false,
+
+			serviceRootStatusCode: http.StatusOK,
+			systemsStatusCode:     http.StatusOK,
+			systemsBody:           resetSystemsBody,
+			systemStatusCode:      http.StatusOK,
+			systemBody:            resetSystemNoResetTypesBody,
+			resetStatusCode:       http.StatusNoContent,
+
+			wantResetType: "On",
+			assertErr:     require.NoError,
+		},
+		{
 			name: "error - failed to connect to BMC",
 
 			serviceRootStatusCode: http.StatusInternalServerError,
@@ -1319,7 +1379,7 @@ func TestRedfish_ServerPowerOn(t *testing.T) {
 			systemBody:                resetSystemBody,
 			resetActionInfoStatusCode: http.StatusInternalServerError,
 
-			assertErr: errassert.Contains("Failed to get BMC reset action info"),
+			assertErr: errassert.Contains("Failed to get supported reset types from BMC"),
 		},
 		{
 			name: "error - reset type parameter missing from action info",
@@ -1347,6 +1407,17 @@ func TestRedfish_ServerPowerOn(t *testing.T) {
 			systemBody:                resetSystemBody,
 			resetActionInfoStatusCode: http.StatusOK,
 			resetActionInfoBody:       resetActionInfoUnsupportedBody,
+
+			assertErr: errassert.Contains("is not supported by the BMC"),
+		},
+		{
+			name: "error - reset type not supported by BMC advertised inline",
+
+			serviceRootStatusCode: http.StatusOK,
+			systemsStatusCode:     http.StatusOK,
+			systemsBody:           resetSystemsBody,
+			systemStatusCode:      http.StatusOK,
+			systemBody:            resetSystemInlineUnsupportedBody,
 
 			assertErr: errassert.Contains("is not supported by the BMC"),
 		},
@@ -1447,6 +1518,34 @@ func TestRedfish_ServerPowerOff(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
+			name:  "success - reset types advertised inline without action info",
+			force: false,
+
+			serviceRootStatusCode: http.StatusOK,
+			systemsStatusCode:     http.StatusOK,
+			systemsBody:           resetSystemsBody,
+			systemStatusCode:      http.StatusOK,
+			systemBody:            resetSystemInlineBody,
+			resetStatusCode:       http.StatusNoContent,
+
+			wantResetType: "GracefulShutdown",
+			assertErr:     require.NoError,
+		},
+		{
+			name:  "success - no reset types advertised",
+			force: false,
+
+			serviceRootStatusCode: http.StatusOK,
+			systemsStatusCode:     http.StatusOK,
+			systemsBody:           resetSystemsBody,
+			systemStatusCode:      http.StatusOK,
+			systemBody:            resetSystemNoResetTypesBody,
+			resetStatusCode:       http.StatusNoContent,
+
+			wantResetType: "GracefulShutdown",
+			assertErr:     require.NoError,
+		},
+		{
 			name: "error - failed to connect to BMC",
 
 			serviceRootStatusCode: http.StatusInternalServerError,
@@ -1492,7 +1591,7 @@ func TestRedfish_ServerPowerOff(t *testing.T) {
 			systemBody:                resetSystemBody,
 			resetActionInfoStatusCode: http.StatusInternalServerError,
 
-			assertErr: errassert.Contains("Failed to get BMC reset action info"),
+			assertErr: errassert.Contains("Failed to get supported reset types from BMC"),
 		},
 		{
 			name: "error - reset type parameter missing from action info",
@@ -1520,6 +1619,17 @@ func TestRedfish_ServerPowerOff(t *testing.T) {
 			systemBody:                resetSystemBody,
 			resetActionInfoStatusCode: http.StatusOK,
 			resetActionInfoBody:       resetActionInfoUnsupportedBody,
+
+			assertErr: errassert.Contains("is not supported by the BMC"),
+		},
+		{
+			name: "error - reset type not supported by BMC advertised inline",
+
+			serviceRootStatusCode: http.StatusOK,
+			systemsStatusCode:     http.StatusOK,
+			systemsBody:           resetSystemsBody,
+			systemStatusCode:      http.StatusOK,
+			systemBody:            resetSystemInlineUnsupportedBody,
 
 			assertErr: errassert.Contains("is not supported by the BMC"),
 		},
@@ -1620,6 +1730,34 @@ func TestRedfish_ServerRestart(t *testing.T) {
 			assertErr: require.NoError,
 		},
 		{
+			name:  "success - reset types advertised inline without action info",
+			force: false,
+
+			serviceRootStatusCode: http.StatusOK,
+			systemsStatusCode:     http.StatusOK,
+			systemsBody:           resetSystemsBody,
+			systemStatusCode:      http.StatusOK,
+			systemBody:            resetSystemInlineBody,
+			resetStatusCode:       http.StatusNoContent,
+
+			wantResetType: "GracefulRestart",
+			assertErr:     require.NoError,
+		},
+		{
+			name:  "success - no reset types advertised",
+			force: false,
+
+			serviceRootStatusCode: http.StatusOK,
+			systemsStatusCode:     http.StatusOK,
+			systemsBody:           resetSystemsBody,
+			systemStatusCode:      http.StatusOK,
+			systemBody:            resetSystemNoResetTypesBody,
+			resetStatusCode:       http.StatusNoContent,
+
+			wantResetType: "GracefulRestart",
+			assertErr:     require.NoError,
+		},
+		{
 			name: "error - failed to connect to BMC",
 
 			serviceRootStatusCode: http.StatusInternalServerError,
@@ -1665,7 +1803,7 @@ func TestRedfish_ServerRestart(t *testing.T) {
 			systemBody:                resetSystemBody,
 			resetActionInfoStatusCode: http.StatusInternalServerError,
 
-			assertErr: errassert.Contains("Failed to get BMC reset action info"),
+			assertErr: errassert.Contains("Failed to get supported reset types from BMC"),
 		},
 		{
 			name: "error - reset type parameter missing from action info",
@@ -1693,6 +1831,17 @@ func TestRedfish_ServerRestart(t *testing.T) {
 			systemBody:                resetSystemBody,
 			resetActionInfoStatusCode: http.StatusOK,
 			resetActionInfoBody:       resetActionInfoUnsupportedBody,
+
+			assertErr: errassert.Contains("is not supported by the BMC"),
+		},
+		{
+			name: "error - reset type not supported by BMC advertised inline",
+
+			serviceRootStatusCode: http.StatusOK,
+			systemsStatusCode:     http.StatusOK,
+			systemsBody:           resetSystemsBody,
+			systemStatusCode:      http.StatusOK,
+			systemBody:            resetSystemInlineUnsupportedBody,
 
 			assertErr: errassert.Contains("is not supported by the BMC"),
 		},


### PR DESCRIPTION
first try AllowableValues then try ActionInfo