### PR TITLE
e2e-tests: add test for start and stop of servers through BMC

### DIFF
--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -29,6 +29,7 @@ Other environment variables that can be set to control the tests:
 * `OPERATIONS_CENTER_E2E_TEST_DEBUG`: Enable debug output (default: "false")
 * `OPERATIONS_CENTER_E2E_TEST_NO_CLEANUP`: Disable cleanup of resources after tests, WARNING: this might cause errors, only use with single test cases (default: "false")
 * `OPERATIONS_CENTER_E2E_TEST_NO_CLEANUP_ON_ERROR`: Disable cleanup of resources after failed tests, WARNING: this might cause errors, only use with single test cases or with `-failfast` flag of `go test` (default: "false")
+* `OPERATIONS_CENTER_E2E_TEST_BMC_PROXY_ADDRESS`: Address of the end 2 end test host, at which the in-process Redfish proxy used by the BMC tests is reachable from the Operations Center VM. If not set, the address is derived from the network the Operations Center VM is attached to (default: "")
 
 ## Setup
 
@@ -187,7 +188,25 @@ Examples:
   case.
 * `t.Cleanup(cleanupTokenSeed(t, token))`, cleans up the token seed created
   during the test case.
+* `t.Cleanup(serverBMCConfigCleanup(t, tmpDir, name))`, resets the BMC config of
+  a server, so that Operations Center stops talking to a BMC, which is about to
+  go away.
 
 For debug purposes, the cleanup can be disabled by setting the environment
 variable `OPERATIONS_CENTER_E2E_TEST_NO_CLEANUP` or
 `OPERATIONS_CENTER_E2E_TEST_NO_CLEANUP_ON_ERROR` to a truthy value.
+
+### Fake BMC
+
+The BMC support of Operations Center is tested against
+[incus-redfish-proxy](https://github.com/FuturFusion/incus-redfish-proxy), which
+exposes an Incus instance through a subset of the Redfish API. The proxy is
+served in-process by the test on an ephemeral port of the end 2 end test host
+(see `startRedfishProxy`), so no additional service needs to be installed.
+
+The proxy presents a self signed certificate, which Operations Center pins
+during the connection test performed by `provisioning server edit`.
+
+The Operations Center VM reaches the proxy at the address of the end 2 end test
+host on the network the VM is attached to. If this address can not be derived
+automatically, set `OPERATIONS_CENTER_E2E_TEST_BMC_PROXY_ADDRESS`.

--- a/e2e_tests/e2e_test.go
+++ b/e2e_tests/e2e_test.go
@@ -133,6 +133,15 @@ func TestE2E_WithToken_CreateClusterAndRebootCluster(t *testing.T) {
 	)
 }
 
+func TestE2E_WithToken_ServerBMCPowerOffAndOn(t *testing.T) {
+	runE2ETest(
+		t,
+		"token - power a server off and on again via BMC",
+		setupIncusOSWithToken([]string{"IncusOS01"}),
+		serverBMCPowerOffAndOn("IncusOS01"),
+	)
+}
+
 func TestE2E_FromManualUpload_CreateCluster(t *testing.T) {
 	runE2ETest(
 		t,

--- a/e2e_tests/env.go
+++ b/e2e_tests/env.go
@@ -15,6 +15,7 @@ var (
 	debug                = envBoolOrDefault("OPERATIONS_CENTER_E2E_TEST_DEBUG", false)
 	noCleanup            = envBoolOrDefault("OPERATIONS_CENTER_E2E_TEST_NO_CLEANUP", false)
 	noCleanupOnError     = envBoolOrDefault("OPERATIONS_CENTER_E2E_TEST_NO_CLEANUP_ON_ERROR", false)
+	bmcProxyAddress      = envOrDefault("OPERATIONS_CENTER_E2E_TEST_BMC_PROXY_ADDRESS", "")
 
 	goCoverDir      = ""
 	ocE2EGoCoverDir = ""

--- a/e2e_tests/helpers.go
+++ b/e2e_tests/helpers.go
@@ -382,19 +382,34 @@ func waitExpectedLogWithContext(ctx context.Context, t *testing.T, vm string, un
 	vm = fmt.Sprintf(vm, args...)
 
 	count := 0
+	lastErr := ""
+
 	for {
-		resp := run(t, `incus exec %s -- bash -c "journalctl -b -u %s"`, vm, unit)
+		resp := runWithContext(ctx, t, `incus exec %s -- bash -c "journalctl -b -u %s"`, vm, unit)
 		if resp.err != nil {
 			return resp.err
 		}
 
-		if isRegex {
-			if regexp.MustCompile(want).MatchString(resp.Output()) {
-				break
+		if resp.Success() {
+			lastErr = ""
+
+			if isRegex {
+				if regexp.MustCompile(want).MatchString(resp.Output()) {
+					break
+				}
+			} else {
+				if strings.Contains(resp.Output(), want) {
+					break
+				}
 			}
-		} else {
-			if strings.Contains(resp.Output(), want) {
-				break
+		} else if ctx.Err() == nil {
+			// Reading the log fails as long as the VM is not (yet) reachable,
+			// e.g. while it is booting, so keep retrying, but remember the
+			// reason in order to report it, if we run out of time.
+			lastErr = resp.Error()
+
+			if count%10 == 0 {
+				t.Logf("Failed to read log of unit %q on %s: %s", unit, vm, lastErr)
 			}
 		}
 
@@ -406,6 +421,10 @@ func waitExpectedLogWithContext(ctx context.Context, t *testing.T, vm string, un
 
 		select {
 		case <-ctx.Done():
+			if lastErr != "" {
+				return fmt.Errorf("Timed out after %ds waiting for log %q on %s, last error: %s: %w", count, want, vm, lastErr, ctx.Err())
+			}
+
 			return fmt.Errorf("Timed out after %ds waiting for log %q on %s: %w", count, want, vm, ctx.Err())
 
 		case <-time.After(1 * time.Second):
@@ -455,7 +474,12 @@ func mustWaitUpdatesReady(t *testing.T) {
 func mustWaitIncusOSReady(t *testing.T, names []string) {
 	t.Helper()
 
-	timeout := 5 * time.Minute
+	const (
+		agentTimeout = 5 * time.Minute
+		logTimeout   = 5 * time.Minute
+	)
+
+	timeout := agentTimeout + logTimeout
 	if !concurrentSetup {
 		timeout = time.Duration(int(timeout) * len(names))
 	}
@@ -480,12 +504,19 @@ func mustWaitIncusOSReady(t *testing.T, names []string) {
 			}()
 
 			t.Logf("Waiting for %s to be ready", name)
-			err = waitAgentRunningWithContext(errgrpctx, t, name)
+
+			agentWaitCtx, cancel := context.WithTimeout(errgrpctx, strechedTimeout(agentTimeout))
+			err = waitAgentRunningWithContext(agentWaitCtx, t, name)
+			cancel()
+
 			if err != nil {
 				return err
 			}
 
-			err = waitExpectedLogWithContext(errgrpctx, t, name, "incus-osd", "System is ready", false)
+			logWaitCtx, cancel := context.WithTimeout(errgrpctx, strechedTimeout(logTimeout))
+			err = waitExpectedLogWithContext(logWaitCtx, t, name, "incus-osd", "System is ready", false)
+			cancel()
+
 			if err != nil {
 				return err
 			}
@@ -660,6 +691,82 @@ func mustGetInstanceIPAndNames(t *testing.T, names []string) (instanceIPs []stri
 	}
 
 	return instanceIPs, instanceNames
+}
+
+func setServerBMCConfigWithContext(ctx context.Context, t *testing.T, tmpDir string, name string, apiType string, endpoint string) error {
+	t.Helper()
+
+	serverPutFilename := filepath.Join(tmpDir, fmt.Sprintf("server_put_%s.json", name))
+
+	resp := runWithContext(ctx, t, `../bin/operations-center.linux.%[1]s provisioning server show %[2]s -f json | jq -ce --arg api_type '%[3]s' --arg endpoint '%[4]s' '{ public_connection_url, channel, description, properties, bmc_config: { api_type: $api_type, endpoint: $endpoint, certificate: "", auto_pin_certificate: ($api_type != ""), username: "", password: "" } }' > %[5]s`, cpuArch, name, apiType, endpoint, serverPutFilename)
+
+	err := fmtRunErr(resp)
+	if err != nil {
+		return fmt.Errorf("Failed to assemble the server config for %q: %w", name, err)
+	}
+
+	resp = runWithContext(ctx, t, `../bin/operations-center.linux.%s provisioning server edit %s < %s`, cpuArch, name, serverPutFilename)
+
+	return fmtRunErr(resp)
+}
+
+func mustSetServerBMCConfig(t *testing.T, tmpDir string, name string, apiType string, endpoint string) {
+	t.Helper()
+
+	stop := timeTrack(t)
+	defer stop()
+
+	err := setServerBMCConfigWithContext(t.Context(), t, tmpDir, name, apiType, endpoint)
+	require.NoErrorf(t, err, "Failed to set the BMC config of server %q", name)
+}
+
+func serverBMCConfigCleanup(t *testing.T, tmpDir string, name string) func() {
+	t.Helper()
+
+	return func() {
+		if noCleanup || (noCleanupOnError && t.Failed()) {
+			return
+		}
+
+		// In t.Cleanup, t.Context() is already cancelled, so we need a detached context.
+		ctx, cancel := context.WithTimeout(context.Background(), strechedTimeout(30*time.Second))
+		defer cancel()
+
+		stop := timeTrack(t, "server BMC config cleanup")
+		defer stop()
+
+		err := setServerBMCConfigWithContext(ctx, t, tmpDir, name, "", "")
+		if err != nil {
+			t.Logf("Failed to reset the BMC config of server %q: %v", name, err)
+		}
+	}
+}
+
+func serverPowerStateCleanup(t *testing.T, name string) func() {
+	t.Helper()
+
+	return func() {
+		if noCleanup || (noCleanupOnError && t.Failed()) {
+			return
+		}
+
+		// In t.Cleanup, t.Context() is already cancelled, so we need a detached context.
+		ctx, cancel := context.WithTimeout(context.Background(), strechedTimeout(2*time.Minute))
+		defer cancel()
+
+		resp := runWithContext(ctx, t, `incus list -f json | jq -r -e '[ .[] | select(.name == "%s" and .status == "Running") ] | length == 1'`, name)
+		if resp.Success() {
+			return
+		}
+
+		stop := timeTrack(t, "server power state cleanup")
+		defer stop()
+
+		resp = runWithContext(ctx, t, `incus start %s`, name)
+		if !resp.Success() {
+			t.Error(resp.Error())
+		}
+	}
 }
 
 // indent indents the given input line by line by prefix.

--- a/e2e_tests/redfish_proxy_test.go
+++ b/e2e_tests/redfish_proxy_test.go
@@ -1,0 +1,224 @@
+package e2e
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/FuturFusion/incus-redfish-proxy/redfishproxy"
+	"github.com/stretchr/testify/require"
+)
+
+// startRedfishProxy serves an in-process Redfish proxy for the given Incus
+// instance on an ephemeral host port and returns the endpoint URL, at which the
+// proxy is reachable from inside the OperationsCenter VM.
+func startRedfishProxy(t *testing.T, instanceName string) string {
+	t.Helper()
+
+	stop := timeTrack(t)
+	defer stop()
+
+	hostAddress := redfishProxyHostAddress(t)
+
+	// The proxy needs to talk to the same Incus remote and project as the incus
+	// CLI used by the tests, otherwise it does not find the instance.
+	handler, err := redfishproxy.NewHandler(redfishproxy.Config{
+		InstanceName: instanceName,
+		Remote:       mustRun(t, `incus remote get-default`).OutputTrimmed(),
+		Project:      mustRun(t, `incus project get-current`).OutputTrimmed(),
+	})
+	require.NoErrorf(t, err, "Failed to create Redfish proxy handler for %q", instanceName)
+
+	tlsCert := mustGenerateRedfishProxyCertificate(t, hostAddress)
+
+	// Bind on all the interfaces, since the address, at which the
+	// OperationsCenter VM reaches the host, is derived separately.
+	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	require.NoError(t, err, "Failed to listen for the Redfish proxy")
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok, "Failed to get the port of the Redfish proxy listener")
+
+	port := strconv.Itoa(tcpAddr.Port)
+	server := &http.Server{
+		Handler:           handler,
+		TLSConfig:         &tls.Config{Certificates: []tls.Certificate{tlsCert}},
+		ReadHeaderTimeout: strechedTimeout(10 * time.Second),
+	}
+
+	t.Cleanup(func() {
+		if noCleanup || (noCleanupOnError && t.Failed()) {
+			return
+		}
+
+		// In t.Cleanup, t.Context() is already cancelled, so we need a detached context.
+		ctx, cancel := context.WithTimeout(context.Background(), strechedTimeout(30*time.Second))
+		defer cancel()
+
+		err := server.Shutdown(ctx)
+		if err != nil {
+			t.Errorf("Failed to shut down the Redfish proxy for %q: %v", instanceName, err)
+		}
+	})
+
+	go func() {
+		err := server.ServeTLS(listener, "", "")
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("Redfish proxy for %q stopped unexpectedly: %v", instanceName, err)
+		}
+	}()
+
+	endpoint := "https://" + net.JoinHostPort(hostAddress, port)
+
+	ctx, cancel := context.WithTimeout(t.Context(), strechedTimeout(10*time.Second))
+	defer cancel()
+
+	err = waitForTCPPort(ctx, t, net.JoinHostPort("127.0.0.1", port), 100*time.Millisecond)
+	require.NoErrorf(t, err, "Redfish proxy for %q did not come up", instanceName)
+
+	mustAssertRedfishProxyReachable(t, endpoint, instanceName)
+
+	t.Logf("Redfish proxy for %q is listening on %s", instanceName, endpoint)
+
+	return endpoint
+}
+
+// mustGenerateRedfishProxyCertificate generates the self signed certificate
+// presented by the Redfish proxy.
+//
+// Operations Center pins this certificate during the connection test and then
+// derives the expected server name from it, preferring the first DNS SAN over
+// the first IP SAN. The certificate therefore contains the address, at which the
+// OperationsCenter VM reaches the proxy, as its only SAN.
+func mustGenerateRedfishProxyCertificate(t *testing.T, hostAddress string) tls.Certificate {
+	t.Helper()
+
+	ip := net.ParseIP(hostAddress)
+	require.NotNilf(t, ip, "Address of the Redfish proxy %q is not an IP address", hostAddress)
+
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err, "Failed to generate the key for the Redfish proxy")
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Operations Center end 2 end tests"},
+			CommonName:   "incus-redfish-proxy",
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{ip},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err, "Failed to create the certificate for the Redfish proxy")
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	require.NoError(t, err, "Failed to load the certificate for the Redfish proxy")
+
+	cert, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	require.NoError(t, err)
+
+	err = cert.VerifyHostname(hostAddress)
+	require.NoErrorf(t, err, "Certificate of the Redfish proxy is not valid for %q", hostAddress)
+
+	return tlsCert
+}
+
+// mustAssertRedfishProxyReachable verifies, that the Redfish proxy answers the
+// service root, which is the first resource requested by a Redfish client, and
+// the computer system of the instance, which is the first resource requiring
+// the proxy to talk to Incus. This distinguishes a broken proxy from a proxy,
+// which is not reachable from inside the OperationsCenter VM.
+func mustAssertRedfishProxyReachable(t *testing.T, endpoint string, instanceName string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), strechedTimeout(10*time.Second))
+	defer cancel()
+
+	// The certificate is pinned by Operations Center, not by this smoke test.
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // nolint: gosec // self signed certificate of the test's own proxy.
+		},
+	}
+
+	resources := []string{
+		"/redfish/v1/",
+		fmt.Sprintf("/redfish/v1/Systems/%s", instanceName),
+	}
+
+	for _, resource := range resources {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+resource, nil)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoErrorf(t, err, "Redfish proxy for %q is not answering", instanceName)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		err = resp.Body.Close()
+		require.NoError(t, err)
+
+		require.Equalf(t, http.StatusOK, resp.StatusCode, "expect the Redfish proxy to serve %q, got: %s", resource, body)
+	}
+}
+
+// redfishProxyHostAddress returns the address of the e2e host on the network,
+// the OperationsCenter VM is attached to. This is the address, at which the
+// in-process Redfish proxy is reachable from inside the OperationsCenter VM.
+func redfishProxyHostAddress(t *testing.T) string {
+	t.Helper()
+
+	if bmcProxyAddress != "" {
+		return bmcProxyAddress
+	}
+
+	networkResp := mustRun(t, `incus list -f json | jq -r -e '[ .[] | select(.name == "OperationsCenter") | .expanded_devices | to_entries[] | select(.value.type == "nic") | (.value.network // .value.parent // empty) ] | first'`)
+	network := networkResp.OutputTrimmed()
+	require.NotEmpty(t, network, "Failed to determine the network of the OperationsCenter VM")
+
+	// For a managed bridge, the first address of ipv4.address is the address of
+	// the host on that bridge.
+	resp := run(t, `incus network get %s ipv4.address | cut -d / -f 1`, network)
+	address := resp.OutputTrimmed()
+	if resp.Success() && net.ParseIP(address) != nil {
+		return address
+	}
+
+	// Fall back to the address configured on the host interface, which covers
+	// unmanaged bridges and networks with an externally managed address.
+	resp = mustRun(t, `ip -4 -json addr show dev %s | jq -r -e '.[0].addr_info[0].local'`, network)
+	address = resp.OutputTrimmed()
+	require.NotNilf(t, net.ParseIP(address), "Failed to determine the address of the host on network %q", network)
+
+	return address
+}

--- a/e2e_tests/server_bmc_power_test.go
+++ b/e2e_tests/server_bmc_power_test.go
@@ -1,0 +1,130 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// serverBMCPowerOffAndOn powers the given server off and on again through its
+// BMC, which is provided by an in-process Redfish proxy.
+func serverBMCPowerOffAndOn(serverName string) func(t *testing.T, tmpDir string) {
+	return func(t *testing.T, tmpDir string) {
+		t.Helper()
+
+		stop := timeTrack(t)
+		defer stop()
+
+		// The Redfish proxy acts as the BMC of the IncusOS instance.
+		endpoint := startRedfishProxy(t, serverName)
+
+		// Register cleanup
+		t.Cleanup(serverPowerStateCleanup(t, serverName))
+		t.Cleanup(serverBMCConfigCleanup(t, tmpDir, serverName))
+
+		// Setup
+		t.Log("Configure the BMC of the server")
+		mustSetServerBMCConfig(t, tmpDir, serverName, "redfish-v1-generic", endpoint)
+
+		assertBMCConfig(t, serverName, endpoint)
+
+		// Run test
+		//
+		// Powering off the server with --force is the equivalent of pulling the
+		// plug, so the file systems of the server need to be flushed before,
+		// otherwise recently written files are lost.
+		t.Log("Flush the file systems of the server")
+		mustRunWithTimeout(t, `incus exec %s -- sync`, time.Minute, serverName)
+
+		t.Log("Power off the server via BMC")
+		mustRunWithTimeout(t, `../bin/operations-center.linux.%s provisioning server bmc server-power-off %s --force`, 5*time.Minute, cpuArch, serverName)
+
+		// Assertions
+		assertInstanceStatus(t, serverName, "Stopped", 3*time.Minute)
+		assertBMCServerPowerState(t, serverName, "Off", 2*time.Minute)
+
+		// Run test
+		t.Log("Power on the server via BMC")
+		mustRunWithTimeout(t, `../bin/operations-center.linux.%s provisioning server bmc server-power-on %s`, 5*time.Minute, cpuArch, serverName)
+
+		// Assertions
+		assertInstanceStatus(t, serverName, "Running", 2*time.Minute)
+		assertBMCServerPowerState(t, serverName, "On", 2*time.Minute)
+
+		mustWaitIncusOSReady(t, []string{serverName})
+		mustWaitInventoryReady(t, []string{serverName})
+	}
+}
+
+// assertBMCConfig verifies, that the BMC config has been applied, that the
+// certificate presented by the BMC has been pinned and that Operations Center
+// is able to collect data from the BMC.
+func assertBMCConfig(t *testing.T, serverName string, endpoint string) {
+	t.Helper()
+
+	stop := timeTrack(t)
+	defer stop()
+
+	resp := mustRun(t, `../bin/operations-center.linux.%s provisioning server show %s -f json | jq -r -e '.bmc_config.endpoint'`, cpuArch, serverName)
+	require.Equal(t, endpoint, resp.OutputTrimmed(), "expect the BMC endpoint to be persisted")
+
+	resp = mustRun(t, `../bin/operations-center.linux.%s provisioning server show %s -f json | jq -r -e '.bmc_config.certificate'`, cpuArch, serverName)
+	require.Contains(t, resp.Output(), "-----BEGIN CERTIFICATE-----", "expect the BMC certificate to be pinned")
+
+	resp = mustRun(t, `../bin/operations-center.linux.%s provisioning server show %s -f json | jq -r '.bmc_config.auto_pin_certificate'`, cpuArch, serverName)
+	require.Equal(t, "false", resp.OutputTrimmed(), "expect auto pinning of the BMC certificate to be disabled after pinning")
+
+	// A refresh collects the BMC data synchronously.
+	mustRunWithTimeout(t, `../bin/operations-center.linux.%s provisioning server bmc refresh %s`, time.Minute, cpuArch, serverName)
+
+	resp = mustRun(t, `../bin/operations-center.linux.%s provisioning server show %s -f json | jq -r -e '.bmc_data.bmc_protocol'`, cpuArch, serverName)
+	require.Equal(t, "Redfish", resp.OutputTrimmed(), "expect BMC data to be collected")
+
+	resp = mustRun(t, `../bin/operations-center.linux.%s provisioning server show %s -f json | jq -r -e '.bmc_data.server_power_state'`, cpuArch, serverName)
+	require.Equal(t, "On", resp.OutputTrimmed(), "expect the server to be reported as powered on")
+}
+
+// assertInstanceStatus waits for the Incus instance to reach the wanted status.
+func assertInstanceStatus(t *testing.T, name string, status string, timeout time.Duration) {
+	t.Helper()
+
+	stop := timeTrack(t)
+	defer stop()
+
+	desc := fmt.Sprintf("instance %q to be %q", name, status)
+
+	success, err := waitForSuccessWithTimeout(t, desc, `incus list -f json | jq -r -e '[ .[] | select(.name == "%s" and .status == "%s") ] | length == 1'`, timeout, name, status)
+	require.NoErrorf(t, err, "expect %s", desc)
+
+	if !success {
+		fmt.Println("====[ Instances ]====")
+		resp := mustRun(t, `incus list -f json | jq -c '[ .[] | { name: .name, status: .status } ]'`)
+		fmt.Println(resp.Output())
+	}
+
+	require.Truef(t, success, "expect %s", desc)
+}
+
+// assertBMCServerPowerState waits for Operations Center to report the wanted
+// power state of the server.
+func assertBMCServerPowerState(t *testing.T, serverName string, powerState string, timeout time.Duration) {
+	t.Helper()
+
+	stop := timeTrack(t)
+	defer stop()
+
+	desc := fmt.Sprintf("BMC power state of server %q to be %q", serverName, powerState)
+
+	success, err := waitForSuccessWithTimeout(t, desc, `../bin/operations-center.linux.%s provisioning server show %s -f json | jq -r -e '.bmc_data.server_power_state == "%s"'`, timeout, cpuArch, serverName, powerState)
+	require.NoErrorf(t, err, "expect %s", desc)
+
+	if !success {
+		fmt.Println("====[ BMC Data ]====")
+		resp := mustRun(t, `../bin/operations-center.linux.%s provisioning server show %s --bmc-data`, cpuArch, serverName)
+		fmt.Println(resp.Output())
+	}
+
+	require.Truef(t, success, "expect %s", desc)
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/adhocore/gronx v1.20.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
+	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/apex/log v1.9.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v17 v17.0.1 // indirect
@@ -112,6 +113,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/natefinch/wrap v0.2.0 // indirect
 	github.com/nwidger/jsoncolor v0.3.2 // indirect
+	github.com/oapi-codegen/runtime v1.4.2 // indirect
 	github.com/oklog/ulid/v2 v2.1.2 // indirect
 	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect
 	github.com/olekukonko/errors v1.3.0 // indirect
@@ -192,6 +194,7 @@ require (
 )
 
 require (
+	github.com/FuturFusion/incus-redfish-proxy v0.0.0-20260825170101-8aca873b0966
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/brianvoe/gofakeit/v7 v7.15.0
 	github.com/dsnet/golib/memfile v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/FuturFusion/incus-redfish-proxy v0.0.0-20260825170101-8aca873b0966 h1:GG9H9PPR66DYRdXV1dJfSr3Zmxml/3QJ6oSVvoz99+o=
+github.com/FuturFusion/incus-redfish-proxy v0.0.0-20260825170101-8aca873b0966/go.mod h1:byWrAsNsDuYYLSnkCbcGANWWKaRB3axUbzklEinLUPs=
 github.com/FuturFusion/migration-manager v0.6.14 h1:0H9pecWg0ZvUzQ4ksy7I6vi3eHAz9dp7i9zLUQNtUaE=
 github.com/FuturFusion/migration-manager v0.6.14/go.mod h1:hXvbTajeQj5Tdx3gXQwuW81I8b/cwb9WAgmhGR9vK2A=
 github.com/IBM/pgxpoolprometheus v1.1.3 h1:LYDekhCpo0I6qBrnfZlCSDqdr8UX/ZJ2C3GwhrTSVcw=
@@ -64,6 +66,7 @@ github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/Rican7/retry v0.3.0/go.mod h1:CxSDrhAyXmTMeEuRAnArMu1FHu48vtfjLREWqVl7Vw0=
 github.com/Rican7/retry v0.3.1 h1:scY4IbO8swckzoA/11HgBwaZRJEyY9vaNJshcdhp1Mc=
 github.com/Rican7/retry v0.3.1/go.mod h1:CxSDrhAyXmTMeEuRAnArMu1FHu48vtfjLREWqVl7Vw0=
@@ -76,6 +79,8 @@ github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
+github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
+github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/apex/log v1.9.0 h1:FHtw/xuaM8AgmvDDTI9fiwoAL25Sq2cxojnZICUU8l0=
 github.com/apex/log v1.9.0/go.mod h1:m82fZlWIuiWzWP04XCTXmnX0xRkYYbCdYn8jbJeLBEA=
 github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
@@ -97,6 +102,7 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/brianvoe/gofakeit/v7 v7.15.0 h1:kGLYAWN8tnmxq2PelKVK6zwpM7kMxdz9SGPH31mFkNs=
@@ -382,6 +388,7 @@ github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -521,6 +528,10 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nwidger/jsoncolor v0.3.2 h1:rVJJlwAWDJShnbTYOQ5RM7yTA20INyKXlJ/fg4JMhHQ=
 github.com/nwidger/jsoncolor v0.3.2/go.mod h1:Cs34umxLbJvgBMnVNVqhji9BhoT/N/KinHqZptQ7cf4=
+github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
+github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
+github.com/oapi-codegen/runtime v1.4.2 h1:GMxFVYLzoYLua+/KvzgSphkyK1lLTReQI9Vf4hvATKE=
+github.com/oapi-codegen/runtime v1.4.2/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
 github.com/oauth2-proxy/mockoidc v0.0.0-20240214162133-caebfff84d25 h1:9bCMuD3TcnjeqjPT2gSlha4asp8NvgcFRYExCaikCxk=
 github.com/oauth2-proxy/mockoidc v0.0.0-20240214162133-caebfff84d25/go.mod h1:eDjgYHYDJbPLBLsyZ6qRaugP0mX8vePOhZ5id1fdzJw=
 github.com/oklog/ulid/v2 v2.1.2 h1:IEclFb9JNvzYA6MW2SCxbLzcHTVsfqm3PrqGQJH5zec=
@@ -652,6 +663,7 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/spf13/viper v1.21.0 h1:x5S+0EU27Lbphp4UKm1C+1oQO+rKx36vfCoaVebLFSU=
 github.com/spf13/viper v1.21.0/go.mod h1:P0lhsswPGWD/1lZJ9ny3fYnVqxiegrlNrEmgLjbTCAY=
+github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/stmcginnis/gofish v0.24.0 h1:zaBBFNtdSFH/+lJju29HMDHU3suIR+YhygqoJYxW+2Q=
 github.com/stmcginnis/gofish v0.24.0/go.mod h1:PzF5i8ecRG9A2ol8XT64npKUunyraJ+7t0kYMpQAtqU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
uses incus-redfish-proxy as bridge between operations-center and an incus instance