### PR TITLE
Prepare BMC functions for automated deployment

### DIFF
--- a/internal/provisioning/adapter/bmc/redfish/redfish.go
+++ b/internal/provisioning/adapter/bmc/redfish/redfish.go
@@ -670,6 +670,67 @@ func (r redfish) ServerSetLocationIndicator(ctx context.Context, server provisio
 
 const defaultWaitForTaskRetryAfter = 2 * time.Second
 
+// taskState reports the state of the task behind uri and, while it is still
+// running, how long the BMC asks to wait before the next poll.
+func taskState(client *gofish.APIClient, uri string) (api.BMCTaskState, time.Duration, error) {
+	resp, err := client.Get(uri)
+	if err != nil {
+		if isTaskMonitorGone(err) {
+			return api.BMCTaskStateUnknown, 0, nil
+		}
+
+		return api.BMCTaskStateUnknown, 0, wrapRedfishError(err)
+	}
+
+	resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusAccepted: // still running
+		return api.BMCTaskStateRunning, taskRetryAfter(resp), nil
+
+	case http.StatusOK, http.StatusCreated: // task finished
+		return api.BMCTaskStateCompleted, 0, nil
+
+	default:
+		return api.BMCTaskStateUnknown, 0, fmt.Errorf("Unexpected status %d polling %s", resp.StatusCode, uri)
+	}
+}
+
+// taskRetryAfter returns the poll interval the BMC asks for.
+func taskRetryAfter(resp *http.Response) time.Duration {
+	ra := resp.Header.Get("Retry-After")
+	if ra == "" {
+		return defaultWaitForTaskRetryAfter
+	}
+
+	secs, err := strconv.Atoi(ra)
+	if err != nil {
+		return defaultWaitForTaskRetryAfter
+	}
+
+	return time.Duration(secs) * time.Second
+}
+
+func (r redfish) TaskState(ctx context.Context, server provisioning.Server, taskMonitor *provisioning.BMCTaskMonitor) (api.BMCTaskState, error) {
+	if taskMonitor == nil || taskMonitor.URI == "" {
+		return api.BMCTaskStateUnknown, nil
+	}
+
+	client, logout, err := r.getClient(ctx, server)
+	if err != nil {
+		return api.BMCTaskStateUnknown, fmt.Errorf("Failed to connect to BMC %q: %w", server.BMCConfig.Endpoint, err)
+	}
+
+	defer logout()
+
+	state, _, err := taskState(client, taskMonitor.URI)
+	if err != nil {
+		return api.BMCTaskStateUnknown, err
+	}
+
+	return state, nil
+}
+
 func (r redfish) WaitForTask(ctx context.Context, server provisioning.Server, taskMonitor *provisioning.BMCTaskMonitor) error {
 	if taskMonitor == nil {
 		return nil
@@ -690,34 +751,23 @@ func (r redfish) WaitForTask(ctx context.Context, server provisioning.Server, ta
 			return fmt.Errorf("Waiting for task %s: %w", uri, err)
 		}
 
-		resp, err := client.Get(uri)
+		state, retryAfter, err := taskState(client, uri)
 		if err != nil {
-			return wrapRedfishError(err)
+			return err
 		}
 
-		resp.Body.Close()
+		switch state {
+		case api.BMCTaskStateRunning: // keep polling
 
-		switch resp.StatusCode {
-		case http.StatusAccepted: // still running
-
-		case http.StatusOK, http.StatusCreated: // task finished
+		case api.BMCTaskStateCompleted:
 			return nil
 
-		default:
-			return fmt.Errorf("Unexpected status %d polling %s", resp.StatusCode, uri)
-		}
-
-		wait := defaultWaitForTaskRetryAfter
-		ra := resp.Header.Get("Retry-After")
-		if ra != "" {
-			secs, err := strconv.Atoi(ra)
-			if err == nil {
-				wait = time.Duration(secs) * time.Second
-			}
+		case api.BMCTaskStateUnknown:
+			return fmt.Errorf("The BMC does not know the task %s (any more)", uri)
 		}
 
 		select {
-		case <-time.After(wait):
+		case <-time.After(retryAfter):
 			continue
 
 		case <-ctx.Done():

--- a/internal/provisioning/adapter/bmc/redfish/redfish_error.go
+++ b/internal/provisioning/adapter/bmc/redfish/redfish_error.go
@@ -203,6 +203,16 @@ func isValueRejected(err error, property string, value string) bool {
 		(redfishErrorMentions(err, property) || redfishErrorMentions(err, value))
 }
 
+func isTaskMonitorGone(err error) bool {
+	var redfishErr *schemas.Error
+	if !errors.As(err, &redfishErr) {
+		return false
+	}
+
+	return redfishErr.HTTPReturnedStatusCode == http.StatusNotFound ||
+		redfishErr.HTTPReturnedStatusCode == http.StatusGone
+}
+
 func isPreconditionRejected(err error) bool {
 	var redfishErr *schemas.Error
 	if !errors.As(err, &redfishErr) {

--- a/internal/provisioning/adapter/bmc/redfish/redfish_test.go
+++ b/internal/provisioning/adapter/bmc/redfish/redfish_test.go
@@ -2235,6 +2235,21 @@ func TestRedfish_WaitForTask(t *testing.T) {
 			assertErr: require.Error,
 		},
 		{
+			name: "error - task monitor gone",
+			argCtx: func(t *testing.T) context.Context {
+				t.Helper()
+				return t.Context()
+			},
+			argTaskMonitor: &provisioning.BMCTaskMonitor{
+				URI: "/redfish/v1/TaskMonitor/1",
+			},
+
+			serviceRootStatusCode:  http.StatusOK,
+			taskMonitorStatusCodes: []int{http.StatusGone},
+
+			assertErr: require.Error,
+		},
+		{
 			name: "error - context already canceled",
 			argCtx: func(t *testing.T) context.Context {
 				t.Helper()
@@ -2287,6 +2302,149 @@ func TestRedfish_WaitForTask(t *testing.T) {
 			err := client.WaitForTask(tc.argCtx(t), provisioning.Server{BMCConfig: api.BMCConfig{Endpoint: svr.URL}}, tc.argTaskMonitor)
 
 			tc.assertErr(t, err)
+		})
+	}
+}
+
+func TestRedfish_TaskState(t *testing.T) {
+	tests := []struct {
+		name           string
+		argTaskMonitor *provisioning.BMCTaskMonitor
+
+		serviceRootStatusCode  int
+		taskMonitorStatusCodes []int
+
+		wantState api.BMCTaskState
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name:           "success - nil task monitor",
+			argTaskMonitor: nil,
+
+			// The BMC is never contacted, so the service root is not served.
+			serviceRootStatusCode: http.StatusInternalServerError,
+
+			wantState: api.BMCTaskStateUnknown,
+			assertErr: require.NoError,
+		},
+		{
+			name:           "success - empty task monitor URI",
+			argTaskMonitor: &provisioning.BMCTaskMonitor{},
+
+			serviceRootStatusCode: http.StatusInternalServerError,
+
+			wantState: api.BMCTaskStateUnknown,
+			assertErr: require.NoError,
+		},
+		{
+			name: "success - running",
+			argTaskMonitor: &provisioning.BMCTaskMonitor{
+				URI: "/redfish/v1/TaskMonitor/1",
+			},
+
+			serviceRootStatusCode:  http.StatusOK,
+			taskMonitorStatusCodes: []int{http.StatusAccepted},
+
+			wantState: api.BMCTaskStateRunning,
+			assertErr: require.NoError,
+		},
+		{
+			name: "success - completed",
+			argTaskMonitor: &provisioning.BMCTaskMonitor{
+				URI: "/redfish/v1/TaskMonitor/1",
+			},
+
+			serviceRootStatusCode:  http.StatusOK,
+			taskMonitorStatusCodes: []int{http.StatusOK},
+
+			wantState: api.BMCTaskStateCompleted,
+			assertErr: require.NoError,
+		},
+		{
+			name: "success - completed with created status",
+			argTaskMonitor: &provisioning.BMCTaskMonitor{
+				URI: "/redfish/v1/TaskMonitor/1",
+			},
+
+			serviceRootStatusCode:  http.StatusOK,
+			taskMonitorStatusCodes: []int{http.StatusCreated},
+
+			wantState: api.BMCTaskStateCompleted,
+			assertErr: require.NoError,
+		},
+		{
+			name: "success - task monitor not found",
+			argTaskMonitor: &provisioning.BMCTaskMonitor{
+				URI: "/redfish/v1/TaskMonitor/1",
+			},
+
+			serviceRootStatusCode:  http.StatusOK,
+			taskMonitorStatusCodes: []int{http.StatusNotFound},
+
+			wantState: api.BMCTaskStateUnknown,
+			assertErr: require.NoError,
+		},
+		{
+			name: "success - task monitor gone",
+			argTaskMonitor: &provisioning.BMCTaskMonitor{
+				URI: "/redfish/v1/TaskMonitor/1",
+			},
+
+			serviceRootStatusCode:  http.StatusOK,
+			taskMonitorStatusCodes: []int{http.StatusGone},
+
+			wantState: api.BMCTaskStateUnknown,
+			assertErr: require.NoError,
+		},
+		{
+			name: "error - failed to connect to BMC",
+			argTaskMonitor: &provisioning.BMCTaskMonitor{
+				URI: "/redfish/v1/TaskMonitor/1",
+			},
+
+			serviceRootStatusCode: http.StatusInternalServerError,
+
+			wantState: api.BMCTaskStateUnknown,
+			assertErr: require.Error,
+		},
+		{
+			name: "error - unexpected status code polling task",
+			argTaskMonitor: &provisioning.BMCTaskMonitor{
+				URI: "/redfish/v1/TaskMonitor/1",
+			},
+
+			serviceRootStatusCode:  http.StatusOK,
+			taskMonitorStatusCodes: []int{http.StatusInternalServerError},
+
+			wantState: api.BMCTaskStateUnknown,
+			assertErr: require.Error,
+		},
+		{
+			name: "error - unexpected success status code polling task",
+			argTaskMonitor: &provisioning.BMCTaskMonitor{
+				URI: "/redfish/v1/TaskMonitor/1",
+			},
+
+			serviceRootStatusCode:  http.StatusOK,
+			taskMonitorStatusCodes: []int{http.StatusNoContent},
+
+			wantState: api.BMCTaskStateUnknown,
+			assertErr: require.Error,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svr := newMockRedfishServer(t, mockRedfishServer{
+				serviceRootStatusCode:  tc.serviceRootStatusCode,
+				taskMonitorStatusCodes: tc.taskMonitorStatusCodes,
+			}, nil)
+
+			client := redfish.New()
+			state, err := client.TaskState(t.Context(), provisioning.Server{BMCConfig: api.BMCConfig{Endpoint: svr.URL}}, tc.argTaskMonitor)
+
+			tc.assertErr(t, err)
+			require.Equal(t, tc.wantState, state)
 		})
 	}
 }

--- a/internal/provisioning/adapter/middleware/bmc_server_client_port_error_wrapper_gen.go
+++ b/internal/provisioning/adapter/middleware/bmc_server_client_port_error_wrapper_gen.go
@@ -166,6 +166,16 @@ func (_d BMCServerClientPortWithErrorWrapper) ServerSetLocationIndicator(ctx con
 	return _d._base.ServerSetLocationIndicator(ctx, server, active)
 }
 
+// TaskState implements provisioning.BMCServerClientPort.
+func (_d BMCServerClientPortWithErrorWrapper) TaskState(ctx context.Context, server provisioning.Server, taskMonitor *provisioning.BMCTaskMonitor) (bMCTaskState api.BMCTaskState, err error) {
+	defer func() {
+		if err != nil {
+			err = _d._wrapErrFunc(err)
+		}
+	}()
+	return _d._base.TaskState(ctx, server, taskMonitor)
+}
+
 // WaitForTask implements provisioning.BMCServerClientPort.
 func (_d BMCServerClientPortWithErrorWrapper) WaitForTask(ctx context.Context, server provisioning.Server, taskMonitor *provisioning.BMCTaskMonitor) (err error) {
 	defer func() {

--- a/internal/provisioning/adapter/middleware/bmc_server_client_port_prometheus_gen.go
+++ b/internal/provisioning/adapter/middleware/bmc_server_client_port_prometheus_gen.go
@@ -235,6 +235,20 @@ func (_d BMCServerClientPortWithPrometheus) ServerSetLocationIndicator(ctx conte
 	return _d.base.ServerSetLocationIndicator(ctx, server, active)
 }
 
+// TaskState implements provisioning.BMCServerClientPort.
+func (_d BMCServerClientPortWithPrometheus) TaskState(ctx context.Context, server provisioning.Server, taskMonitor *provisioning.BMCTaskMonitor) (bMCTaskState api.BMCTaskState, err error) {
+	_since := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+
+		bmcserverClientPortDurationSummaryVec.WithLabelValues(_d.instanceName, "TaskState", result).Observe(time.Since(_since).Seconds())
+	}()
+	return _d.base.TaskState(ctx, server, taskMonitor)
+}
+
 // WaitForTask implements provisioning.BMCServerClientPort.
 func (_d BMCServerClientPortWithPrometheus) WaitForTask(ctx context.Context, server provisioning.Server, taskMonitor *provisioning.BMCTaskMonitor) (err error) {
 	_since := time.Now()

--- a/internal/provisioning/adapter/middleware/bmc_server_client_port_slog_gen.go
+++ b/internal/provisioning/adapter/middleware/bmc_server_client_port_slog_gen.go
@@ -543,6 +543,42 @@ func (_d BMCServerClientPortWithSlog) ServerSetLocationIndicator(ctx context.Con
 	return _d._base.ServerSetLocationIndicator(ctx, server, active)
 }
 
+// TaskState implements provisioning.BMCServerClientPort.
+func (_d BMCServerClientPortWithSlog) TaskState(ctx context.Context, server provisioning.Server, taskMonitor *provisioning.BMCTaskMonitor) (bMCTaskState api.BMCTaskState, err error) {
+	log := slog.With()
+	if slog.Default().Enabled(ctx, logger.LevelTrace) {
+		log = log.With(
+			slog.Any("ctx", ctx),
+			slog.Any("server", server),
+			slog.Any("taskMonitor", taskMonitor),
+		)
+	}
+	log.DebugContext(ctx, "=> calling TaskState")
+	defer func() {
+		log := slog.With()
+		if slog.Default().Enabled(ctx, logger.LevelTrace) {
+			log = slog.With(
+				slog.Any("bMCTaskState", bMCTaskState),
+				slog.Any("err", err),
+			)
+		} else {
+			if err != nil {
+				log = slog.With("err", err)
+			}
+		}
+		if err != nil {
+			if _d._isInformativeErrFunc(err) {
+				log.DebugContext(ctx, "<= method TaskState returned an informative error")
+			} else {
+				log.ErrorContext(ctx, "<= method TaskState returned an error")
+			}
+		} else {
+			log.DebugContext(ctx, "<= method TaskState finished")
+		}
+	}()
+	return _d._base.TaskState(ctx, server, taskMonitor)
+}
+
 // WaitForTask implements provisioning.BMCServerClientPort.
 func (_d BMCServerClientPortWithSlog) WaitForTask(ctx context.Context, server provisioning.Server, taskMonitor *provisioning.BMCTaskMonitor) (err error) {
 	log := slog.With()

--- a/internal/provisioning/adapter/mock/bmc_server_client_port_mock_gen.go
+++ b/internal/provisioning/adapter/mock/bmc_server_client_port_mock_gen.go
@@ -64,6 +64,9 @@ var _ provisioning.BMCServerClientPort = &BMCServerClientPortMock{}
 //			ServerSetLocationIndicatorFunc: func(ctx context.Context, server provisioning.Server, active bool) error {
 //				panic("mock out the ServerSetLocationIndicator method")
 //			},
+//			TaskStateFunc: func(ctx context.Context, server provisioning.Server, taskMonitor *provisioning.BMCTaskMonitor) (api.BMCTaskState, error) {
+//				panic("mock out the TaskState method")
+//			},
 //			WaitForTaskFunc: func(ctx context.Context, server provisioning.Server, taskMonitor *provisioning.BMCTaskMonitor) error {
 //				panic("mock out the WaitForTask method")
 //			},
@@ -115,6 +118,9 @@ type BMCServerClientPortMock struct {
 
 	// ServerSetLocationIndicatorFunc mocks the ServerSetLocationIndicator method.
 	ServerSetLocationIndicatorFunc func(ctx context.Context, server provisioning.Server, active bool) error
+
+	// TaskStateFunc mocks the TaskState method.
+	TaskStateFunc func(ctx context.Context, server provisioning.Server, taskMonitor *provisioning.BMCTaskMonitor) (api.BMCTaskState, error)
 
 	// WaitForTaskFunc mocks the WaitForTask method.
 	WaitForTaskFunc func(ctx context.Context, server provisioning.Server, taskMonitor *provisioning.BMCTaskMonitor) error
@@ -247,6 +253,15 @@ type BMCServerClientPortMock struct {
 			// Active is the active argument value.
 			Active bool
 		}
+		// TaskState holds details about calls to the TaskState method.
+		TaskState []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Server is the server argument value.
+			Server provisioning.Server
+			// TaskMonitor is the taskMonitor argument value.
+			TaskMonitor *provisioning.BMCTaskMonitor
+		}
 		// WaitForTask holds details about calls to the WaitForTask method.
 		WaitForTask []struct {
 			// Ctx is the ctx argument value.
@@ -271,6 +286,7 @@ type BMCServerClientPortMock struct {
 	lockServerPowerOn              sync.RWMutex
 	lockServerRestart              sync.RWMutex
 	lockServerSetLocationIndicator sync.RWMutex
+	lockTaskState                  sync.RWMutex
 	lockWaitForTask                sync.RWMutex
 }
 
@@ -831,6 +847,46 @@ func (mock *BMCServerClientPortMock) ServerSetLocationIndicatorCalls() []struct 
 	mock.lockServerSetLocationIndicator.RLock()
 	calls = mock.calls.ServerSetLocationIndicator
 	mock.lockServerSetLocationIndicator.RUnlock()
+	return calls
+}
+
+// TaskState calls TaskStateFunc.
+func (mock *BMCServerClientPortMock) TaskState(ctx context.Context, server provisioning.Server, taskMonitor *provisioning.BMCTaskMonitor) (api.BMCTaskState, error) {
+	if mock.TaskStateFunc == nil {
+		panic("BMCServerClientPortMock.TaskStateFunc: method is nil but BMCServerClientPort.TaskState was just called")
+	}
+	callInfo := struct {
+		Ctx         context.Context
+		Server      provisioning.Server
+		TaskMonitor *provisioning.BMCTaskMonitor
+	}{
+		Ctx:         ctx,
+		Server:      server,
+		TaskMonitor: taskMonitor,
+	}
+	mock.lockTaskState.Lock()
+	mock.calls.TaskState = append(mock.calls.TaskState, callInfo)
+	mock.lockTaskState.Unlock()
+	return mock.TaskStateFunc(ctx, server, taskMonitor)
+}
+
+// TaskStateCalls gets all the calls that were made to TaskState.
+// Check the length with:
+//
+//	len(mockedBMCServerClientPort.TaskStateCalls())
+func (mock *BMCServerClientPortMock) TaskStateCalls() []struct {
+	Ctx         context.Context
+	Server      provisioning.Server
+	TaskMonitor *provisioning.BMCTaskMonitor
+} {
+	var calls []struct {
+		Ctx         context.Context
+		Server      provisioning.Server
+		TaskMonitor *provisioning.BMCTaskMonitor
+	}
+	mock.lockTaskState.RLock()
+	calls = mock.calls.TaskState
+	mock.lockTaskState.RUnlock()
 	return calls
 }
 

--- a/internal/provisioning/server/server_service.go
+++ b/internal/provisioning/server/server_service.go
@@ -2470,21 +2470,32 @@ func (s *serverService) BMCRefreshByName(ctx context.Context, name string) error
 }
 
 func (s *serverService) BMCServerPowerOnByName(ctx context.Context, name string, force bool) error {
+	_, err := s.bmcServerPowerOnByName(ctx, name, force, true)
+
+	return err
+}
+
+// bmcServerPowerOnByName returns the task monitor instead of awaiting it in the background, if wait is false.
+func (s *serverService) bmcServerPowerOnByName(ctx context.Context, name string, force bool, wait bool) (*provisioning.BMCTaskMonitor, error) {
 	server, client, err := s.getServerAndBMCClientByName(ctx, name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	taskMonitor, err := client.ServerPowerOn(ctx, *server, force)
 	if err != nil {
-		return fmt.Errorf("Failed to trigger power on of server %q via BMC: %w", server.Name, err)
+		return nil, fmt.Errorf("Failed to trigger power on of server %q via BMC: %w", server.Name, err)
+	}
+
+	if !wait {
+		return taskMonitor, nil
 	}
 
 	go func() {
 		// Use a detached context in order to make sure, no existing DB transaction is inherited.
 		ctx := context.Background()
 
-		err = client.WaitForTask(ctx, *server, taskMonitor)
+		err := client.WaitForTask(ctx, *server, taskMonitor)
 		if err != nil {
 			slog.WarnContext(ctx, "Failed to wait for task monitor to complete after server power on operation", logger.Err(err))
 		}
@@ -2495,25 +2506,36 @@ func (s *serverService) BMCServerPowerOnByName(ctx context.Context, name string,
 		}
 	}()
 
-	return nil
+	return nil, nil
 }
 
 func (s *serverService) BMCServerPowerOffByName(ctx context.Context, name string, force bool) error {
+	_, err := s.bmcServerPowerOffByName(ctx, name, force, true)
+
+	return err
+}
+
+// bmcServerPowerOffByName returns the task monitor instead of awaiting it in the background, if wait is false.
+func (s *serverService) bmcServerPowerOffByName(ctx context.Context, name string, force bool, wait bool) (*provisioning.BMCTaskMonitor, error) {
 	server, client, err := s.getServerAndBMCClientByName(ctx, name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	taskMonitor, err := client.ServerPowerOff(ctx, *server, force)
 	if err != nil {
-		return fmt.Errorf("Failed to trigger power off of server %q via BMC: %w", server.Name, err)
+		return nil, fmt.Errorf("Failed to trigger power off of server %q via BMC: %w", server.Name, err)
+	}
+
+	if !wait {
+		return taskMonitor, nil
 	}
 
 	go func() {
 		// Use a detached context in order to make sure, no existing DB transaction is inherited.
 		ctx := context.Background()
 
-		err = client.WaitForTask(ctx, *server, taskMonitor)
+		err := client.WaitForTask(ctx, *server, taskMonitor)
 		if err != nil {
 			slog.WarnContext(ctx, "Failed to wait for task monitor to complete after server power off operation", logger.Err(err))
 		}
@@ -2524,21 +2546,32 @@ func (s *serverService) BMCServerPowerOffByName(ctx context.Context, name string
 		}
 	}()
 
-	return nil
+	return nil, nil
 }
 
 func (s *serverService) BMCServerRestartByName(ctx context.Context, name string, force bool) error {
+	_, err := s.bmcServerRestartByName(ctx, name, force, true)
+
+	return err
+}
+
+// bmcServerRestartByName returns the task monitor instead of discarding it, if wait is false.
+func (s *serverService) bmcServerRestartByName(ctx context.Context, name string, force bool, wait bool) (*provisioning.BMCTaskMonitor, error) {
 	server, client, err := s.getServerAndBMCClientByName(ctx, name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = client.ServerRestart(ctx, *server, force)
+	taskMonitor, err := client.ServerRestart(ctx, *server, force)
 	if err != nil {
-		return fmt.Errorf("Failed to trigger restart of server %q via BMC: %w", server.Name, err)
+		return nil, fmt.Errorf("Failed to trigger restart of server %q via BMC: %w", server.Name, err)
 	}
 
-	return nil
+	if !wait {
+		return taskMonitor, nil
+	}
+
+	return nil, nil
 }
 
 func (s *serverService) BMCServerSetLocationIndicatorByName(ctx context.Context, name string, active bool) error {
@@ -2561,14 +2594,25 @@ func (s *serverService) BMCServerSetLocationIndicatorByName(ctx context.Context,
 }
 
 func (s *serverService) ApplyBIOSAttributesByName(ctx context.Context, name string, attributes map[string]any) error {
+	_, err := s.applyBIOSAttributesByName(ctx, name, attributes, true)
+
+	return err
+}
+
+// applyBIOSAttributesByName returns the task monitor instead of awaiting it in the background, if wait is false.
+func (s *serverService) applyBIOSAttributesByName(ctx context.Context, name string, attributes map[string]any, wait bool) (*provisioning.BMCTaskMonitor, error) {
 	server, client, err := s.getServerAndBMCClientByName(ctx, name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	taskMonitor, err := client.ApplyBIOSAttributes(ctx, *server, attributes)
 	if err != nil {
-		return fmt.Errorf("Failed to trigger BIOS attribute application of server %q via BMC: %w", server.Name, err)
+		return nil, fmt.Errorf("Failed to trigger BIOS attribute application of server %q via BMC: %w", server.Name, err)
+	}
+
+	if !wait {
+		return taskMonitor, nil
 	}
 
 	// The BIOS settings are applied on the next reset of the server, so the task
@@ -2583,7 +2627,7 @@ func (s *serverService) ApplyBIOSAttributesByName(ctx context.Context, name stri
 		}
 	}()
 
-	return nil
+	return nil, nil
 }
 
 func (s *serverService) BMCBIOSAttributesByName(ctx context.Context, name string) ([]api.BIOSAttribute, error) {
@@ -2662,26 +2706,33 @@ func (s *serverService) BMCDumpByName(ctx context.Context, name string, addition
 }
 
 func (s *serverService) BMCAttachMediaByName(ctx context.Context, name string, media api.ServerBMCAttachMedia) error {
+	_, err := s.bmcAttachMediaByName(ctx, name, media, true)
+
+	return err
+}
+
+// bmcAttachMediaByName returns the task monitor instead of awaiting it in the background, if wait is false.
+func (s *serverService) bmcAttachMediaByName(ctx context.Context, name string, media api.ServerBMCAttachMedia, wait bool) (*provisioning.BMCTaskMonitor, error) {
 	if name == "" {
-		return fmt.Errorf("Server name cannot be empty: %w", domain.ErrOperationNotPermitted)
+		return nil, fmt.Errorf("Server name cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
 
 	tokenUUID, err := uuid.Parse(media.TokenUUID)
 	if err != nil {
-		return fmt.Errorf("Invalid token UUID %q: %w", media.TokenUUID, domain.ErrOperationNotPermitted)
+		return nil, fmt.Errorf("Invalid token UUID %q: %w", media.TokenUUID, domain.ErrOperationNotPermitted)
 	}
 
 	if media.Seed == "" {
-		return fmt.Errorf("Token seed cannot be empty: %w", domain.ErrOperationNotPermitted)
+		return nil, fmt.Errorf("Token seed cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
 
 	if media.VirtualMediaID == "" {
-		return fmt.Errorf("Virtual media ID cannot be empty: %w", domain.ErrOperationNotPermitted)
+		return nil, fmt.Errorf("Virtual media ID cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
 
 	imageType := api.ImageType(media.Type)
 	if !imageType.IsValid() {
-		return fmt.Errorf("Invalid image type %q: %w", media.Type, domain.ErrOperationNotPermitted)
+		return nil, fmt.Errorf("Invalid image type %q: %w", media.Type, domain.ErrOperationNotPermitted)
 	}
 
 	// The undefined architecture is part of images.UpdateFileArchitectures, but
@@ -2689,7 +2740,7 @@ func (s *serverService) BMCAttachMediaByName(ctx context.Context, name string, m
 	architecture := images.UpdateFileArchitecture(media.Architecture)
 	_, ok := images.UpdateFileArchitectures[architecture]
 	if !ok || architecture == images.UpdateFileArchitectureUndefined {
-		return fmt.Errorf("Invalid architecture %q: %w", media.Architecture, domain.ErrOperationNotPermitted)
+		return nil, fmt.Errorf("Invalid architecture %q: %w", media.Architecture, domain.ErrOperationNotPermitted)
 	}
 
 	// Verify the requested channel exists, if provided. An empty channel lets
@@ -2697,7 +2748,7 @@ func (s *serverService) BMCAttachMediaByName(ctx context.Context, name string, m
 	if media.Channel != "" {
 		_, err = s.channelSvc.GetByName(ctx, media.Channel)
 		if err != nil {
-			return fmt.Errorf("Failed to get channel %q: %w", media.Channel, err)
+			return nil, fmt.Errorf("Failed to get channel %q: %w", media.Channel, err)
 		}
 	}
 
@@ -2705,23 +2756,23 @@ func (s *serverService) BMCAttachMediaByName(ctx context.Context, name string, m
 	// without authentication.
 	seed, err := s.tokenSvc.GetTokenSeedByName(ctx, tokenUUID, media.Seed)
 	if err != nil {
-		return fmt.Errorf("Failed to get token seed %q: %w", media.Seed, err)
+		return nil, fmt.Errorf("Failed to get token seed %q: %w", media.Seed, err)
 	}
 
 	if !seed.Public {
-		return fmt.Errorf("Token seed %q must be public to attach it as installation media via the BMC: %w", media.Seed, domain.ErrOperationNotPermitted)
+		return nil, fmt.Errorf("Token seed %q must be public to attach it as installation media via the BMC: %w", media.Seed, domain.ErrOperationNotPermitted)
 	}
 
 	fingerprintID, err := s.tokenSvc.ResolveTokenSeedImageID(ctx, tokenUUID, seed.Name, imageType, architecture, media.Channel)
 	if err != nil {
-		return fmt.Errorf("Failed to resolve the installation media image of token seed %q: %w", media.Seed, err)
+		return nil, fmt.Errorf("Failed to resolve the installation media image of token seed %q: %w", media.Seed, err)
 	}
 
 	// Build the image URL the BMC streams the installation media from. It points
 	// at the public token seed image endpoint of Operations Center.
 	base := config.GetNetwork().OperationsCenterAddress
 	if base == "" {
-		return fmt.Errorf("Operations Center address is not configured, cannot build installation media URL: %w", domain.ErrOperationNotPermitted)
+		return nil, fmt.Errorf("Operations Center address is not configured, cannot build installation media URL: %w", domain.ErrOperationNotPermitted)
 	}
 
 	// OperationsCenterAddress is validated on config save.
@@ -2740,12 +2791,12 @@ func (s *serverService) BMCAttachMediaByName(ctx context.Context, name string, m
 
 	server, err := s.repo.GetByName(ctx, name)
 	if err != nil {
-		return fmt.Errorf("Failed to get server %q by name: %w", name, err)
+		return nil, fmt.Errorf("Failed to get server %q by name: %w", name, err)
 	}
 
 	client, ok := s.bmcServerClients[server.BMCConfig.APIType]
 	if !ok {
-		return fmt.Errorf("Failed to get BMC server client for type %q", server.BMCConfig.APIType)
+		return nil, fmt.Errorf("Failed to get BMC server client for type %q", server.BMCConfig.APIType)
 	}
 
 	mediaMessage := lifecycle.BMCVirtualMediaMessage{
@@ -2762,17 +2813,21 @@ func (s *serverService) BMCAttachMediaByName(ctx context.Context, name string, m
 
 	taskMonitor, err := client.AttachMedia(ctx, *server, media.VirtualMediaID, imageURL.String(), media.SetBootDevice)
 	if err != nil {
-		return fmt.Errorf("Failed to attach media to server %q via BMC: %w", server.Name, err)
+		return nil, fmt.Errorf("Failed to attach media to server %q via BMC: %w", server.Name, err)
 	}
 
 	mediaMessage.Operation = lifecycle.BMCVirtualMediaOperationAttach
 	lifecycle.BMCVirtualMediaSignal.Emit(ctx, mediaMessage)
 
+	if !wait {
+		return taskMonitor, nil
+	}
+
 	go func() {
 		// Use a detached context in order to make sure, no existing DB transaction is inherited.
 		ctx := context.Background()
 
-		err = client.WaitForTask(ctx, *server, taskMonitor)
+		err := client.WaitForTask(ctx, *server, taskMonitor)
 		if err != nil {
 			slog.WarnContext(ctx, "Failed to wait for task monitor to complete after attach media operation", logger.Err(err))
 		}
@@ -2783,7 +2838,7 @@ func (s *serverService) BMCAttachMediaByName(ctx context.Context, name string, m
 		}
 	}()
 
-	return nil
+	return nil, nil
 }
 
 // maxMediaURLLength is the length beyond which BMCs are known to cut the image
@@ -2807,34 +2862,51 @@ func mediaURLWarnings(mediaURL *url.URL) []string {
 }
 
 func (s *serverService) BMCDetachMediaByName(ctx context.Context, name string, virtualMediaID string) error {
+	_, err := s.bmcDetachMediaByName(ctx, name, virtualMediaID, true)
+
+	return err
+}
+
+// bmcDetachMediaByName returns the task monitor instead of awaiting it in the background, if wait is false.
+func (s *serverService) bmcDetachMediaByName(ctx context.Context, name string, virtualMediaID string, wait bool) (*provisioning.BMCTaskMonitor, error) {
 	if name == "" {
-		return fmt.Errorf("Server name cannot be empty: %w", domain.ErrOperationNotPermitted)
+		return nil, fmt.Errorf("Server name cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
 
 	if virtualMediaID == "" {
-		return fmt.Errorf("Virtual media ID cannot be empty: %w", domain.ErrOperationNotPermitted)
+		return nil, fmt.Errorf("Virtual media ID cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
 
 	server, err := s.repo.GetByName(ctx, name)
 	if err != nil {
-		return fmt.Errorf("Failed to get server %q by name: %w", name, err)
+		return nil, fmt.Errorf("Failed to get server %q by name: %w", name, err)
 	}
 
 	client, ok := s.bmcServerClients[server.BMCConfig.APIType]
 	if !ok {
-		return fmt.Errorf("Failed to get BMC server client for type %q", server.BMCConfig.APIType)
+		return nil, fmt.Errorf("Failed to get BMC server client for type %q", server.BMCConfig.APIType)
 	}
 
 	taskMonitor, err := client.DetachMedia(ctx, *server, virtualMediaID)
 	if err != nil {
-		return fmt.Errorf("Failed to detach media from server %q via BMC: %w", server.Name, err)
+		return nil, fmt.Errorf("Failed to detach media from server %q via BMC: %w", server.Name, err)
+	}
+
+	lifecycle.BMCVirtualMediaSignal.Emit(ctx, lifecycle.BMCVirtualMediaMessage{
+		Operation:      lifecycle.BMCVirtualMediaOperationDetach,
+		Server:         server.Name,
+		VirtualMediaID: virtualMediaID,
+	})
+
+	if !wait {
+		return taskMonitor, nil
 	}
 
 	go func() {
 		// Use a detached context in order to make sure, no existing DB transaction is inherited.
 		ctx := context.Background()
 
-		err = client.WaitForTask(ctx, *server, taskMonitor)
+		err := client.WaitForTask(ctx, *server, taskMonitor)
 		if err != nil {
 			slog.WarnContext(ctx, "Failed to wait for task monitor to complete after detach media operation", logger.Err(err))
 		}
@@ -2845,11 +2917,5 @@ func (s *serverService) BMCDetachMediaByName(ctx context.Context, name string, v
 		}
 	}()
 
-	lifecycle.BMCVirtualMediaSignal.Emit(ctx, lifecycle.BMCVirtualMediaMessage{
-		Operation:      lifecycle.BMCVirtualMediaOperationDetach,
-		Server:         server.Name,
-		VirtualMediaID: virtualMediaID,
-	})
-
-	return nil
+	return nil, nil
 }

--- a/internal/provisioning/server/server_service_internal_test.go
+++ b/internal/provisioning/server/server_service_internal_test.go
@@ -1,11 +1,25 @@
 package server
 
 import (
+	"context"
+	"crypto/tls"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
+	"github.com/lxc/incus-os/incus-osd/api/images"
 	"github.com/stretchr/testify/require"
+
+	config "github.com/FuturFusion/operations-center/internal/config/daemon"
+	envMock "github.com/FuturFusion/operations-center/internal/environment/mock"
+	"github.com/FuturFusion/operations-center/internal/provisioning"
+	adapterMock "github.com/FuturFusion/operations-center/internal/provisioning/adapter/mock"
+	svcMock "github.com/FuturFusion/operations-center/internal/provisioning/mock"
+	repoMock "github.com/FuturFusion/operations-center/internal/provisioning/repo/mock"
+	"github.com/FuturFusion/operations-center/shared/api"
+	"github.com/FuturFusion/operations-center/shared/api/system"
 )
 
 func Test_availableVersionGreaterThan(t *testing.T) {
@@ -116,6 +130,142 @@ func Test_mediaURLWarnings(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, tc.want, mediaURLWarnings(mediaURL))
+		})
+	}
+}
+
+func TestServerService_bmcTaskMonitorHandover(t *testing.T) {
+	fixedDate := time.Date(2025, 3, 12, 10, 57, 43, 0, time.UTC)
+
+	const tokenUUID = "e9de436e-b94e-4aef-8563-883aec84096e"
+
+	taskMonitor := &provisioning.BMCTaskMonitor{
+		URI: "https://bmc.local/task/1",
+	}
+
+	setup := func(t *testing.T) *serverService {
+		t.Helper()
+
+		config.InitTest(t, &envMock.EnvironmentMock{
+			IsIncusOSFunc: func() bool {
+				return false
+			},
+		}, nil)
+
+		err := config.UpdateNetwork(t.Context(), system.NetworkPut{
+			OperationsCenterAddress: "https://192.168.1.200:8443",
+			RestServerAddress:       "[::]:8443",
+		})
+		require.NoError(t, err)
+
+		repo := &repoMock.ServerRepoMock{
+			GetByNameFunc: func(ctx context.Context, name string) (*provisioning.Server, error) {
+				return &provisioning.Server{
+					Name: "one",
+					BMCConfig: api.BMCConfig{
+						APIType: api.BMCAPITypeRedfishV1Generic,
+					},
+				}, nil
+			},
+		}
+
+		tokenSvc := &svcMock.TokenServiceMock{
+			GetTokenSeedByNameFunc: func(ctx context.Context, id uuid.UUID, name string) (*provisioning.TokenSeed, error) {
+				return &provisioning.TokenSeed{Name: name, Public: true}, nil
+			},
+			ResolveTokenSeedImageIDFunc: func(ctx context.Context, id uuid.UUID, name string, imageType api.ImageType, architecture images.UpdateFileArchitecture, channel string) (string, error) {
+				return "a1B2c3D4e5F6", nil
+			},
+		}
+
+		bmcClient := &adapterMock.BMCServerClientPortMock{
+			ServerPowerOnFunc: func(ctx context.Context, server provisioning.Server, force bool) (*provisioning.BMCTaskMonitor, error) {
+				return taskMonitor, nil
+			},
+			ServerPowerOffFunc: func(ctx context.Context, server provisioning.Server, force bool) (*provisioning.BMCTaskMonitor, error) {
+				return taskMonitor, nil
+			},
+			ServerRestartFunc: func(ctx context.Context, server provisioning.Server, force bool) (*provisioning.BMCTaskMonitor, error) {
+				return taskMonitor, nil
+			},
+			ApplyBIOSAttributesFunc: func(ctx context.Context, server provisioning.Server, attributes map[string]any) (*provisioning.BMCTaskMonitor, error) {
+				return taskMonitor, nil
+			},
+			AttachMediaFunc: func(ctx context.Context, server provisioning.Server, virtualMediaID string, mediaURL string, setBootDevice bool) (*provisioning.BMCTaskMonitor, error) {
+				return taskMonitor, nil
+			},
+			DetachMediaFunc: func(ctx context.Context, server provisioning.Server, virtualMediaID string) (*provisioning.BMCTaskMonitor, error) {
+				return taskMonitor, nil
+			},
+		}
+
+		return New(
+			repo, nil, nil, tokenSvc, nil, nil, nil, tls.Certificate{},
+			WithNow(func() time.Time { return fixedDate }),
+			AddBMCServerClient(api.BMCAPITypeRedfishV1Generic, bmcClient),
+		)
+	}
+
+	tests := []struct {
+		name string
+		call func(t *testing.T, serverSvc *serverService) (*provisioning.BMCTaskMonitor, error)
+	}{
+		{
+			name: "bmcServerPowerOnByName",
+			call: func(t *testing.T, serverSvc *serverService) (*provisioning.BMCTaskMonitor, error) {
+				t.Helper()
+				return serverSvc.bmcServerPowerOnByName(t.Context(), "one", false, false)
+			},
+		},
+		{
+			name: "bmcServerPowerOffByName",
+			call: func(t *testing.T, serverSvc *serverService) (*provisioning.BMCTaskMonitor, error) {
+				t.Helper()
+				return serverSvc.bmcServerPowerOffByName(t.Context(), "one", false, false)
+			},
+		},
+		{
+			name: "bmcServerRestartByName",
+			call: func(t *testing.T, serverSvc *serverService) (*provisioning.BMCTaskMonitor, error) {
+				t.Helper()
+				return serverSvc.bmcServerRestartByName(t.Context(), "one", false, false)
+			},
+		},
+		{
+			name: "applyBIOSAttributesByName",
+			call: func(t *testing.T, serverSvc *serverService) (*provisioning.BMCTaskMonitor, error) {
+				t.Helper()
+				return serverSvc.applyBIOSAttributesByName(t.Context(), "one", map[string]any{"NumaNodesPerSocket": 4}, false)
+			},
+		},
+		{
+			name: "bmcAttachMediaByName",
+			call: func(t *testing.T, serverSvc *serverService) (*provisioning.BMCTaskMonitor, error) {
+				t.Helper()
+				return serverSvc.bmcAttachMediaByName(t.Context(), "one", api.ServerBMCAttachMedia{
+					TokenUUID:      tokenUUID,
+					Seed:           "default",
+					Type:           "iso",
+					Architecture:   "x86_64",
+					VirtualMediaID: "system:1",
+				}, false)
+			},
+		},
+		{
+			name: "bmcDetachMediaByName",
+			call: func(t *testing.T, serverSvc *serverService) (*provisioning.BMCTaskMonitor, error) {
+				t.Helper()
+				return serverSvc.bmcDetachMediaByName(t.Context(), "one", "system:1", false)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTaskMonitor, err := tc.call(t, setup(t))
+
+			require.NoError(t, err)
+			require.Same(t, taskMonitor, gotTaskMonitor)
 		})
 	}
 }

--- a/internal/provisioning/server_ports.go
+++ b/internal/provisioning/server_ports.go
@@ -123,6 +123,7 @@ type BMCServerClientPort interface {
 	ServerRestart(ctx context.Context, server Server, force bool) (*BMCTaskMonitor, error)
 	ServerSetLocationIndicator(ctx context.Context, server Server, active bool) error
 	WaitForTask(ctx context.Context, server Server, taskMonitor *BMCTaskMonitor) error
+	TaskState(ctx context.Context, server Server, taskMonitor *BMCTaskMonitor) (api.BMCTaskState, error)
 	LogSources(ctx context.Context, server Server) ([]string, error)
 	LogEntriesBySource(ctx context.Context, server Server, logSource string) ([]api.BMCLogEvent, error)
 	Dump(ctx context.Context, server Server, additionalEndpoints []string, skipPredefined bool, trace bool) (api.BMCDump, error)

--- a/shared/api/provisioning_server_bmc.go
+++ b/shared/api/provisioning_server_bmc.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -229,4 +230,43 @@ type ServerBMCDetachMedia struct {
 	// "manager:2") as reported in the BMC virtual media data.
 	// Example: system:1
 	VirtualMediaID string `json:"virtual_media_id" yaml:"virtual_media_id"`
+}
+
+// BMCTaskState describes the state of a task started via the BMC.
+type BMCTaskState string
+
+const (
+	BMCTaskStateUnknown   BMCTaskState = "unknown"
+	BMCTaskStateRunning   BMCTaskState = "running"
+	BMCTaskStateCompleted BMCTaskState = "completed"
+)
+
+var bmcTaskStates = map[BMCTaskState]struct{}{
+	BMCTaskStateUnknown:   {},
+	BMCTaskStateRunning:   {},
+	BMCTaskStateCompleted: {},
+}
+
+func (s BMCTaskState) String() string {
+	return string(s)
+}
+
+func (s BMCTaskState) MarshalText() ([]byte, error) {
+	return []byte(s), nil
+}
+
+func (s *BMCTaskState) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		*s = BMCTaskStateUnknown
+		return nil
+	}
+
+	_, ok := bmcTaskStates[BMCTaskState(text)]
+	if !ok {
+		return fmt.Errorf("%q is not a valid BMC task state", string(text))
+	}
+
+	*s = BMCTaskState(text)
+
+	return nil
 }


### PR DESCRIPTION
Expose task monitor internally to the server service, such that the automated deployment can keep track of the task state.