### PR TITLE
Import existing client certificates into Terraform state

### DIFF
--- a/doc/reference/cluster.md
+++ b/doc/reference/cluster.md
@@ -109,8 +109,8 @@ the cluster. Providing at least one certificate disables this.
 
 Certificates, which the cluster does already trust, e.g. because they have been
 applied with the seed config of the servers, are not added a second time. They
-are only rendered as comments into the generated Terraform configuration, so
-they can be taken under management later on.
+are imported into the state of the generated Terraform configuration instead, so
+they are managed the same way as the ones added by it.
 
 ## One Off Clustering
 

--- a/internal/provisioning/adapter/terraform/templates/resources_certificates.tf.gotmpl
+++ b/internal/provisioning/adapter/terraform/templates/resources_certificates.tf.gotmpl
@@ -15,38 +15,42 @@ EOT
 }
 
 {{ end -}}
-{{- if .IncusPreseed.Certificates -}}
+{{- if .KnownTrustedCertificates -}}
+# The cluster does already trust the following client certificates, e.g. because
+# they have been applied with the seed config of the servers. They are therefore
+# imported into the Terraform state instead of being added to the cluster.
+{{ range .KnownTrustedCertificates }}
+resource "incus_certificate" "{{ .Name }}" {
+  name        = "{{ .Name }}"
+  description = "{{ .Description }}"
+  restricted  = {{ .Restricted }}
+  type        = "{{ .Type }}"
+
+  projects = {{ trimPrefix "  " (indent 2 (toPrettyJson .Projects) ) }}
+
+  certificate = <<EOT
+{{ .Certificate }}
+EOT
+
+  depends_on = []
+}
+
+import {
+  to = incus_certificate.{{ .Name }}
+  id = "{{ .Fingerprint }}"
+}
+
+{{ end -}}
+{{- end -}}
+{{- if or .IncusPreseed.Certificates .KnownTrustedCertificates -}}
 resource "null_resource" "post_certificates" {
   depends_on = [
 {{- range .IncusPreseed.Certificates }}
     incus_certificate.{{ .Name }},
 {{- end }}
+{{- range .KnownTrustedCertificates }}
+    incus_certificate.{{ .Name }},
+{{- end }}
   ]
 }
 {{ end -}}
-{{- if .KnownTrustedCertificates -}}
-{{ if .IncusPreseed.Certificates }}
-{{ end -}}
-# The cluster does already trust the following client certificates, e.g. because
-# they have been applied with the seed config of the servers. They are therefore
-# not managed by this Terraform configuration.
-#
-# To take such a certificate under management, import it into the Terraform state
-# and uncomment the respective resource.
-{{ range .KnownTrustedCertificates }}
-# resource "incus_certificate" "{{ .Name }}" {
-#   name        = "{{ .Name }}"
-#   description = "{{ .Description }}"
-#   restricted  = {{ .Restricted }}
-#   type        = "{{ .Type }}"
-#
-#   projects = {{ trimPrefix "  " (indent 2 (toPrettyJson .Projects) ) | replace "\n" "\n# " }}
-#
-#   certificate = <<EOT
-# {{ .Certificate | replace "\n" "\n# " }}
-# EOT
-#
-#   depends_on = []
-# }
-{{ end -}}
-{{- end -}}

--- a/internal/provisioning/adapter/terraform/terraform.go
+++ b/internal/provisioning/adapter/terraform/terraform.go
@@ -256,7 +256,7 @@ func cleanup(path string) func() error {
 // incusPreseedWithDefaults returns the Incus preseed for the cluster, which is
 // provisioned by Operations Center, together with the Incus certificate
 // definitions for the client certificates, the cluster does already trust.
-func incusPreseedWithDefaults(config map[string]any, trustedClientCertificates []string, knownTrustedClientCertificates []string) (_ incusapi.InitLocalPreseed, knownCertificates []incusapi.CertificatesPost, _ error) {
+func incusPreseedWithDefaults(config map[string]any, trustedClientCertificates []string, knownTrustedClientCertificates []string) (_ incusapi.InitLocalPreseed, knownCertificates []securitytls.TrustedClientCertificate, _ error) {
 	body, err := json.Marshal(config)
 	if err != nil {
 		return incusapi.InitLocalPreseed{}, nil, err
@@ -575,7 +575,7 @@ func incusPreseedWithDefaults(config map[string]any, trustedClientCertificates [
 			return incusapi.InitLocalPreseed{}, nil, fmt.Errorf("Failed to derive Incus certificates from the trusted client certificates: %w", err)
 		}
 
-		knownCertificates, err = securitytls.TrustedClientCertificates(knownTrustedClientCertificates)
+		knownCertificates, err = securitytls.TrustedClientCertificatesWithFingerprint(knownTrustedClientCertificates)
 		if err != nil {
 			return incusapi.InitLocalPreseed{}, nil, fmt.Errorf("Failed to derive Incus certificates from the already trusted client certificates: %w", err)
 		}

--- a/internal/provisioning/adapter/terraform/terraform_internal_test.go
+++ b/internal/provisioning/adapter/terraform/terraform_internal_test.go
@@ -6,6 +6,7 @@ import (
 	incusapi "github.com/lxc/incus/v7/shared/api"
 	"github.com/stretchr/testify/require"
 
+	securitytls "github.com/FuturFusion/operations-center/internal/security/tls"
 	"github.com/FuturFusion/operations-center/internal/util/testing/testcert"
 )
 
@@ -340,7 +341,7 @@ func Test_incusPreseedWithDefaults_trustedClientCertificates(t *testing.T) {
 
 		assertErr             require.ErrorAssertionFunc
 		wantCertificates      []incusapi.CertificatesPost
-		wantKnownCertificates []incusapi.CertificatesPost
+		wantKnownCertificates []securitytls.TrustedClientCertificate
 	}{
 		{
 			name:                      "no trusted client certificates",
@@ -386,15 +387,18 @@ func Test_incusPreseedWithDefaults_trustedClientCertificates(t *testing.T) {
 					},
 				},
 			},
-			wantKnownCertificates: []incusapi.CertificatesPost{
+			wantKnownCertificates: []securitytls.TrustedClientCertificate{
 				{
-					CertificatePut: incusapi.CertificatePut{
-						Name:        "oc-trusted-" + testcert.SecondClientCertificateFingerprint[:12],
-						Description: "Client trusted by Operations Center",
-						Type:        "client",
-						Projects:    []string{},
-						Certificate: testcert.SecondClientCertificate,
+					CertificatesPost: incusapi.CertificatesPost{
+						CertificatePut: incusapi.CertificatePut{
+							Name:        "oc-trusted-" + testcert.SecondClientCertificateFingerprint[:12],
+							Description: "Client trusted by Operations Center",
+							Type:        "client",
+							Projects:    []string{},
+							Certificate: testcert.SecondClientCertificate,
+						},
 					},
+					Fingerprint: testcert.SecondClientCertificateFingerprint,
 				},
 			},
 		},

--- a/internal/provisioning/adapter/terraform/testdata/resources_certificates_known_trusted_clients.tf
+++ b/internal/provisioning/adapter/terraform/testdata/resources_certificates_known_trusted_clients.tf
@@ -1,33 +1,41 @@
 # The cluster does already trust the following client certificates, e.g. because
 # they have been applied with the seed config of the servers. They are therefore
-# not managed by this Terraform configuration.
-#
-# To take such a certificate under management, import it into the Terraform state
-# and uncomment the respective resource.
+# imported into the Terraform state instead of being added to the cluster.
 
-# resource "incus_certificate" "oc-trusted-b4e08ef4c7fb" {
-#   name        = "oc-trusted-b4e08ef4c7fb"
-#   description = "Client trusted by Operations Center"
-#   restricted  = false
-#   type        = "client"
-#
-#   projects = []
-#
-#   certificate = <<EOT
-# -----BEGIN CERTIFICATE-----
-# MIIB4zCCAWqgAwIBAgIUZT1U82k44TuXkKcq1jdXYxaZDDgwCgYIKoZIzj0EAwMw
-# ODEZMBcGA1UECgwQTGludXggQ29udGFpbmVyczEbMBkGA1UEAwwSdXNlckBob3N0
-# LnNvbWUudGxkMB4XDTI2MDgxMTA2MTgyOFoXDTM2MDgwODA2MTgyOFowODEZMBcG
-# A1UECgwQTGludXggQ29udGFpbmVyczEbMBkGA1UEAwwSdXNlckBob3N0LnNvbWUu
-# dGxkMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEW9cy2pfFn/i3XdgNGl5WqLkthPHS
-# 4x5zQubllNA66BAcV23vVqJ0xXMfKctlVgrU0NRSNEn5mX7gDnfHGzS33pfQbxMO
-# ThiwdAX4SpN6rs2dZGpI/qNwA0sS2NhXGNm7ozUwMzAOBgNVHQ8BAf8EBAMCBaAw
-# EwYDVR0lBAwwCgYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAKBggqhkjOPQQDAwNn
-# ADBkAjB4QSY3y5U08XfwWR3eFZU2fH4IDVf3GHEBIaEtNlXzBqBCyrOcUz343hI4
-# Nq1cnl8CMBhlQlZZuq8pgMkj3kCwBREpfCFxfOu0b1PMOW/4mX9NSvh44L4u3Qpn
-# QnQF/nCEsw==
-# -----END CERTIFICATE-----
-# EOT
-#
-#   depends_on = []
-# }
+resource "incus_certificate" "oc-trusted-b4e08ef4c7fb" {
+  name        = "oc-trusted-b4e08ef4c7fb"
+  description = "Client trusted by Operations Center"
+  restricted  = false
+  type        = "client"
+
+  projects = []
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIB4zCCAWqgAwIBAgIUZT1U82k44TuXkKcq1jdXYxaZDDgwCgYIKoZIzj0EAwMw
+ODEZMBcGA1UECgwQTGludXggQ29udGFpbmVyczEbMBkGA1UEAwwSdXNlckBob3N0
+LnNvbWUudGxkMB4XDTI2MDgxMTA2MTgyOFoXDTM2MDgwODA2MTgyOFowODEZMBcG
+A1UECgwQTGludXggQ29udGFpbmVyczEbMBkGA1UEAwwSdXNlckBob3N0LnNvbWUu
+dGxkMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEW9cy2pfFn/i3XdgNGl5WqLkthPHS
+4x5zQubllNA66BAcV23vVqJ0xXMfKctlVgrU0NRSNEn5mX7gDnfHGzS33pfQbxMO
+ThiwdAX4SpN6rs2dZGpI/qNwA0sS2NhXGNm7ozUwMzAOBgNVHQ8BAf8EBAMCBaAw
+EwYDVR0lBAwwCgYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAKBggqhkjOPQQDAwNn
+ADBkAjB4QSY3y5U08XfwWR3eFZU2fH4IDVf3GHEBIaEtNlXzBqBCyrOcUz343hI4
+Nq1cnl8CMBhlQlZZuq8pgMkj3kCwBREpfCFxfOu0b1PMOW/4mX9NSvh44L4u3Qpn
+QnQF/nCEsw==
+-----END CERTIFICATE-----
+EOT
+
+  depends_on = []
+}
+
+import {
+  to = incus_certificate.oc-trusted-b4e08ef4c7fb
+  id = "b4e08ef4c7fb1c14b4b73422e9375fa3bdd992836ed58bc78673dcd532083ad0"
+}
+
+resource "null_resource" "post_certificates" {
+  depends_on = [
+    incus_certificate.oc-trusted-b4e08ef4c7fb,
+  ]
+}

--- a/internal/provisioning/adapter/terraform/testdata/resources_certificates_mixed_trusted_clients.tf
+++ b/internal/provisioning/adapter/terraform/testdata/resources_certificates_mixed_trusted_clients.tf
@@ -25,42 +25,45 @@ EOT
   depends_on = []
 }
 
+# The cluster does already trust the following client certificates, e.g. because
+# they have been applied with the seed config of the servers. They are therefore
+# imported into the Terraform state instead of being added to the cluster.
+
+resource "incus_certificate" "oc-trusted-11f365352f3d" {
+  name        = "oc-trusted-11f365352f3d"
+  description = "Client trusted by Operations Center"
+  restricted  = false
+  type        = "client"
+
+  projects = []
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIB5zCCAWygAwIBAgIUTrUg32+ydT9x27MVgT61VvsacBcwCgYIKoZIzj0EAwMw
+OTEZMBcGA1UECgwQTGludXggQ29udGFpbmVyczEcMBoGA1UEAwwTb3RoZXJAaG9z
+dC5zb21lLnRsZDAeFw0yNjA4MTEwODU5MjlaFw0zNjA4MDgwODU5MjlaMDkxGTAX
+BgNVBAoMEExpbnV4IENvbnRhaW5lcnMxHDAaBgNVBAMME290aGVyQGhvc3Quc29t
+ZS50bGQwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAARtugZrtkt6eRSpoYTn26i+ufkj
+j85qBSCIE/EKFYpcFasWrdL6+qzUqKW38POXfZ8FFamhjEl3t+k4fxFd/GV2Atzi
+HiYGT5YeevJ4WHb3c9XNJ9G2EYCVlDGyJ1SHkFqjNTAzMA4GA1UdDwEB/wQEAwIF
+oDATBgNVHSUEDDAKBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMAoGCCqGSM49BAMD
+A2kAMGYCMQDYuISb/SbY78RKEHecDDx67BAEW/C0OxmSiQJU9a1FRNqhUwRTI9Sx
+d6vQ1sIxvb8CMQCI5TiIxdWQn/AHlguC94RrOBbNAfQ2oGm7+ci6KnX8mGEwZ4vW
+4KMOxXCIti9xX6w=
+-----END CERTIFICATE-----
+EOT
+
+  depends_on = []
+}
+
+import {
+  to = incus_certificate.oc-trusted-11f365352f3d
+  id = "11f365352f3d4e2c4d501b6b5786457627dbd525689aa86a2623069a4d840765"
+}
+
 resource "null_resource" "post_certificates" {
   depends_on = [
     incus_certificate.oc-trusted-b4e08ef4c7fb,
+    incus_certificate.oc-trusted-11f365352f3d,
   ]
 }
-
-# The cluster does already trust the following client certificates, e.g. because
-# they have been applied with the seed config of the servers. They are therefore
-# not managed by this Terraform configuration.
-#
-# To take such a certificate under management, import it into the Terraform state
-# and uncomment the respective resource.
-
-# resource "incus_certificate" "oc-trusted-11f365352f3d" {
-#   name        = "oc-trusted-11f365352f3d"
-#   description = "Client trusted by Operations Center"
-#   restricted  = false
-#   type        = "client"
-#
-#   projects = []
-#
-#   certificate = <<EOT
-# -----BEGIN CERTIFICATE-----
-# MIIB5zCCAWygAwIBAgIUTrUg32+ydT9x27MVgT61VvsacBcwCgYIKoZIzj0EAwMw
-# OTEZMBcGA1UECgwQTGludXggQ29udGFpbmVyczEcMBoGA1UEAwwTb3RoZXJAaG9z
-# dC5zb21lLnRsZDAeFw0yNjA4MTEwODU5MjlaFw0zNjA4MDgwODU5MjlaMDkxGTAX
-# BgNVBAoMEExpbnV4IENvbnRhaW5lcnMxHDAaBgNVBAMME290aGVyQGhvc3Quc29t
-# ZS50bGQwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAARtugZrtkt6eRSpoYTn26i+ufkj
-# j85qBSCIE/EKFYpcFasWrdL6+qzUqKW38POXfZ8FFamhjEl3t+k4fxFd/GV2Atzi
-# HiYGT5YeevJ4WHb3c9XNJ9G2EYCVlDGyJ1SHkFqjNTAzMA4GA1UdDwEB/wQEAwIF
-# oDATBgNVHSUEDDAKBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMAoGCCqGSM49BAMD
-# A2kAMGYCMQDYuISb/SbY78RKEHecDDx67BAEW/C0OxmSiQJU9a1FRNqhUwRTI9Sx
-# d6vQ1sIxvb8CMQCI5TiIxdWQn/AHlguC94RrOBbNAfQ2oGm7+ci6KnX8mGEwZ4vW
-# 4KMOxXCIti9xX6w=
-# -----END CERTIFICATE-----
-# EOT
-#
-#   depends_on = []
-# }

--- a/internal/security/tls/certificate.go
+++ b/internal/security/tls/certificate.go
@@ -94,16 +94,45 @@ func FilterCertificatesByFingerprints(certificatesPEM []string, fingerprints []s
 	return filteredCertificates, nil
 }
 
+type TrustedClientCertificate struct {
+	incusapi.CertificatesPost
+
+	Fingerprint string
+}
+
 // TrustedClientCertificates converts the given X509 PEM encoded client
 // certificates into Incus certificate definitions.
 //
 // The name of each certificate is derived from its SHA256 fingerprint.
 func TrustedClientCertificates(certificatesPEM []string) ([]incusapi.CertificatesPost, error) {
+	trustedCertificates, err := TrustedClientCertificatesWithFingerprint(certificatesPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(trustedCertificates) == 0 {
+		return nil, nil
+	}
+
+	certificates := make([]incusapi.CertificatesPost, 0, len(trustedCertificates))
+	for _, trustedCertificate := range trustedCertificates {
+		certificates = append(certificates, trustedCertificate.CertificatesPost)
+	}
+
+	return certificates, nil
+}
+
+// TrustedClientCertificatesWithFingerprint converts the given X509 PEM encoded
+// client certificates into Incus certificate definitions, each together with
+// the SHA256 fingerprint of the respective certificate.
+//
+// The name of each certificate is derived from its SHA256 fingerprint.
+func TrustedClientCertificatesWithFingerprint(certificatesPEM []string) ([]TrustedClientCertificate, error) {
 	if len(certificatesPEM) == 0 {
 		return nil, nil
 	}
 
-	certificates := make([]incusapi.CertificatesPost, 0, len(certificatesPEM))
+	certificates := make([]TrustedClientCertificate, 0, len(certificatesPEM))
 	seenFingerprints := make(map[string]struct{}, len(certificatesPEM))
 
 	for _, certificatePEM := range certificatesPEM {
@@ -122,15 +151,18 @@ func TrustedClientCertificates(certificatesPEM []string) ([]incusapi.Certificate
 
 		seenFingerprints[fingerprint] = struct{}{}
 
-		certificates = append(certificates, incusapi.CertificatesPost{
-			CertificatePut: incusapi.CertificatePut{
-				Name:        trustedClientCertificateNamePrefix + fingerprint[:12],
-				Description: "Client trusted by Operations Center",
-				Type:        "client",
-				Restricted:  false,
-				Projects:    []string{},
-				Certificate: certificatePEM,
+		certificates = append(certificates, TrustedClientCertificate{
+			CertificatesPost: incusapi.CertificatesPost{
+				CertificatePut: incusapi.CertificatePut{
+					Name:        trustedClientCertificateNamePrefix + fingerprint[:12],
+					Description: "Client trusted by Operations Center",
+					Type:        "client",
+					Restricted:  false,
+					Projects:    []string{},
+					Certificate: certificatePEM,
+				},
 			},
+			Fingerprint: fingerprint,
 		})
 	}
 

--- a/internal/security/tls/certificate_test.go
+++ b/internal/security/tls/certificate_test.go
@@ -142,6 +142,68 @@ Zm9vYmFy
 	}
 }
 
+func TestTrustedClientCertificatesWithFingerprint(t *testing.T) {
+	wantCertificate := securitytls.TrustedClientCertificate{
+		CertificatesPost: incusapi.CertificatesPost{
+			CertificatePut: incusapi.CertificatePut{
+				Name:        "oc-trusted-" + testcert.ClientCertificateFingerprint[:12],
+				Description: "Client trusted by Operations Center",
+				Type:        "client",
+				Restricted:  false,
+				Projects:    []string{},
+				Certificate: testcert.ClientCertificate,
+			},
+		},
+		Fingerprint: testcert.ClientCertificateFingerprint,
+	}
+
+	tests := []struct {
+		name            string
+		certificatesPEM []string
+
+		assertErr require.ErrorAssertionFunc
+		want      []securitytls.TrustedClientCertificate
+	}{
+		{
+			name:            "success - nil",
+			certificatesPEM: nil,
+
+			assertErr: require.NoError,
+			want:      nil,
+		},
+		{
+			name:            "success - single certificate",
+			certificatesPEM: []string{testcert.ClientCertificate},
+
+			assertErr: require.NoError,
+			want:      []securitytls.TrustedClientCertificate{wantCertificate},
+		},
+		{
+			name:            "success - same certificate provided twice",
+			certificatesPEM: []string{testcert.ClientCertificate, testcert.ClientCertificate},
+
+			assertErr: require.NoError,
+			want:      []securitytls.TrustedClientCertificate{wantCertificate},
+		},
+		{
+			name:            "error - not a PEM block",
+			certificatesPEM: []string{"not a certificate"},
+
+			assertErr: require.Error,
+			want:      nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := securitytls.TrustedClientCertificatesWithFingerprint(tc.certificatesPEM)
+
+			tc.assertErr(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestFilterCertificatesByFingerprints(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
I had this change locally already for #1001 but then I just updated the comment on the PR and did not push the changes.

This now actually imports the client certificates into the Terraform state.

Relates to: #892