### PR TITLE
Make server update BMC connection test optional

### DIFF
--- a/internal/api/api_provisioning_server.go
+++ b/internal/api/api_provisioning_server.go
@@ -539,7 +539,7 @@ func (s *serverHandler) serverPut(r *http.Request) response.Response {
 		currentServer.Channel = server.Channel
 	}
 
-	err = s.service.Update(ctx, *currentServer, false, updateServer)
+	err = s.service.Update(ctx, *currentServer, false, updateServer, true)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed updating server %q: %w", name, err))
 	}

--- a/internal/provisioning/cluster/cluster_service.go
+++ b/internal/provisioning/cluster/cluster_service.go
@@ -466,7 +466,7 @@ func (s *clusterService) Create(ctx context.Context, newCluster provisioning.Clu
 	}
 
 	for _, server := range servers {
-		err = s.serverSvc.Update(ctx, server, true, true)
+		err = s.serverSvc.Update(ctx, server, true, true, false)
 		if err != nil {
 			return newCluster, err
 		}
@@ -768,7 +768,7 @@ func (s *clusterService) AddServers(ctx context.Context, name string, serverName
 
 		// Update Server records in the repo.
 		for _, server := range additionalServers {
-			err = s.serverSvc.Update(ctx, server, true, true)
+			err = s.serverSvc.Update(ctx, server, true, true, false)
 			if err != nil {
 				return fmt.Errorf("Failed to update server record for %q: %w", server.Name, err)
 			}
@@ -1475,14 +1475,14 @@ func (s *clusterService) Update(ctx context.Context, newCluster provisioning.Clu
 	for _, server := range servers {
 		previousChannel := server.Channel
 		server.Channel = newCluster.Channel
-		err = s.serverSvc.Update(ctx, server, true, true)
+		err = s.serverSvc.Update(ctx, server, true, true, false)
 		if err != nil {
 			return fmt.Errorf("Failed to update member %q of cluster %q: %w", server.Name, newCluster.Name, err)
 		}
 
 		reverter.Add(func() {
 			server.Channel = previousChannel
-			err = s.serverSvc.Update(ctx, server, true, false)
+			err = s.serverSvc.Update(ctx, server, true, false, false)
 			if err != nil {
 				slog.ErrorContext(ctx, "Failed to restore previous server state after failed to update member server of cluster", slog.String("cluster", newCluster.Name), slog.String("server", server.Name), logger.Err(err))
 			}

--- a/internal/provisioning/cluster/cluster_service_test.go
+++ b/internal/provisioning/cluster/cluster_service_test.go
@@ -3355,7 +3355,7 @@ func TestClusterService_Create(t *testing.T) {
 					server, err := queue.Pop(t, &tc.serverSvcGetByName)
 					return server, err
 				},
-				UpdateFunc: func(ctx context.Context, server provisioning.Server, force bool, updateSystem bool) error {
+				UpdateFunc: func(ctx context.Context, server provisioning.Server, force bool, updateSystem bool, bmcConnectionTest bool) error {
 					return tc.serverSvcUpdateErr
 				},
 				UpdateSystemUpdateFunc: func(ctx context.Context, name string, updateConfig provisioning.ServerSystemUpdate) error {
@@ -4964,7 +4964,7 @@ func TestClusterService_AddServers(t *testing.T) {
 				GetAllWithFilterFunc: func(ctx context.Context, filter provisioning.ServerFilter) (provisioning.Servers, error) {
 					return tc.serverSvcGetAllWithFilter, tc.serverSvcGetAllWithFilterErr
 				},
-				UpdateFunc: func(ctx context.Context, server provisioning.Server, force, updateSystem bool) error {
+				UpdateFunc: func(ctx context.Context, server provisioning.Server, force, updateSystem, bmcConnectionTest bool) error {
 					return tc.serverSvcUpdateErr
 				},
 			}
@@ -8174,7 +8174,7 @@ func TestClusterService_RemoveServer(t *testing.T) {
 				GetAllWithFilterFunc: func(ctx context.Context, filter provisioning.ServerFilter) (provisioning.Servers, error) {
 					return tc.serverSvcGetAllWithFilter, tc.serverSvcGetAllWithFilterErr
 				},
-				UpdateFunc: func(ctx context.Context, server provisioning.Server, force, updateSystem bool) error {
+				UpdateFunc: func(ctx context.Context, server provisioning.Server, force, updateSystem, bmcConnectionTest bool) error {
 					return tc.serverSvcUpdateErr.PopOrNil(t)
 				},
 				FactoryResetByNameFunc: func(ctx context.Context, name string, tokenID *uuid.UUID, tokenSeedName *string, force bool) error {
@@ -9067,7 +9067,7 @@ func TestClusterService_Update(t *testing.T) {
 				GetAllWithFilterFunc: func(ctx context.Context, filter provisioning.ServerFilter) (provisioning.Servers, error) {
 					return tc.serverSvcGetAllWithFilter, tc.serverSvcGetAllWithFilterErr
 				},
-				UpdateFunc: func(ctx context.Context, server provisioning.Server, force, updateSystem bool) error {
+				UpdateFunc: func(ctx context.Context, server provisioning.Server, force, updateSystem, bmcConnectionTest bool) error {
 					return tc.serverSvcUpdateErrs.PopOrNil(t)
 				},
 			}

--- a/internal/provisioning/middleware/server_service_prometheus_gen.go
+++ b/internal/provisioning/middleware/server_service_prometheus_gen.go
@@ -598,7 +598,7 @@ func (_d ServerServiceWithPrometheus) SyncCluster(ctx context.Context, clusterNa
 }
 
 // Update implements provisioning.ServerService.
-func (_d ServerServiceWithPrometheus) Update(ctx context.Context, server provisioning.Server, force bool, updateSystem bool) (err error) {
+func (_d ServerServiceWithPrometheus) Update(ctx context.Context, server provisioning.Server, force bool, updateSystem bool, bmcConnectionTest bool) (err error) {
 	_since := time.Now()
 	defer func() {
 		result := "ok"
@@ -608,7 +608,7 @@ func (_d ServerServiceWithPrometheus) Update(ctx context.Context, server provisi
 
 		serverServiceDurationSummaryVec.WithLabelValues(_d.instanceName, "Update", result).Observe(time.Since(_since).Seconds())
 	}()
-	return _d.base.Update(ctx, server, force, updateSystem)
+	return _d.base.Update(ctx, server, force, updateSystem, bmcConnectionTest)
 }
 
 // UpdateSystemByName implements provisioning.ServerService.

--- a/internal/provisioning/middleware/server_service_slog_gen.go
+++ b/internal/provisioning/middleware/server_service_slog_gen.go
@@ -1426,7 +1426,7 @@ func (_d ServerServiceWithSlog) SyncCluster(ctx context.Context, clusterName str
 }
 
 // Update implements provisioning.ServerService.
-func (_d ServerServiceWithSlog) Update(ctx context.Context, server provisioning.Server, force bool, updateSystem bool) (err error) {
+func (_d ServerServiceWithSlog) Update(ctx context.Context, server provisioning.Server, force bool, updateSystem bool, bmcConnectionTest bool) (err error) {
 	log := slog.With()
 	if slog.Default().Enabled(ctx, logger.LevelTrace) {
 		log = log.With(
@@ -1434,6 +1434,7 @@ func (_d ServerServiceWithSlog) Update(ctx context.Context, server provisioning.
 			slog.Any("server", server),
 			slog.Bool("force", force),
 			slog.Bool("updateSystem", updateSystem),
+			slog.Bool("bmcConnectionTest", bmcConnectionTest),
 		)
 	}
 	log.DebugContext(ctx, "=> calling Update")
@@ -1458,7 +1459,7 @@ func (_d ServerServiceWithSlog) Update(ctx context.Context, server provisioning.
 			log.DebugContext(ctx, "<= method Update finished")
 		}
 	}()
-	return _d._base.Update(ctx, server, force, updateSystem)
+	return _d._base.Update(ctx, server, force, updateSystem, bmcConnectionTest)
 }
 
 // UpdateSystemByName implements provisioning.ServerService.

--- a/internal/provisioning/mock/server_service_mock_gen.go
+++ b/internal/provisioning/mock/server_service_mock_gen.go
@@ -145,7 +145,7 @@ var _ provisioning.ServerService = &ServerServiceMock{}
 //			SyncClusterFunc: func(ctx context.Context, clusterName string) error {
 //				panic("mock out the SyncCluster method")
 //			},
-//			UpdateFunc: func(ctx context.Context, server provisioning.Server, force bool, updateSystem bool) error {
+//			UpdateFunc: func(ctx context.Context, server provisioning.Server, force bool, updateSystem bool, bmcConnectionTest bool) error {
 //				panic("mock out the Update method")
 //			},
 //			UpdateSystemByNameFunc: func(ctx context.Context, name string, updateRequest api.ServerUpdatePost, force bool) error {
@@ -297,7 +297,7 @@ type ServerServiceMock struct {
 	SyncClusterFunc func(ctx context.Context, clusterName string) error
 
 	// UpdateFunc mocks the Update method.
-	UpdateFunc func(ctx context.Context, server provisioning.Server, force bool, updateSystem bool) error
+	UpdateFunc func(ctx context.Context, server provisioning.Server, force bool, updateSystem bool, bmcConnectionTest bool) error
 
 	// UpdateSystemByNameFunc mocks the UpdateSystemByName method.
 	UpdateSystemByNameFunc func(ctx context.Context, name string, updateRequest api.ServerUpdatePost, force bool) error
@@ -654,6 +654,8 @@ type ServerServiceMock struct {
 			Force bool
 			// UpdateSystem is the updateSystem argument value.
 			UpdateSystem bool
+			// BmcConnectionTest is the bmcConnectionTest argument value.
+			BmcConnectionTest bool
 		}
 		// UpdateSystemByName holds details about calls to the UpdateSystemByName method.
 		UpdateSystemByName []struct {
@@ -2296,25 +2298,27 @@ func (mock *ServerServiceMock) SyncClusterCalls() []struct {
 }
 
 // Update calls UpdateFunc.
-func (mock *ServerServiceMock) Update(ctx context.Context, server provisioning.Server, force bool, updateSystem bool) error {
+func (mock *ServerServiceMock) Update(ctx context.Context, server provisioning.Server, force bool, updateSystem bool, bmcConnectionTest bool) error {
 	if mock.UpdateFunc == nil {
 		panic("ServerServiceMock.UpdateFunc: method is nil but ServerService.Update was just called")
 	}
 	callInfo := struct {
-		Ctx          context.Context
-		Server       provisioning.Server
-		Force        bool
-		UpdateSystem bool
+		Ctx               context.Context
+		Server            provisioning.Server
+		Force             bool
+		UpdateSystem      bool
+		BmcConnectionTest bool
 	}{
-		Ctx:          ctx,
-		Server:       server,
-		Force:        force,
-		UpdateSystem: updateSystem,
+		Ctx:               ctx,
+		Server:            server,
+		Force:             force,
+		UpdateSystem:      updateSystem,
+		BmcConnectionTest: bmcConnectionTest,
 	}
 	mock.lockUpdate.Lock()
 	mock.calls.Update = append(mock.calls.Update, callInfo)
 	mock.lockUpdate.Unlock()
-	return mock.UpdateFunc(ctx, server, force, updateSystem)
+	return mock.UpdateFunc(ctx, server, force, updateSystem, bmcConnectionTest)
 }
 
 // UpdateCalls gets all the calls that were made to Update.
@@ -2322,16 +2326,18 @@ func (mock *ServerServiceMock) Update(ctx context.Context, server provisioning.S
 //
 //	len(mockedServerService.UpdateCalls())
 func (mock *ServerServiceMock) UpdateCalls() []struct {
-	Ctx          context.Context
-	Server       provisioning.Server
-	Force        bool
-	UpdateSystem bool
+	Ctx               context.Context
+	Server            provisioning.Server
+	Force             bool
+	UpdateSystem      bool
+	BmcConnectionTest bool
 } {
 	var calls []struct {
-		Ctx          context.Context
-		Server       provisioning.Server
-		Force        bool
-		UpdateSystem bool
+		Ctx               context.Context
+		Server            provisioning.Server
+		Force             bool
+		UpdateSystem      bool
+		BmcConnectionTest bool
 	}
 	mock.lockUpdate.RLock()
 	calls = mock.calls.Update

--- a/internal/provisioning/server/server_service.go
+++ b/internal/provisioning/server/server_service.go
@@ -518,13 +518,13 @@ func availableVersionGreaterThan(currentVersion string, availableVersion string)
 
 // Update writes the new server state to the DB and pushes the changed
 // settings to the system as well, if updateSystem argument is set to true.
-func (s *serverService) Update(ctx context.Context, server provisioning.Server, force bool, updateSystem bool) error {
+func (s *serverService) Update(ctx context.Context, server provisioning.Server, force bool, updateSystem bool, bmcConnectionTest bool) error {
 	err := server.Validate()
 	if err != nil {
 		return fmt.Errorf("Failed to validate server for update: %w", err)
 	}
 
-	if server.BMCConfig.HasBMC() {
+	if bmcConnectionTest && server.BMCConfig.HasBMC() {
 		client, ok := s.bmcServerClients[server.BMCConfig.APIType]
 		if !ok {
 			return fmt.Errorf("Failed to get BMC server client for type %q", server.BMCConfig.APIType)
@@ -619,7 +619,7 @@ func (s *serverService) UpdateSystemNetwork(ctx context.Context, name string, sy
 		updatedServer.LastStatusUpdated = s.now()
 		updatedServer.LastSeen = s.now()
 
-		err = s.Update(ctx, *updatedServer, true, false)
+		err = s.Update(ctx, *updatedServer, true, false, false)
 		if err != nil {
 			return fmt.Errorf("Failed to update system network: %w", err)
 		}
@@ -687,7 +687,7 @@ func (s *serverService) UpdateSystemStorage(ctx context.Context, name string, sy
 		updatedServer.LastStatusUpdated = s.now()
 		updatedServer.LastSeen = s.now()
 
-		err = s.Update(ctx, *updatedServer, true, false)
+		err = s.Update(ctx, *updatedServer, true, false, false)
 		if err != nil {
 			return fmt.Errorf("Failed to update system network: %w", err)
 		}
@@ -1564,7 +1564,7 @@ func (s *serverService) UpdateSystemByName(ctx context.Context, name string, upd
 		server.StatusDetail = api.ServerStatusDetailReadyUpdatingOS
 		server.LastStatusUpdated = s.now()
 
-		err = s.Update(ctx, *server, false, false)
+		err = s.Update(ctx, *server, false, false, false)
 		if err != nil {
 			return fmt.Errorf("Failed to update server state to updating for %q: %w", server.Name, err)
 		}
@@ -1576,7 +1576,7 @@ func (s *serverService) UpdateSystemByName(ctx context.Context, name string, upd
 	}
 
 	reverter.Add(func() {
-		err := s.Update(ctx, previousServer, false, false)
+		err := s.Update(ctx, previousServer, false, false, false)
 		if err != nil {
 			slog.ErrorContext(ctx, "Failed to restore previous server state after failed to update the system", slog.String("server", name), logger.Err(err))
 		}

--- a/internal/provisioning/server/server_service_test.go
+++ b/internal/provisioning/server/server_service_test.go
@@ -1383,15 +1383,18 @@ func TestServerService_Update(t *testing.T) {
 	certificate := string(certificatePEM)
 
 	tests := []struct {
-		name           string
-		argForce       bool
-		server         provisioning.Server
-		repoUpdateErrs queue.Errs
-		repoGetByName  []queue.Item[*provisioning.Server]
+		name                 string
+		argForce             bool
+		argBMCConnectionTest bool
+		server               provisioning.Server
+		repoUpdateErrs       queue.Errs
+		repoGetByName        []queue.Item[*provisioning.Server]
 
 		registerBMCClient    bool
 		bmcConnectionTestCrt string
 		bmcConnectionTestErr error
+
+		wantBMCConnectionTestCalled bool
 
 		assertErr           require.ErrorAssertionFunc
 		assertLog           log.MatcherFunc
@@ -1475,8 +1478,11 @@ one
 					},
 				},
 			},
+			argBMCConnectionTest: true,
 			registerBMCClient:    true,
 			bmcConnectionTestCrt: "cert-pem",
+
+			wantBMCConnectionTestCalled: true,
 
 			assertErr: require.NoError,
 			assertLog: log.Empty,
@@ -1526,8 +1532,11 @@ one
 					},
 				},
 			},
+			argBMCConnectionTest: true,
 			registerBMCClient:    true,
 			bmcConnectionTestCrt: "cert-pem",
+
+			wantBMCConnectionTestCalled: true,
 
 			assertErr: require.NoError,
 			assertLog: log.Empty,
@@ -1577,8 +1586,11 @@ one
 					},
 				},
 			},
+			argBMCConnectionTest: true,
 			registerBMCClient:    true,
 			bmcConnectionTestCrt: "cert-pem",
+
+			wantBMCConnectionTestCalled: true,
 
 			assertErr: require.NoError,
 			assertLog: log.Empty,
@@ -1608,7 +1620,8 @@ one
 					AutoPinCertificate: true,
 				},
 			},
-			registerBMCClient: false, // client for redfish-v1-generic is not registered
+			argBMCConnectionTest: true,
+			registerBMCClient:    false, // client for redfish-v1-generic is not registered
 
 			assertErr:           errassert.Contains(`Failed to get BMC server client for type "redfish-v1-generic"`),
 			assertLog:           log.Empty,
@@ -1634,12 +1647,71 @@ one
 					AutoPinCertificate: true,
 				},
 			},
+			argBMCConnectionTest: true,
 			registerBMCClient:    true,
 			bmcConnectionTestErr: boom.Error,
+
+			wantBMCConnectionTestCalled: true,
 
 			assertErr:           boom.ErrorIs,
 			assertLog:           log.Empty,
 			assertUpdatedServer: func(t *testing.T, server provisioning.Server) { t.Helper() },
+		},
+		{
+			name:     "success - BMC connection test not requested - unreachable BMC does not fail the server state update",
+			argForce: false,
+			server: provisioning.Server{
+				Name:          "one",
+				Type:          api.ServerTypeIncus,
+				Cluster:       ptr.To("one"),
+				ConnectionURL: "http://one/",
+				Certificate: `-----BEGIN CERTIFICATE-----
+one
+-----END CERTIFICATE-----
+`,
+				Status:  api.ServerStatusReady,
+				Channel: "stable",
+				BMCConfig: api.BMCConfig{
+					APIType:            api.BMCAPITypeRedfishV1Generic,
+					Endpoint:           "https://bmc.example.com/",
+					AutoPinCertificate: true,
+				},
+			},
+			repoGetByName: []queue.Item[*provisioning.Server]{
+				{
+					Value: &provisioning.Server{
+						Name:    "one",
+						Channel: "stable",
+					},
+				},
+				{
+					Value: &provisioning.Server{
+						Name:    "one",
+						Channel: "stable",
+					},
+				},
+				{
+					Value: &provisioning.Server{
+						Name:    "one",
+						Channel: "stable",
+					},
+				},
+			},
+			argBMCConnectionTest: false,
+			registerBMCClient:    true,
+			bmcConnectionTestErr: boom.Error,
+
+			wantBMCConnectionTestCalled: false,
+
+			assertErr: require.NoError,
+			assertLog: log.Empty,
+			assertUpdatedServer: func(t *testing.T, server provisioning.Server) {
+				t.Helper()
+				// The BMC config is persisted unmodified, pinning of the certificate
+				// is deferred to the next update, which requests a connection test.
+				require.Empty(t, server.BMCConfig.Certificate)
+				require.True(t, server.BMCConfig.AutoPinCertificate)
+			},
 		},
 		{
 			name: "error - validation",
@@ -1831,8 +1903,11 @@ one
 				},
 			}
 
+			bmcClientConnectionTestCalled := false
 			bmcClient := &adapterMock.BMCServerClientPortMock{
 				ConnectionTestFunc: func(ctx context.Context, server provisioning.Server) (string, error) {
+					bmcClientConnectionTestCalled = true
+
 					return tc.bmcConnectionTestCrt, tc.bmcConnectionTestErr
 				},
 			}
@@ -1874,13 +1949,14 @@ one
 			)
 
 			// Run test
-			err = serverSvc.Update(t.Context(), tc.server, tc.argForce, true)
+			err = serverSvc.Update(t.Context(), tc.server, tc.argForce, true, tc.argBMCConnectionTest)
 
 			// Assert
 			tc.assertErr(t, err)
 			tc.assertLog(t, logBuf)
 			tc.assertUpdatedServer(t, updatedServer)
 
+			require.Equal(t, tc.wantBMCConnectionTestCalled, bmcClientConnectionTestCalled)
 			require.Empty(t, tc.repoUpdateErrs)
 		})
 	}
@@ -7766,6 +7842,7 @@ func TestServerService_UpdateSystemByName(t *testing.T) {
 		clientUpdateOSErr                               error
 		channelSvcGetByNameErr                          error
 		clusterSvcIsInstanceLifecycleOperationPermitted bool
+		registerUnreachableBMCClient                    bool
 		flakyLog                                        bool
 
 		assertErr require.ErrorAssertionFunc
@@ -7953,6 +8030,33 @@ func TestServerService_UpdateSystemByName(t *testing.T) {
 			assertErr: boom.ErrorIs,
 			assertLog: log.Match("Failed to restore previous server state after failed to update the system server=one err=.*boom!"),
 		},
+		{
+			name: "success - trigger OS update - unreachable BMC",
+			argUpdateRequest: api.ServerUpdatePost{
+				OS: api.ServerUpdateApplication{
+					Name:          "os",
+					TriggerUpdate: true,
+				},
+			},
+			repoGetByName: provisioning.Server{
+				Name:          "operations-center",
+				Type:          api.ServerTypeOperationsCenter,
+				Channel:       "stable",
+				ConnectionURL: "https://one/",
+				Certificate:   "certificate",
+				Status:        api.ServerStatusReady,
+				BMCConfig: api.BMCConfig{
+					APIType:            api.BMCAPITypeRedfishV1Generic,
+					Endpoint:           "https://bmc.example.com/",
+					AutoPinCertificate: true,
+				},
+			},
+			clusterSvcIsInstanceLifecycleOperationPermitted: true,
+			registerUnreachableBMCClient:                    true,
+
+			assertErr: require.NoError,
+			assertLog: log.Noop,
+		},
 	}
 
 	for _, tc := range tests {
@@ -8004,9 +8108,22 @@ func TestServerService_UpdateSystemByName(t *testing.T) {
 				},
 			}
 
+			opts := []provisioningServer.Option{
+				provisioningServer.WithWarningEmitter(provisioning.NoopWarningService{}),
+			}
+			if tc.registerUnreachableBMCClient {
+				bmcClient := &adapterMock.BMCServerClientPortMock{
+					ConnectionTestFunc: func(ctx context.Context, server provisioning.Server) (string, error) {
+						return "", boom.Error
+					},
+				}
+
+				opts = append(opts, provisioningServer.AddBMCServerClient(api.BMCAPITypeRedfishV1Generic, bmcClient))
+			}
+
 			serverSvc := provisioningServer.New(
 				repo, client, nil, nil, clusterSvc, channelSvc, updateSvc, tls.Certificate{},
-				provisioningServer.WithWarningEmitter(provisioning.NoopWarningService{}),
+				opts...,
 			)
 
 			logT := log.TestifyT(t)

--- a/internal/provisioning/server_ports.go
+++ b/internal/provisioning/server_ports.go
@@ -18,7 +18,7 @@ type ServerService interface {
 	GetAllNames(ctx context.Context) ([]string, error)
 	GetAllNamesWithFilter(ctx context.Context, filter ServerFilter) ([]string, error)
 	GetByName(ctx context.Context, name string) (*Server, error)
-	Update(ctx context.Context, server Server, force bool, updateSystem bool) error
+	Update(ctx context.Context, server Server, force bool, updateSystem bool, bmcConnectionTest bool) error
 	UpdateSystemNetwork(ctx context.Context, name string, networkConfig ServerSystemNetwork) error
 	UpdateSystemStorage(ctx context.Context, name string, networkConfig ServerSystemStorage) error
 	GetSystemProvider(ctx context.Context, name string) (ServerSystemProvider, error)


### PR DESCRIPTION
Don't make server status updates fail if the connection test to the BMC fails (e.g. during rolling update).