### PR TITLE
Several improvements and fixes for auto deploy

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -58,6 +58,7 @@ OpenTofu
 PEM
 PFX
 PKCS
+PowerEdge
 pre
 preseed
 Redfish
@@ -74,6 +75,7 @@ sso
 starlark
 struct
 Terraform
+ThinkSystem
 TLS
 toolchain
 TPM

--- a/doc/development/server-deployment.md
+++ b/doc/development/server-deployment.md
@@ -277,7 +277,8 @@ fires first.
    rebooted", so the deployment falls through to the next signal.
 1. **Enough of the installation media has been read and it has gone idle** for
    `ServerDeploymentMediaIdlePeriod`. Operations Center serves the media itself
-   and records the read progress per image and source address.
+   and records the read progress per deployment. Only a deployment requested with
+   `force` is told by this signal.
 1. **An overall timeout** as a backstop, which fails the deployment rather than
    guessing.
 
@@ -293,30 +294,45 @@ a BMC fetches the whole image before the server even boots, and when no progress
 has been recorded at all, which is the case after a daemon restart, since the
 progress is kept in memory only.
 
-**Signals 2 and 3 are both gated on the installation being able to be done at
-all**, so that neither can end the wait while the installer is still running.
-What separates the two cases is the read progress: a firmware, that still has
-something to pick up, reboots the server within the first POST cycles of a boot
-and keeps the media quiet meanwhile, while the installer streams hundreds of
-megabytes of it.
+**Signal 2 is gated on the installer having been running**, so that the reboot,
+that ends the first stage, is not confused with the one the firmware performs to
+pick up staged BIOS attributes or enrolled secure boot certificates. The latter
+comes within the POST cycles of the very boot, that is supposed to start the
+installer, so what separates the two is `BootProgress`: only a boot, that got as
+far as `OSBootStarted`, ran the installer. Where the reboot does not end the
+wait, it re-anchors the snapshot instead, so it is not carried into the next
+comparison. `ServerDeploymentInstallRebootFallbackDelay` stands in for the boot
+progress where the BMC does not report it, and is the only case, in which time
+decides.
 
-**Signal 2 is therefore carried by the read progress.** A reboot ends the wait as
-soon as `ServerDeploymentMediaMinBytesRead` has been read, however long the
-installation took — a machine, that is done in five minutes, is not held back for
-ten. Only where the read progress can not be told at all does
-`ServerDeploymentMinInstallDuration` stand in for it. Where the reboot does not
-end the wait, it re-anchors the snapshot instead, so the firmware reboot is not
-carried into the next comparison.
+**Ejecting has to be prompt.** A server, whose media is still attached when it
+comes back up, can boot it a second time rather than the system just installed,
+where the installer finds no install target anymore and the server never
+registers. The POST of that reboot is the whole budget, which is why signal 2
+must not wait out a duration once it has seen the installer run.
 
-**Signal 3 keeps the floor**, since the media going quiet is a weaker statement
-than a reboot: the installer stops reading while it partitions the disk, and
-ejecting the media then would break the installation. It ends the wait no earlier
-than `ServerDeploymentMinInstallDuration` after entering it.
+**The read progress tells neither signal apart**, since it does not tell the
+installer streaming the media apart from the BMC pulling it in: a BMC, that
+caches the media rather than handing every read through, reads the whole image
+out while the server boots and then goes quiet for the rest of the installation,
+which is exactly what "read out and idle" is supposed to mean. A Dell PowerEdge
+does this, and ejecting the media on that signal breaks the installation with an
+I/O error on the virtual CD.
 
-With `force` — a token seed without `force_reboot` — signal 2 does not fire on
-its own, since the installer waits for the media to disappear instead of
-rebooting. Ejecting the media, which happens right after signal 3, is what makes
-IncusOS reboot in that case.
+**Signal 3 is therefore reserved for `force`** — a token seed without
+`force_reboot` — where the installer waits for the media to disappear instead of
+rebooting, so signal 2 does not fire on its own and ejecting the media is what
+makes IncusOS reboot. A server, that reboots on its own, is told by signals 1
+and 2 alone.
+
+There, `ServerDeploymentMediaIdlePeriod` is the whole latency of the deployment:
+the server has installed and is idling in front of "Please remove the install
+media", and nothing happens until the ejection comes. The period therefore only
+covers a gap within the installation — a Lenovo ThinkSystem reads the media right
+up to the end of the first stage — and is not a place to buy safety margin.
+`ServerDeploymentMinInstallDuration` keeps the floor underneath it, so a BMC,
+that read the media out while the server was still booting, can not end the wait
+before the installation could have run at all.
 
 ### Read progress of the installation media
 

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -13039,10 +13039,13 @@ paths:
                   type: string
                 - description: |-
                     Flat sequence of "<key>/<value>" pairs (architecture, type,
-                    optionally channel) followed by a filename segment, e.g.
-                    "architecture/x86_64/type/iso/file.iso" for the image the token seed
-                    resolves to, or "architecture/x86_64/type/iso/a1B2c3D4e5F6.iso" for
-                    one already generated image.
+                    optionally channel and deployment) followed by a filename segment,
+                    e.g. "architecture/x86_64/type/iso/file.iso" for the image the token
+                    seed resolves to, or "architecture/x86_64/type/iso/a1B2c3D4e5F6.iso"
+                    for one already generated image. A "deployment" pair names the
+                    automated deployment reading the image, which does not change, which
+                    image is served, it only tells the readers of one and the same image
+                    apart.
                   in: path
                   name: params
                   required: true

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5392,9 +5392,10 @@ definitions:
                 description: |-
                     VirtualMediaID identifies the virtual media device the installation media
                     is attached to, using the "<service>:<bmc-id>" notation (e.g. "system:1").
-                    Optional, the first virtual media device advertising CD or DVD support is
-                    picked automatically, if it is left empty, the ones offered by the system
-                    taking precedence over the ones offered by the manager.
+                    Optional, the first virtual media device advertising support for the
+                    requested image type is picked automatically, if it is left empty (CD or
+                    DVD for an ISO image, USB stick or floppy for a raw one), the ones offered
+                    by the system taking precedence over the ones offered by the manager.
                 example: system:1
                 type: string
                 x-go-name: VirtualMediaID

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5352,7 +5352,9 @@ definitions:
                     Force requests, that a token seed, which does not reboot the server upon
                     completion of the installation ("force_reboot"), is accepted. The
                     deployment then relies on the read progress of the installation media
-                    alone to tell, when the first stage of the installation is done.
+                    alone to tell, when the first stage of the installation is done, so it
+                    needs a virtual media device, that streams the media rather than uploading
+                    it before the server boots.
                 example: false
                 type: boolean
                 x-go-name: Force

--- a/doc/tutorials/server-deployment.md
+++ b/doc/tutorials/server-deployment.md
@@ -351,7 +351,10 @@ The relevant flags are:
   away.
 * `--force`: needed, if the token seed does not set `force_reboot`. The
   deployment then relies on the read progress of the installation media alone to
-  detect the end of the first installation stage.
+  detect the end of the first installation stage, so it needs a virtual media
+  device, that streams the media. A BMC, that uploads the media before the server
+  boots, produces no read progress at all, and such a device is refused for this
+  kind of deployment.
 
 Everything, that can be checked up front, is checked when the deployment is
 requested, so an impossible deployment fails right here rather than halfway

--- a/doc/tutorials/server-deployment.md
+++ b/doc/tutorials/server-deployment.md
@@ -341,11 +341,14 @@ The relevant flags are:
   [Enroll the Secure Boot Certificates Manually](#enroll-the-secure-boot-certificates-manually).
 * `--virtual-media-id <virtual-media-id>`: only needed, if the automatically
   selected virtual media device is not the wanted one. Without the flag, the
-  first device advertising CD or DVD support is used, the devices offered by the
-  system taking precedence over the ones offered by the manager.
+  first device advertising support for the requested image type is used, the
+  devices offered by the system taking precedence over the ones offered by the
+  manager.
 * `--type raw`: by default, the ISO image is used for the installation. Some
   virtual media implementations do not support the ISO, in which case the raw
-  image has to be used. Unfortunately, this is only detected mid deployment.
+  image has to be used. The virtual media device is selected accordingly, and a
+  server, whose devices all reject the requested image type, is refused right
+  away.
 * `--force`: needed, if the token seed does not set `force_reboot`. The
   deployment then relies on the read progress of the installation media alone to
   detect the end of the first installation stage.

--- a/internal/api/api_provisioning_token.go
+++ b/internal/api/api_provisioning_token.go
@@ -846,10 +846,13 @@ func (t *tokenHandler) tokenSeedGet(r *http.Request) response.Response {
 //	    name: params
 //	    description: |-
 //	      Flat sequence of "<key>/<value>" pairs (architecture, type,
-//	      optionally channel) followed by a filename segment, e.g.
-//	      "architecture/x86_64/type/iso/file.iso" for the image the token seed
-//	      resolves to, or "architecture/x86_64/type/iso/a1B2c3D4e5F6.iso" for
-//	      one already generated image.
+//	      optionally channel and deployment) followed by a filename segment,
+//	      e.g. "architecture/x86_64/type/iso/file.iso" for the image the token
+//	      seed resolves to, or "architecture/x86_64/type/iso/a1B2c3D4e5F6.iso"
+//	      for one already generated image. A "deployment" pair names the
+//	      automated deployment reading the image, which does not change, which
+//	      image is served, it only tells the readers of one and the same image
+//	      apart.
 //	    type: string
 //	    required: true
 //	  - in: header
@@ -898,21 +901,20 @@ func (t *tokenHandler) tokenSeedImageGet(r *http.Request) response.Response {
 
 	name := r.PathValue("name")
 
-	imageType, architecture, channel, fingerprintID, err := parseSeedImageParams(r.PathValue("params"))
+	params, err := parseSeedImageParams(r.PathValue("params"))
 	if err != nil {
 		return response.BadRequest(err)
 	}
 
-	if fingerprintID != "" {
-		image, err := t.service.GetPreparedTokenSeedImage(r.Context(), UUID, name, imageType, architecture, channel, fingerprintID)
+	imageType, architecture, channel := params.imageType, params.architecture, params.channel
+
+	if params.fingerprintID != "" {
+		image, err := t.service.GetPreparedTokenSeedImage(r.Context(), UUID, name, imageType, architecture, channel, params.fingerprintID)
 		if err != nil {
 			return response.SmartError(err)
 		}
 
-		content := t.trackSeedImageRead(r, provisioning.SeedImageID{
-			CacheID:       provisioning.SeedImageCacheID(UUID, name, imageType, architecture, channel),
-			FingerprintID: fingerprintID,
-		}, image.SeedImageInfo, image.Content)
+		content := t.trackSeedImageRead(r, params.deploymentID, image.SeedImageInfo, image.Content)
 
 		return response.ServeContentResponse(r, content, image.Filename, image.ModTime, image.Size, nil)
 	}
@@ -957,21 +959,33 @@ func (t *tokenHandler) tokenSeedImageGet(r *http.Request) response.Response {
 // http.ServeContent answers a range request by seeking, which only the image
 // underneath it sees as reads.
 //
-// Only a request naming an already prepared image is tracked, since that is the
-// only address a BMC is ever pointed at, see BMCAttachMediaByName. A request
-// naming a token seed serves a CLI or UI download instead, which tells nothing
-// about an installation.
+// Only a request naming an already prepared image and the deployment reading it
+// is tracked.
 //
 // A request arriving through a trusted HTTPS proxy carries the address of the
 // real peer, since such a proxy speaks the PROXY protocol to the listener.
-func (t *tokenHandler) trackSeedImageRead(r *http.Request, imageID provisioning.SeedImageID, info provisioning.SeedImageInfo, content io.ReadSeekCloser) io.ReadSeekCloser {
-	return t.seedProgress.Track(r.Context(), imageID, provisioning.SeedImageSource(r.RemoteAddr), info, content)
+func (t *tokenHandler) trackSeedImageRead(r *http.Request, deploymentID string, info provisioning.SeedImageInfo, content io.ReadSeekCloser) io.ReadSeekCloser {
+	if deploymentID == "" {
+		return content
+	}
+
+	return t.seedProgress.Track(r.Context(), deploymentID, info, content)
 }
 
-// seedImageFingerprintIDRegexp matches the terminal filename segment naming an
-// already generated image. The segment ends up addressing a file, so nothing
-// but the shape provisioning.SeedImageFingerprintID produces is let through.
-var seedImageFingerprintIDRegexp = regexp.MustCompile(`^[A-Za-z0-9_-]{12}$`)
+// seedImageIDRegexp matches the segments naming an already generated image and
+// the deployment reading it. The first ends up addressing a file, so nothing but
+// the shape provisioning.SeedImageFingerprintID produces is let through.
+var seedImageIDRegexp = regexp.MustCompile(`^[A-Za-z0-9_-]{12}$`)
+
+// seedImageParams is what the "/{params...}" tail of the token seed image route
+// addresses.
+type seedImageParams struct {
+	imageType     api.ImageType
+	architecture  images.UpdateFileArchitecture
+	channel       string
+	fingerprintID string
+	deploymentID  string
+}
 
 // parseSeedImageParams parses the "/{params...}" tail of the token seed image
 // route. params is a flat sequence of "<key>/<value>" pairs followed by a final
@@ -979,22 +993,24 @@ var seedImageFingerprintIDRegexp = regexp.MustCompile(`^[A-Za-z0-9_-]{12}$`)
 //
 // That last segment tells the two ways of asking for an image apart. A segment
 // naming one already generated image is returned as fingerprintID.
-func parseSeedImageParams(params string) (imageType api.ImageType, architecture images.UpdateFileArchitecture, channel string, fingerprintID string, err error) {
+func parseSeedImageParams(params string) (seedImageParams, error) {
 	segments := strings.Split(strings.Trim(params, "/"), "/")
 	if len(segments) < 2 {
-		return "", "", "", "", fmt.Errorf("Missing parameters in seed image path %q", params)
+		return seedImageParams{}, fmt.Errorf("Missing parameters in seed image path %q", params)
 	}
 
 	filename := segments[len(segments)-1]
 	segments = segments[:len(segments)-1]
 
+	var parsed seedImageParams
+
 	basename := strings.TrimSuffix(filename, filepath.Ext(filename))
-	if seedImageFingerprintIDRegexp.MatchString(basename) {
-		fingerprintID = basename
+	if seedImageIDRegexp.MatchString(basename) {
+		parsed.fingerprintID = basename
 	}
 
 	if len(segments)%2 != 0 {
-		return "", "", "", "", fmt.Errorf("Seed image path %q has an odd number of key/value segments", params)
+		return seedImageParams{}, fmt.Errorf("Seed image path %q has an odd number of key/value segments", params)
 	}
 
 	values := map[string]string{}
@@ -1003,41 +1019,49 @@ func parseSeedImageParams(params string) (imageType api.ImageType, architecture 
 
 		_, exists := values[key]
 		if exists {
-			return "", "", "", "", fmt.Errorf("Duplicate parameter %q in seed image path", key)
+			return seedImageParams{}, fmt.Errorf("Duplicate parameter %q in seed image path", key)
 		}
 
 		switch key {
-		case "architecture", "channel", "type":
+		case "architecture", "channel", "deployment", "type":
 			values[key] = segments[i+1]
 
 		default:
-			return "", "", "", "", fmt.Errorf("Unknown parameter %q in seed image path", key)
+			return seedImageParams{}, fmt.Errorf("Unknown parameter %q in seed image path", key)
 		}
 	}
 
 	typeArg, ok := values["type"]
 	if !ok {
-		return "", "", "", "", fmt.Errorf("Missing required parameter %q in seed image path", "type")
+		return seedImageParams{}, fmt.Errorf("Missing required parameter %q in seed image path", "type")
 	}
 
-	imageType = api.ImageType(typeArg)
-	if !imageType.IsValid() {
-		return "", "", "", "", fmt.Errorf("Image type %q is not valid", typeArg)
+	parsed.imageType = api.ImageType(typeArg)
+	if !parsed.imageType.IsValid() {
+		return seedImageParams{}, fmt.Errorf("Image type %q is not valid", typeArg)
 	}
 
 	architectureArg, ok := values["architecture"]
 	if !ok {
-		return "", "", "", "", fmt.Errorf("Missing required parameter %q in seed image path", "architecture")
+		return seedImageParams{}, fmt.Errorf("Missing required parameter %q in seed image path", "architecture")
 	}
 
-	architecture = images.UpdateFileArchitecture(architectureArg)
+	parsed.architecture = images.UpdateFileArchitecture(architectureArg)
 
-	_, ok = images.UpdateFileArchitectures[architecture]
+	_, ok = images.UpdateFileArchitectures[parsed.architecture]
 	if !ok {
-		return "", "", "", "", fmt.Errorf("Architecture %q is not valid", architectureArg)
+		return seedImageParams{}, fmt.Errorf("Architecture %q is not valid", architectureArg)
 	}
 
-	return imageType, architecture, values["channel"], fingerprintID, nil
+	deploymentArg, ok := values["deployment"]
+	if ok && !seedImageIDRegexp.MatchString(deploymentArg) {
+		return seedImageParams{}, fmt.Errorf("Deployment ID %q is not valid", deploymentArg)
+	}
+
+	parsed.channel = values["channel"]
+	parsed.deploymentID = deploymentArg
+
+	return parsed, nil
 }
 
 // swagger:operation PUT /1.0/provisioning/tokens/{uuid}/seeds/{name} tokens token_seed_put

--- a/internal/api/api_provisioning_token_internal_test.go
+++ b/internal/api/api_provisioning_token_internal_test.go
@@ -695,10 +695,15 @@ func Test_tokenHandler_tokenSeedImageGetRange(t *testing.T) {
 	}
 }
 
+// Test_tokenHandler_tokenSeedImageGet_readProgress asserts, what is recorded for
+// a deployment streaming its installation media, and that a read, that names no
+// deployment, is not recorded at all.
 func Test_tokenHandler_tokenSeedImageGet_readProgress(t *testing.T) {
 	const (
 		fingerprintID = "AAAAAAAAAAAA"
-		path          = "/" + tokenUUID + "/seeds/test/architecture/x86_64/channel/stable/type/iso/" + fingerprintID + ".iso"
+		deploymentID  = "BBBBBBBBBBBB"
+		basePath      = "/" + tokenUUID + "/seeds/test/architecture/x86_64/channel/stable"
+		path          = basePath + "/deployment/" + deploymentID + "/type/iso/" + fingerprintID + ".iso"
 		content       = "0123456789abcdefghij"
 	)
 
@@ -717,58 +722,123 @@ func Test_tokenHandler_tokenSeedImageGet_readProgress(t *testing.T) {
 	tracker := seedprogress.New()
 	server := newTokenTestServer(t, tokenService, tracker)
 
-	imageID := provisioning.SeedImageID{
-		CacheID:       provisioning.SeedImageCacheID(uuid.MustParse(tokenUUID), "test", api.ImageTypeISO, images.UpdateFileArchitecture64BitX86, "stable"),
-		FingerprintID: fingerprintID,
-	}
+	// A BMC does not necessarily read the installation media from one address
+	// only, so the reads of the deployment have to add up across them.
+	firstAddress := loopbackClient(t, "127.0.0.1")
+	secondAddress := loopbackClient(t, "127.0.0.2")
 
-	// A BMC streams the image from its own address, which is what tells the
-	// reads of several servers installing from the same image apart.
-	firstBMC := loopbackClient(t, "127.0.0.1")
-	secondBMC := loopbackClient(t, "127.0.0.2")
-
-	body, resp := doTokenRequestFullWithClient(t, firstBMC, server, http.MethodGet, path, "", nil)
+	body, resp := doTokenRequestFullWithClient(t, firstAddress, server, http.MethodGet, path, "", nil)
 	require.Equal(t, http.StatusOK, resp.statusCode)
 	require.Equal(t, content, body)
 
-	body, resp = doTokenRequestFullWithClient(t, firstBMC, server, http.MethodGet, path, "", http.Header{"Range": []string{"bytes=5-9"}})
+	body, resp = doTokenRequestFullWithClient(t, firstAddress, server, http.MethodGet, path, "", http.Header{"Range": []string{"bytes=5-9"}})
 	require.Equal(t, http.StatusPartialContent, resp.statusCode)
 	require.Equal(t, content[5:10], body)
 
-	body, resp = doTokenRequestFullWithClient(t, secondBMC, server, http.MethodGet, path, "", http.Header{"Range": []string{"bytes=10-14"}})
+	progress, ok := tracker.Get(context.Background(), deploymentID)
+	require.True(t, ok)
+	require.Equal(t, int64(len(content)), progress.Size)
+
+	require.Equal(t, int64(len(content)+5), progress.BytesServed)
+	require.Equal(t, int64(len(content)), progress.BytesCovered, "the range re-read after the full download is only covered once")
+	require.Equal(t, 2, progress.RequestCount)
+
+	require.False(t, progress.FirstRead.IsZero())
+	require.Equal(t, time.Minute, progress.IdleFor(progress.LastRead.Add(time.Minute)))
+
+	// The very same deployment, read from another address.
+	body, resp = doTokenRequestFullWithClient(t, secondAddress, server, http.MethodGet, path, "", http.Header{"Range": []string{"bytes=10-14"}})
 	require.Equal(t, http.StatusPartialContent, resp.statusCode)
 	require.Equal(t, content[10:15], body)
 
-	firstProgress, ok := tracker.Get(context.Background(), imageID, "127.0.0.1")
+	progress, ok = tracker.Get(context.Background(), deploymentID)
 	require.True(t, ok)
-	require.Equal(t, int64(len(content)), firstProgress.Size)
+	require.Equal(t, int64(len(content)+10), progress.BytesServed, "the reads of both addresses add up")
+	require.Equal(t, 3, progress.RequestCount)
 
-	require.Equal(t, int64(len(content)+5), firstProgress.BytesServed)
-	require.Equal(t, int64(len(content)), firstProgress.BytesCovered, "the range re-read after the full download is only covered once")
-	require.Equal(t, 2, firstProgress.RequestCount)
+	// A prepared image, that names no deployment, is not tracked: nothing ever
+	// asks for its progress.
+	untrackedPath := basePath + "/type/iso/" + fingerprintID + ".iso"
 
-	require.False(t, firstProgress.FirstRead.IsZero())
-	require.Equal(t, time.Minute, firstProgress.IdleFor(firstProgress.LastRead.Add(time.Minute)))
+	body, resp = doTokenRequestFullWithClient(t, firstAddress, server, http.MethodGet, untrackedPath, "", nil)
+	require.Equal(t, http.StatusOK, resp.statusCode)
+	require.Equal(t, content, body)
 
-	secondProgress, ok := tracker.Get(context.Background(), imageID, "127.0.0.2")
-	require.True(t, ok)
-	require.Equal(t, int64(5), secondProgress.BytesServed)
-	require.Equal(t, int64(5), secondProgress.BytesCovered, "a range request is attributed to the part of the image it names")
-	require.Equal(t, 1, secondProgress.RequestCount)
+	_, ok = tracker.Get(context.Background(), "")
+	require.False(t, ok)
 
 	// A download naming the token seed instead of a prepared image is served to
-	// a CLI or to the UI and is not tracked at all.
-	downloadPath := "/" + tokenUUID + "/seeds/test/architecture/x86_64/channel/stable/type/iso/file.iso"
+	// a CLI or to the UI and is not tracked either.
+	downloadPath := basePath + "/type/iso/file.iso"
 
 	body, resp = doTokenRequestFullWithClient(t, loopbackClient(t, "127.0.0.3"), server, http.MethodGet, downloadPath, "", nil)
 	require.Equal(t, http.StatusOK, resp.statusCode)
 	require.Equal(t, content, body)
 
-	_, ok = tracker.Get(context.Background(), imageID, "127.0.0.3")
+	_, ok = tracker.Get(context.Background(), "")
+	require.False(t, ok)
+}
+
+// Test_tokenHandler_tokenSeedImageGet_readProgressPerDeployment asserts, that
+// two deployments installing from the very same generated image are recorded
+// apart, even when their BMCs read from the same address, which happens as soon
+// as they sit behind one NAT.
+func Test_tokenHandler_tokenSeedImageGet_readProgressPerDeployment(t *testing.T) {
+	const (
+		fingerprintID = "AAAAAAAAAAAA"
+		firstID       = "BBBBBBBBBBBB"
+		secondID      = "CCCCCCCCCCCC"
+		basePath      = "/" + tokenUUID + "/seeds/test/architecture/x86_64/channel/stable"
+		content       = "0123456789abcdefghij"
+	)
+
+	tokenService := &provisioningMock.TokenServiceMock{
+		GetPreparedTokenSeedImageFunc: func(ctx context.Context, id uuid.UUID, name string, imageType api.ImageType, architecture images.UpdateFileArchitecture, channel string, fingerprintID string) (*provisioning.TokenImage, error) {
+			return testTokenImage(content), nil
+		},
+		GetTokenSeedByNameFunc: func(ctx context.Context, id uuid.UUID, name string) (*provisioning.TokenSeed, error) {
+			return &provisioning.TokenSeed{Public: true}, nil
+		},
+	}
+
+	tracker := seedprogress.New()
+	server := newTokenTestServer(t, tokenService, tracker)
+
+	bmc := loopbackClient(t, "127.0.0.1")
+
+	// The very same image, addressed by two deployments.
+	firstPath := basePath + "/deployment/" + firstID + "/type/iso/" + fingerprintID + ".iso"
+	secondPath := basePath + "/deployment/" + secondID + "/type/iso/" + fingerprintID + ".iso"
+
+	body, resp := doTokenRequestFullWithClient(t, bmc, server, http.MethodGet, firstPath, "", nil)
+	require.Equal(t, http.StatusOK, resp.statusCode)
+	require.Equal(t, content, body, "the deployment ID does not change, which image is served")
+
+	body, resp = doTokenRequestFullWithClient(t, bmc, server, http.MethodGet, secondPath, "", http.Header{"Range": []string{"bytes=0-4"}})
+	require.Equal(t, http.StatusPartialContent, resp.statusCode)
+	require.Equal(t, content[:5], body)
+
+	firstProgress, ok := tracker.Get(context.Background(), firstID)
+	require.True(t, ok)
+	require.Equal(t, int64(len(content)), firstProgress.BytesCovered)
+
+	secondProgress, ok := tracker.Get(context.Background(), secondID)
+	require.True(t, ok)
+	require.Equal(t, int64(5), secondProgress.BytesCovered, "the reads of one deployment are not attributed to the other")
+
+	// Dropping what one deployment read leaves the other one alone.
+	tracker.Reset(context.Background(), firstID)
+
+	_, ok = tracker.Get(context.Background(), firstID)
 	require.False(t, ok)
 
-	_, ok = tracker.Get(context.Background(), provisioning.SeedImageID{CacheID: imageID.CacheID}, "127.0.0.3")
-	require.False(t, ok)
+	_, ok = tracker.Get(context.Background(), secondID)
+	require.True(t, ok)
+
+	// A deployment ID, that is not of the shape the server produces, is refused
+	// rather than silently opening a record of its own.
+	_, resp = doTokenRequestFullWithClient(t, bmc, server, http.MethodGet, basePath+"/deployment/nope/type/iso/"+fingerprintID+".iso", "", nil)
+	require.Equal(t, http.StatusBadRequest, resp.statusCode)
 }
 
 func loopbackClient(t *testing.T, address string) *http.Client {

--- a/internal/cli/cmds/provisioning/server_deploy.go
+++ b/internal/cli/cmds/provisioning/server_deploy.go
@@ -63,7 +63,7 @@ func (c *cmdServerDeploy) Command() *cobra.Command {
   to stop a deployment.
 `
 
-	cmd.Flags().StringVar(&c.flagVirtualMediaID, "virtual-media-id", "", `Virtual media device to attach the installation media to, e.g. "system:1". Defaults to the first CD/DVD device of the server, preferring the ones offered by the system`)
+	cmd.Flags().StringVar(&c.flagVirtualMediaID, "virtual-media-id", "", `Virtual media device to attach the installation media to, e.g. "system:1". Defaults to the first device of the server taking the requested image type, preferring the ones offered by the system`)
 	cmd.Flags().StringVar(&c.flagType, "type", "iso", "type of image (iso|raw)")
 	cmd.Flags().StringVar(&c.flagArchitecture, "architecture", "x86_64", "CPU architecture for the image (x86_64|aarch64)")
 	cmd.Flags().StringVar(&c.flagChannel, "channel", "", "Channel, the most recent update should be taken from to generate the image")

--- a/internal/cli/cmds/provisioning/server_deploy_internal_test.go
+++ b/internal/cli/cmds/provisioning/server_deploy_internal_test.go
@@ -176,7 +176,7 @@ func TestDeploymentProgressLines_reportsEveryStateOnce(t *testing.T) {
 
 	var (
 		history      = make([]api.ServerDeploymentStep, 0, len(states))
-		reported     []string
+		reported     = make([]string, 0, len(states))
 		reportedUpTo time.Time
 	)
 

--- a/internal/config/daemon/consts.go
+++ b/internal/config/daemon/consts.go
@@ -95,8 +95,9 @@ const (
 	// Time without any read of the installation media, after which the first
 	// stage of the installation is considered done. The period has to outlast the
 	// phase, in which the installer partitions the disk without reading the media
-	// anymore. Waiting too long costs nothing, since the stronger signals end the
-	// wait as soon as they can.
+	// anymore, but no more than that: it is the whole latency of the only signal
+	// a deployment requested with force has, where the server is done installing
+	// and waits for the media to go before it reboots.
 	ServerDeploymentMediaIdlePeriod = 2 * time.Minute
 
 	// Amount of the installation media, that has to have been read, before the
@@ -108,10 +109,20 @@ const (
 	// the installer stops reading.
 	ServerDeploymentMediaMinBytesRead int64 = 500 * 1024 * 1024
 
-	// Time, that has to have passed in the install wait, before anything but the
-	// server having registered itself counts as the end of the first stage of
-	// the installation.
+	// Time, that has to have passed in the install wait, before the first stage
+	// of the installation could be done at all, which the read progress of the
+	// installation media is held against. A Lenovo ThinkSystem was through the
+	// first stage in nine and a half minutes, so this stays well below what an
+	// installation takes.
 	ServerDeploymentMinInstallDuration = 5 * time.Minute
+
+	// Time, that has to have passed in the install wait, before a reboot counts
+	// as the end of the first stage, where the BMC reports no boot progress to
+	// tell the reboot of the firmware, that picks up what has been staged for it,
+	// from the one of the installer. It has to outlast the power on self test
+	// plus the boot of the installation media, which is why it is longer than the
+	// duration above, and it only applies where nothing better is available.
+	ServerDeploymentInstallRebootFallbackDelay = 10 * time.Minute
 
 	// Time, the server is left running after the secure boot certificates have
 	// been enrolled, before the installation is started, where the firmware does

--- a/internal/provisioning/adapter/middleware/seed_image_progress_port_prometheus_gen.go
+++ b/internal/provisioning/adapter/middleware/seed_image_progress_port_prometheus_gen.go
@@ -40,41 +40,31 @@ func NewSeedImageProgressPortWithPrometheus(base provisioning.SeedImageProgressP
 }
 
 // Get implements provisioning.SeedImageProgressPort.
-func (_d SeedImageProgressPortWithPrometheus) Get(ctx context.Context, imageID provisioning.SeedImageID, source string) (seedImageProgress provisioning.SeedImageProgress, b bool) {
+func (_d SeedImageProgressPortWithPrometheus) Get(ctx context.Context, deploymentID string) (seedImageProgress provisioning.SeedImageProgress, b bool) {
 	_since := time.Now()
 	defer func() {
 		result := "ok"
 		seedImageProgressPortDurationSummaryVec.WithLabelValues(_d.instanceName, "Get", result).Observe(time.Since(_since).Seconds())
 	}()
-	return _d.base.Get(ctx, imageID, source)
-}
-
-// GetByImage implements provisioning.SeedImageProgressPort.
-func (_d SeedImageProgressPortWithPrometheus) GetByImage(ctx context.Context, imageID provisioning.SeedImageID) (seedImageProgresss []provisioning.SeedImageProgress) {
-	_since := time.Now()
-	defer func() {
-		result := "ok"
-		seedImageProgressPortDurationSummaryVec.WithLabelValues(_d.instanceName, "GetByImage", result).Observe(time.Since(_since).Seconds())
-	}()
-	return _d.base.GetByImage(ctx, imageID)
+	return _d.base.Get(ctx, deploymentID)
 }
 
 // Reset implements provisioning.SeedImageProgressPort.
-func (_d SeedImageProgressPortWithPrometheus) Reset(ctx context.Context, imageID provisioning.SeedImageID) {
+func (_d SeedImageProgressPortWithPrometheus) Reset(ctx context.Context, deploymentID string) {
 	_since := time.Now()
 	defer func() {
 		result := "ok"
 		seedImageProgressPortDurationSummaryVec.WithLabelValues(_d.instanceName, "Reset", result).Observe(time.Since(_since).Seconds())
 	}()
-	_d.base.Reset(ctx, imageID)
+	_d.base.Reset(ctx, deploymentID)
 }
 
 // Track implements provisioning.SeedImageProgressPort.
-func (_d SeedImageProgressPortWithPrometheus) Track(ctx context.Context, imageID provisioning.SeedImageID, source string, info provisioning.SeedImageInfo, content io.ReadSeekCloser) (readSeekCloser io.ReadSeekCloser) {
+func (_d SeedImageProgressPortWithPrometheus) Track(ctx context.Context, deploymentID string, info provisioning.SeedImageInfo, content io.ReadSeekCloser) (readSeekCloser io.ReadSeekCloser) {
 	_since := time.Now()
 	defer func() {
 		result := "ok"
 		seedImageProgressPortDurationSummaryVec.WithLabelValues(_d.instanceName, "Track", result).Observe(time.Since(_since).Seconds())
 	}()
-	return _d.base.Track(ctx, imageID, source, info, content)
+	return _d.base.Track(ctx, deploymentID, info, content)
 }

--- a/internal/provisioning/adapter/middleware/seed_image_progress_port_slog_gen.go
+++ b/internal/provisioning/adapter/middleware/seed_image_progress_port_slog_gen.go
@@ -41,13 +41,12 @@ func NewSeedImageProgressPortWithSlog(base provisioning.SeedImageProgressPort, o
 }
 
 // Get implements provisioning.SeedImageProgressPort.
-func (_d SeedImageProgressPortWithSlog) Get(ctx context.Context, imageID provisioning.SeedImageID, source string) (seedImageProgress provisioning.SeedImageProgress, b bool) {
+func (_d SeedImageProgressPortWithSlog) Get(ctx context.Context, deploymentID string) (seedImageProgress provisioning.SeedImageProgress, b bool) {
 	log := slog.With()
 	if slog.Default().Enabled(ctx, logger.LevelTrace) {
 		log = log.With(
 			slog.Any("ctx", ctx),
-			slog.Any("imageID", imageID),
-			slog.String("source", source),
+			slog.String("deploymentID", deploymentID),
 		)
 	}
 	log.DebugContext(ctx, "=> calling Get")
@@ -62,39 +61,16 @@ func (_d SeedImageProgressPortWithSlog) Get(ctx context.Context, imageID provisi
 		}
 		log.DebugContext(ctx, "<= method Get finished")
 	}()
-	return _d._base.Get(ctx, imageID, source)
-}
-
-// GetByImage implements provisioning.SeedImageProgressPort.
-func (_d SeedImageProgressPortWithSlog) GetByImage(ctx context.Context, imageID provisioning.SeedImageID) (seedImageProgresss []provisioning.SeedImageProgress) {
-	log := slog.With()
-	if slog.Default().Enabled(ctx, logger.LevelTrace) {
-		log = log.With(
-			slog.Any("ctx", ctx),
-			slog.Any("imageID", imageID),
-		)
-	}
-	log.DebugContext(ctx, "=> calling GetByImage")
-	defer func() {
-		log := slog.With()
-		if slog.Default().Enabled(ctx, logger.LevelTrace) {
-			log = slog.With(
-				slog.Any("seedImageProgresss", seedImageProgresss),
-			)
-		} else {
-		}
-		log.DebugContext(ctx, "<= method GetByImage finished")
-	}()
-	return _d._base.GetByImage(ctx, imageID)
+	return _d._base.Get(ctx, deploymentID)
 }
 
 // Reset implements provisioning.SeedImageProgressPort.
-func (_d SeedImageProgressPortWithSlog) Reset(ctx context.Context, imageID provisioning.SeedImageID) {
+func (_d SeedImageProgressPortWithSlog) Reset(ctx context.Context, deploymentID string) {
 	log := slog.With()
 	if slog.Default().Enabled(ctx, logger.LevelTrace) {
 		log = log.With(
 			slog.Any("ctx", ctx),
-			slog.Any("imageID", imageID),
+			slog.String("deploymentID", deploymentID),
 		)
 	}
 	log.DebugContext(ctx, "=> calling Reset")
@@ -102,17 +78,16 @@ func (_d SeedImageProgressPortWithSlog) Reset(ctx context.Context, imageID provi
 		log := slog.With()
 		log.DebugContext(ctx, "<= method Reset finished")
 	}()
-	_d._base.Reset(ctx, imageID)
+	_d._base.Reset(ctx, deploymentID)
 }
 
 // Track implements provisioning.SeedImageProgressPort.
-func (_d SeedImageProgressPortWithSlog) Track(ctx context.Context, imageID provisioning.SeedImageID, source string, info provisioning.SeedImageInfo, content io.ReadSeekCloser) (readSeekCloser io.ReadSeekCloser) {
+func (_d SeedImageProgressPortWithSlog) Track(ctx context.Context, deploymentID string, info provisioning.SeedImageInfo, content io.ReadSeekCloser) (readSeekCloser io.ReadSeekCloser) {
 	log := slog.With()
 	if slog.Default().Enabled(ctx, logger.LevelTrace) {
 		log = log.With(
 			slog.Any("ctx", ctx),
-			slog.Any("imageID", imageID),
-			slog.String("source", source),
+			slog.String("deploymentID", deploymentID),
 			slog.Any("info", info),
 			slog.Any("content", content),
 		)
@@ -128,5 +103,5 @@ func (_d SeedImageProgressPortWithSlog) Track(ctx context.Context, imageID provi
 		}
 		log.DebugContext(ctx, "<= method Track finished")
 	}()
-	return _d._base.Track(ctx, imageID, source, info, content)
+	return _d._base.Track(ctx, deploymentID, info, content)
 }

--- a/internal/provisioning/adapter/mock/seed_image_progress_port_mock_gen.go
+++ b/internal/provisioning/adapter/mock/seed_image_progress_port_mock_gen.go
@@ -22,16 +22,13 @@ var _ provisioning.SeedImageProgressPort = &SeedImageProgressPortMock{}
 //
 //		// make and configure a mocked provisioning.SeedImageProgressPort
 //		mockedSeedImageProgressPort := &SeedImageProgressPortMock{
-//			GetFunc: func(ctx context.Context, imageID provisioning.SeedImageID, source string) (provisioning.SeedImageProgress, bool) {
+//			GetFunc: func(ctx context.Context, deploymentID string) (provisioning.SeedImageProgress, bool) {
 //				panic("mock out the Get method")
 //			},
-//			GetByImageFunc: func(ctx context.Context, imageID provisioning.SeedImageID) []provisioning.SeedImageProgress {
-//				panic("mock out the GetByImage method")
-//			},
-//			ResetFunc: func(ctx context.Context, imageID provisioning.SeedImageID)  {
+//			ResetFunc: func(ctx context.Context, deploymentID string)  {
 //				panic("mock out the Reset method")
 //			},
-//			TrackFunc: func(ctx context.Context, imageID provisioning.SeedImageID, source string, info provisioning.SeedImageInfo, content io.ReadSeekCloser) io.ReadSeekCloser {
+//			TrackFunc: func(ctx context.Context, deploymentID string, info provisioning.SeedImageInfo, content io.ReadSeekCloser) io.ReadSeekCloser {
 //				panic("mock out the Track method")
 //			},
 //		}
@@ -42,16 +39,13 @@ var _ provisioning.SeedImageProgressPort = &SeedImageProgressPortMock{}
 //	}
 type SeedImageProgressPortMock struct {
 	// GetFunc mocks the Get method.
-	GetFunc func(ctx context.Context, imageID provisioning.SeedImageID, source string) (provisioning.SeedImageProgress, bool)
-
-	// GetByImageFunc mocks the GetByImage method.
-	GetByImageFunc func(ctx context.Context, imageID provisioning.SeedImageID) []provisioning.SeedImageProgress
+	GetFunc func(ctx context.Context, deploymentID string) (provisioning.SeedImageProgress, bool)
 
 	// ResetFunc mocks the Reset method.
-	ResetFunc func(ctx context.Context, imageID provisioning.SeedImageID)
+	ResetFunc func(ctx context.Context, deploymentID string)
 
 	// TrackFunc mocks the Track method.
-	TrackFunc func(ctx context.Context, imageID provisioning.SeedImageID, source string, info provisioning.SeedImageInfo, content io.ReadSeekCloser) io.ReadSeekCloser
+	TrackFunc func(ctx context.Context, deploymentID string, info provisioning.SeedImageInfo, content io.ReadSeekCloser) io.ReadSeekCloser
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -59,63 +53,49 @@ type SeedImageProgressPortMock struct {
 		Get []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// ImageID is the imageID argument value.
-			ImageID provisioning.SeedImageID
-			// Source is the source argument value.
-			Source string
-		}
-		// GetByImage holds details about calls to the GetByImage method.
-		GetByImage []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// ImageID is the imageID argument value.
-			ImageID provisioning.SeedImageID
+			// DeploymentID is the deploymentID argument value.
+			DeploymentID string
 		}
 		// Reset holds details about calls to the Reset method.
 		Reset []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// ImageID is the imageID argument value.
-			ImageID provisioning.SeedImageID
+			// DeploymentID is the deploymentID argument value.
+			DeploymentID string
 		}
 		// Track holds details about calls to the Track method.
 		Track []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// ImageID is the imageID argument value.
-			ImageID provisioning.SeedImageID
-			// Source is the source argument value.
-			Source string
+			// DeploymentID is the deploymentID argument value.
+			DeploymentID string
 			// Info is the info argument value.
 			Info provisioning.SeedImageInfo
 			// Content is the content argument value.
 			Content io.ReadSeekCloser
 		}
 	}
-	lockGet        sync.RWMutex
-	lockGetByImage sync.RWMutex
-	lockReset      sync.RWMutex
-	lockTrack      sync.RWMutex
+	lockGet   sync.RWMutex
+	lockReset sync.RWMutex
+	lockTrack sync.RWMutex
 }
 
 // Get calls GetFunc.
-func (mock *SeedImageProgressPortMock) Get(ctx context.Context, imageID provisioning.SeedImageID, source string) (provisioning.SeedImageProgress, bool) {
+func (mock *SeedImageProgressPortMock) Get(ctx context.Context, deploymentID string) (provisioning.SeedImageProgress, bool) {
 	if mock.GetFunc == nil {
 		panic("SeedImageProgressPortMock.GetFunc: method is nil but SeedImageProgressPort.Get was just called")
 	}
 	callInfo := struct {
-		Ctx     context.Context
-		ImageID provisioning.SeedImageID
-		Source  string
+		Ctx          context.Context
+		DeploymentID string
 	}{
-		Ctx:     ctx,
-		ImageID: imageID,
-		Source:  source,
+		Ctx:          ctx,
+		DeploymentID: deploymentID,
 	}
 	mock.lockGet.Lock()
 	mock.calls.Get = append(mock.calls.Get, callInfo)
 	mock.lockGet.Unlock()
-	return mock.GetFunc(ctx, imageID, source)
+	return mock.GetFunc(ctx, deploymentID)
 }
 
 // GetCalls gets all the calls that were made to Get.
@@ -123,14 +103,12 @@ func (mock *SeedImageProgressPortMock) Get(ctx context.Context, imageID provisio
 //
 //	len(mockedSeedImageProgressPort.GetCalls())
 func (mock *SeedImageProgressPortMock) GetCalls() []struct {
-	Ctx     context.Context
-	ImageID provisioning.SeedImageID
-	Source  string
+	Ctx          context.Context
+	DeploymentID string
 } {
 	var calls []struct {
-		Ctx     context.Context
-		ImageID provisioning.SeedImageID
-		Source  string
+		Ctx          context.Context
+		DeploymentID string
 	}
 	mock.lockGet.RLock()
 	calls = mock.calls.Get
@@ -138,58 +116,22 @@ func (mock *SeedImageProgressPortMock) GetCalls() []struct {
 	return calls
 }
 
-// GetByImage calls GetByImageFunc.
-func (mock *SeedImageProgressPortMock) GetByImage(ctx context.Context, imageID provisioning.SeedImageID) []provisioning.SeedImageProgress {
-	if mock.GetByImageFunc == nil {
-		panic("SeedImageProgressPortMock.GetByImageFunc: method is nil but SeedImageProgressPort.GetByImage was just called")
-	}
-	callInfo := struct {
-		Ctx     context.Context
-		ImageID provisioning.SeedImageID
-	}{
-		Ctx:     ctx,
-		ImageID: imageID,
-	}
-	mock.lockGetByImage.Lock()
-	mock.calls.GetByImage = append(mock.calls.GetByImage, callInfo)
-	mock.lockGetByImage.Unlock()
-	return mock.GetByImageFunc(ctx, imageID)
-}
-
-// GetByImageCalls gets all the calls that were made to GetByImage.
-// Check the length with:
-//
-//	len(mockedSeedImageProgressPort.GetByImageCalls())
-func (mock *SeedImageProgressPortMock) GetByImageCalls() []struct {
-	Ctx     context.Context
-	ImageID provisioning.SeedImageID
-} {
-	var calls []struct {
-		Ctx     context.Context
-		ImageID provisioning.SeedImageID
-	}
-	mock.lockGetByImage.RLock()
-	calls = mock.calls.GetByImage
-	mock.lockGetByImage.RUnlock()
-	return calls
-}
-
 // Reset calls ResetFunc.
-func (mock *SeedImageProgressPortMock) Reset(ctx context.Context, imageID provisioning.SeedImageID) {
+func (mock *SeedImageProgressPortMock) Reset(ctx context.Context, deploymentID string) {
 	if mock.ResetFunc == nil {
 		panic("SeedImageProgressPortMock.ResetFunc: method is nil but SeedImageProgressPort.Reset was just called")
 	}
 	callInfo := struct {
-		Ctx     context.Context
-		ImageID provisioning.SeedImageID
+		Ctx          context.Context
+		DeploymentID string
 	}{
-		Ctx:     ctx,
-		ImageID: imageID,
+		Ctx:          ctx,
+		DeploymentID: deploymentID,
 	}
 	mock.lockReset.Lock()
 	mock.calls.Reset = append(mock.calls.Reset, callInfo)
 	mock.lockReset.Unlock()
-	mock.ResetFunc(ctx, imageID)
+	mock.ResetFunc(ctx, deploymentID)
 }
 
 // ResetCalls gets all the calls that were made to Reset.
@@ -197,12 +139,12 @@ func (mock *SeedImageProgressPortMock) Reset(ctx context.Context, imageID provis
 //
 //	len(mockedSeedImageProgressPort.ResetCalls())
 func (mock *SeedImageProgressPortMock) ResetCalls() []struct {
-	Ctx     context.Context
-	ImageID provisioning.SeedImageID
+	Ctx          context.Context
+	DeploymentID string
 } {
 	var calls []struct {
-		Ctx     context.Context
-		ImageID provisioning.SeedImageID
+		Ctx          context.Context
+		DeploymentID string
 	}
 	mock.lockReset.RLock()
 	calls = mock.calls.Reset
@@ -211,27 +153,25 @@ func (mock *SeedImageProgressPortMock) ResetCalls() []struct {
 }
 
 // Track calls TrackFunc.
-func (mock *SeedImageProgressPortMock) Track(ctx context.Context, imageID provisioning.SeedImageID, source string, info provisioning.SeedImageInfo, content io.ReadSeekCloser) io.ReadSeekCloser {
+func (mock *SeedImageProgressPortMock) Track(ctx context.Context, deploymentID string, info provisioning.SeedImageInfo, content io.ReadSeekCloser) io.ReadSeekCloser {
 	if mock.TrackFunc == nil {
 		panic("SeedImageProgressPortMock.TrackFunc: method is nil but SeedImageProgressPort.Track was just called")
 	}
 	callInfo := struct {
-		Ctx     context.Context
-		ImageID provisioning.SeedImageID
-		Source  string
-		Info    provisioning.SeedImageInfo
-		Content io.ReadSeekCloser
+		Ctx          context.Context
+		DeploymentID string
+		Info         provisioning.SeedImageInfo
+		Content      io.ReadSeekCloser
 	}{
-		Ctx:     ctx,
-		ImageID: imageID,
-		Source:  source,
-		Info:    info,
-		Content: content,
+		Ctx:          ctx,
+		DeploymentID: deploymentID,
+		Info:         info,
+		Content:      content,
 	}
 	mock.lockTrack.Lock()
 	mock.calls.Track = append(mock.calls.Track, callInfo)
 	mock.lockTrack.Unlock()
-	return mock.TrackFunc(ctx, imageID, source, info, content)
+	return mock.TrackFunc(ctx, deploymentID, info, content)
 }
 
 // TrackCalls gets all the calls that were made to Track.
@@ -239,18 +179,16 @@ func (mock *SeedImageProgressPortMock) Track(ctx context.Context, imageID provis
 //
 //	len(mockedSeedImageProgressPort.TrackCalls())
 func (mock *SeedImageProgressPortMock) TrackCalls() []struct {
-	Ctx     context.Context
-	ImageID provisioning.SeedImageID
-	Source  string
-	Info    provisioning.SeedImageInfo
-	Content io.ReadSeekCloser
+	Ctx          context.Context
+	DeploymentID string
+	Info         provisioning.SeedImageInfo
+	Content      io.ReadSeekCloser
 } {
 	var calls []struct {
-		Ctx     context.Context
-		ImageID provisioning.SeedImageID
-		Source  string
-		Info    provisioning.SeedImageInfo
-		Content io.ReadSeekCloser
+		Ctx          context.Context
+		DeploymentID string
+		Info         provisioning.SeedImageInfo
+		Content      io.ReadSeekCloser
 	}
 	mock.lockTrack.RLock()
 	calls = mock.calls.Track

--- a/internal/provisioning/adapter/seedprogress/seedprogress.go
+++ b/internal/provisioning/adapter/seedprogress/seedprogress.go
@@ -1,14 +1,12 @@
-// Package seedprogress records how much of a seed image the sources streaming
-// it have read.
+// Package seedprogress records how much of its installation media a deployment
+// has read.
 package seedprogress
 
 import (
-	"cmp"
 	"context"
 	"io"
 	"log/slog"
 	"maps"
-	"slices"
 	"sync"
 	"time"
 
@@ -30,17 +28,10 @@ type Tracker struct {
 	now                func() time.Time
 
 	mu      sync.Mutex
-	entries map[entryKey]*entry
+	entries map[string]*entry
 }
 
 var _ provisioning.SeedImageProgressPort = &Tracker{}
-
-// entryKey is what tells the readers of the seed images apart. Several servers
-// can install from the same image at the same time.
-type entryKey struct {
-	imageID provisioning.SeedImageID
-	source  string
-}
 
 type entry struct {
 	size int64
@@ -79,7 +70,7 @@ func New(opts ...Option) *Tracker {
 	tracker := &Tracker{
 		idleEvictionPeriod: defaultIdleEvictionPeriod,
 		now:                time.Now,
-		entries:            map[entryKey]*entry{},
+		entries:            map[string]*entry{},
 	}
 
 	for _, opt := range opts {
@@ -90,92 +81,58 @@ func New(opts ...Option) *Tracker {
 }
 
 // Track wraps content, so that the reads served from it are recorded as
-// progress of source reading the image identified by imageID.
-func (t *Tracker) Track(ctx context.Context, imageID provisioning.SeedImageID, source string, info provisioning.SeedImageInfo, content io.ReadSeekCloser) io.ReadSeekCloser {
-	key := entryKey{
-		imageID: imageID,
-		source:  source,
-	}
-
+// progress of the deployment named by deploymentID.
+func (t *Tracker) Track(ctx context.Context, deploymentID string, info provisioning.SeedImageInfo, content io.ReadSeekCloser) io.ReadSeekCloser {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.evict()
 
-	e := t.entry(key)
+	e := t.entry(deploymentID)
 	e.size = info.Size
 	e.lastActivity = t.now()
 
 	return &trackedContent{
-		ctx:     ctx,
-		tracker: t,
-		key:     key,
-		content: content,
+		ctx:          ctx,
+		tracker:      t,
+		deploymentID: deploymentID,
+		content:      content,
 	}
 }
 
-// Get returns the progress recorded for imageID being read by source and
-// reports whether anything has been recorded at all.
-func (t *Tracker) Get(_ context.Context, imageID provisioning.SeedImageID, source string) (provisioning.SeedImageProgress, bool) {
+// Get returns the progress recorded for the deployment and reports whether
+// anything has been recorded at all.
+func (t *Tracker) Get(_ context.Context, deploymentID string) (provisioning.SeedImageProgress, bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.evict()
 
-	key := entryKey{imageID: imageID, source: source}
-
-	e, ok := t.entries[key]
+	e, ok := t.entries[deploymentID]
 	if !ok {
 		return provisioning.SeedImageProgress{}, false
 	}
 
-	return e.progress(key), true
+	return e.progress(deploymentID), true
 }
 
-// GetByImage returns the progress recorded for imageID by every source, that
-// has read it, ordered by source.
-func (t *Tracker) GetByImage(_ context.Context, imageID provisioning.SeedImageID) []provisioning.SeedImageProgress {
+// Reset drops what has been recorded for the deployment, leaving every other
+// deployment, including the ones reading the very same image, alone.
+func (t *Tracker) Reset(_ context.Context, deploymentID string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	t.evict()
-
-	var progress []provisioning.SeedImageProgress
-
-	for key, e := range t.entries {
-		if key.imageID != imageID {
-			continue
-		}
-
-		progress = append(progress, e.progress(key))
-	}
-
-	slices.SortFunc(progress, func(a provisioning.SeedImageProgress, b provisioning.SeedImageProgress) int {
-		return cmp.Compare(a.Source, b.Source)
-	})
-
-	return progress
-}
-
-// Reset drops what has been recorded for imageID, no matter which source read
-// it.
-func (t *Tracker) Reset(_ context.Context, imageID provisioning.SeedImageID) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	maps.DeleteFunc(t.entries, func(key entryKey, _ *entry) bool {
-		return key.imageID == imageID
-	})
+	delete(t.entries, deploymentID)
 }
 
 // record accounts for the n bytes at offset having been read.
-func (t *Tracker) record(ctx context.Context, key entryKey, offset int64, n int, isRequestStart bool) {
+func (t *Tracker) record(ctx context.Context, deploymentID string, offset int64, n int, isRequestStart bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	now := t.now()
 
-	e := t.entry(key)
+	e := t.entry(deploymentID)
 	e.bytesServed += int64(n)
 	e.coverage.add(offset, int64(n))
 
@@ -198,8 +155,7 @@ func (t *Tracker) record(ctx context.Context, key entryKey, offset int64, n int,
 
 	slog.DebugContext(
 		ctx, "Seed image read progress",
-		slog.String("image_id", key.imageID.String()),
-		slog.String("source", key.source),
+		slog.String("deployment_id", deploymentID),
 		slog.Int64("bytes_covered", e.coverage.bytes()),
 		slog.Int64("bytes_served", e.bytesServed),
 		slog.Int64("size", e.size),
@@ -210,10 +166,9 @@ func (t *Tracker) record(ctx context.Context, key entryKey, offset int64, n int,
 
 // progress returns what has been recorded for the entry. The caller holds the
 // lock.
-func (e *entry) progress(key entryKey) provisioning.SeedImageProgress {
+func (e *entry) progress(deploymentID string) provisioning.SeedImageProgress {
 	return provisioning.SeedImageProgress{
-		ImageID:      key.imageID,
-		Source:       key.source,
+		DeploymentID: deploymentID,
 		Size:         e.size,
 		BytesServed:  e.bytesServed,
 		BytesCovered: e.coverage.bytes(),
@@ -223,38 +178,38 @@ func (e *entry) progress(key entryKey) provisioning.SeedImageProgress {
 	}
 }
 
-// entry returns the entry for key, adding it if it does not exist yet. The
-// caller holds the lock.
-func (t *Tracker) entry(key entryKey) *entry {
-	e, ok := t.entries[key]
+// entry returns the entry of the deployment, adding it if it does not exist yet.
+// The caller holds the lock.
+func (t *Tracker) entry(deploymentID string) *entry {
+	e, ok := t.entries[deploymentID]
 	if !ok {
 		e = &entry{}
-		t.entries[key] = e
+		t.entries[deploymentID] = e
 	}
 
 	return e
 }
 
 // evict drops the records without any activity for the idle eviction period, so
-// that a long running daemon does not accumulate one record per source and
-// image. The caller holds the lock.
+// that a long running daemon does not accumulate one record per deployment ever
+// run. The caller holds the lock.
 func (t *Tracker) evict() {
 	deadline := t.now().Add(-t.idleEvictionPeriod)
 
-	maps.DeleteFunc(t.entries, func(_ entryKey, e *entry) bool {
+	maps.DeleteFunc(t.entries, func(_ string, e *entry) bool {
 		return e.lastActivity.Before(deadline)
 	})
 }
 
-// trackedContent reports the reads served from one image to one source.
+// trackedContent reports the reads served from one image to one deployment.
 type trackedContent struct {
 	// ctx is the context of the request being served. It is only used to log
 	// the progress along with what identifies the request.
-	ctx     context.Context
-	tracker *Tracker
-	key     entryKey
-	content io.ReadSeekCloser
-	pos     int64
+	ctx          context.Context
+	tracker      *Tracker
+	deploymentID string
+	content      io.ReadSeekCloser
+	pos          int64
 
 	hasRead bool
 }
@@ -262,7 +217,7 @@ type trackedContent struct {
 func (c *trackedContent) Read(p []byte) (int, error) {
 	n, err := c.content.Read(p)
 	if n > 0 {
-		c.tracker.record(c.ctx, c.key, c.pos, n, !c.hasRead)
+		c.tracker.record(c.ctx, c.deploymentID, c.pos, n, !c.hasRead)
 		c.pos += int64(n)
 		c.hasRead = true
 	}

--- a/internal/provisioning/adapter/seedprogress/seedprogress_test.go
+++ b/internal/provisioning/adapter/seedprogress/seedprogress_test.go
@@ -13,12 +13,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/provisioning/adapter/seedprogress"
 )
 
-const testSource = "10.0.0.1"
-
-var testImageID = provisioning.SeedImageID{
-	CacheID:       "cache-id",
-	FingerprintID: "fingerprint",
-}
+const testDeploymentID = "deployment-1"
 
 func TestTracker_overlappingRangeReads(t *testing.T) {
 	const content = "0123456789abcdefghij"
@@ -26,14 +21,14 @@ func TestTracker_overlappingRangeReads(t *testing.T) {
 	ctx := context.Background()
 	tracker := seedprogress.New()
 
-	image := tracker.Track(ctx, testImageID, testSource, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
+	image := tracker.Track(ctx, testDeploymentID, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
 
 	readRange(t, image, 10, 5)
 	readRange(t, image, 0, 5)
 
 	require.NoError(t, image.Close())
 
-	progress, ok := tracker.Get(ctx, testImageID, testSource)
+	progress, ok := tracker.Get(ctx, testDeploymentID)
 	require.True(t, ok)
 	require.Equal(t, int64(10), progress.BytesServed)
 	require.Equal(t, int64(10), progress.BytesCovered, "two disjoint ranges cover what they add up to")
@@ -46,14 +41,14 @@ func TestTracker_repeatedRangeReads(t *testing.T) {
 	ctx := context.Background()
 	tracker := seedprogress.New()
 
-	image := tracker.Track(ctx, testImageID, testSource, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
+	image := tracker.Track(ctx, testDeploymentID, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
 
 	readRange(t, image, 0, 5)
 	readRange(t, image, 0, 5)
 
 	require.NoError(t, image.Close())
 
-	progress, ok := tracker.Get(ctx, testImageID, testSource)
+	progress, ok := tracker.Get(ctx, testDeploymentID)
 	require.True(t, ok)
 	require.Equal(t, int64(10), progress.BytesServed, "every byte handed out is counted")
 	require.Equal(t, int64(5), progress.BytesCovered, "a range read twice is only covered once")
@@ -72,14 +67,14 @@ func TestTracker_coverageAcrossRequests(t *testing.T) {
 		{offset: 0, length: 10},
 		{offset: 5, length: 15},
 	} {
-		image := tracker.Track(ctx, testImageID, testSource, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
+		image := tracker.Track(ctx, testDeploymentID, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
 
 		readRange(t, image, read.offset, read.length)
 
 		require.NoError(t, image.Close())
 	}
 
-	progress, ok := tracker.Get(ctx, testImageID, testSource)
+	progress, ok := tracker.Get(ctx, testDeploymentID)
 	require.True(t, ok)
 	require.Equal(t, int64(25), progress.BytesServed)
 	require.Equal(t, int64(20), progress.BytesCovered, "the ranges two requests overlap in are only covered once")
@@ -92,7 +87,7 @@ func TestTracker_seekedReadsRecordAbsoluteOffsets(t *testing.T) {
 	ctx := context.Background()
 	tracker := seedprogress.New()
 
-	image := tracker.Track(ctx, testImageID, testSource, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
+	image := tracker.Track(ctx, testDeploymentID, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
 
 	_, err := image.Seek(-4, io.SeekEnd)
 	require.NoError(t, err)
@@ -110,76 +105,68 @@ func TestTracker_seekedReadsRecordAbsoluteOffsets(t *testing.T) {
 
 	require.NoError(t, image.Close())
 
-	progress, ok := tracker.Get(ctx, testImageID, testSource)
+	progress, ok := tracker.Get(ctx, testDeploymentID)
 	require.True(t, ok)
 	require.Equal(t, int64(12), progress.BytesServed)
 	require.Equal(t, int64(8), progress.BytesCovered, "a range reached by any kind of seek is covered once")
 }
 
-func TestTracker_reset(t *testing.T) {
+func TestTrackerReset(t *testing.T) {
 	const content = "0123456789"
 
 	ctx := context.Background()
 	tracker := seedprogress.New()
 
-	otherImage := provisioning.SeedImageID{CacheID: "other", FingerprintID: "fingerprint"}
+	const otherDeploymentID = "deployment-2"
 
-	for _, read := range []struct {
-		imageID provisioning.SeedImageID
-		source  string
-	}{
-		{imageID: testImageID, source: testSource},
-		{imageID: testImageID, source: "10.0.0.2"},
-		{imageID: otherImage, source: testSource},
-	} {
-		image := tracker.Track(ctx, read.imageID, read.source, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
+	for _, deploymentID := range []string{testDeploymentID, otherDeploymentID} {
+		image := tracker.Track(ctx, deploymentID, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
 
 		readRange(t, image, 0, 5)
 
 		require.NoError(t, image.Close())
 	}
 
-	tracker.Reset(ctx, testImageID)
+	tracker.Reset(ctx, testDeploymentID)
 
-	require.Empty(t, tracker.GetByImage(ctx, testImageID), "every source, that read the image, is dropped")
-	require.Len(t, tracker.GetByImage(ctx, otherImage), 1, "another image is kept")
+	_, ok := tracker.Get(ctx, testDeploymentID)
+	require.False(t, ok, "what the deployment read is dropped")
+
+	progress, ok := tracker.Get(ctx, otherDeploymentID)
+	require.True(t, ok, "the deployment still reading the image keeps its progress")
+	require.Equal(t, int64(5), progress.BytesCovered)
+
+	tracker.Reset(ctx, "deployment-never-seen")
 }
 
-func TestTracker_getByImage(t *testing.T) {
+func TestTracker_readsFromSeveralSources(t *testing.T) {
 	const content = "0123456789"
 
 	ctx := context.Background()
 	tracker := seedprogress.New()
 
-	otherImage := provisioning.SeedImageID{CacheID: "other", FingerprintID: "fingerprint"}
-
 	for _, read := range []struct {
-		imageID provisioning.SeedImageID
-		source  string
-		length  int64
+		offset int64
+		length int64
 	}{
-		{imageID: testImageID, source: "10.0.0.2", length: 4},
-		{imageID: testImageID, source: "10.0.0.1", length: 7},
-		{imageID: otherImage, source: "10.0.0.3", length: 2},
+		{offset: 0, length: 4},
+		{offset: 4, length: 3},
 	} {
-		image := tracker.Track(ctx, read.imageID, read.source, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
+		image := tracker.Track(ctx, testDeploymentID, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
 
-		readRange(t, image, 0, read.length)
+		readRange(t, image, read.offset, read.length)
 
 		require.NoError(t, image.Close())
 	}
 
-	progress := tracker.GetByImage(ctx, testImageID)
+	progress, ok := tracker.Get(ctx, testDeploymentID)
+	require.True(t, ok)
+	require.Equal(t, int64(7), progress.BytesServed)
+	require.Equal(t, int64(7), progress.BytesCovered, "the reads of both addresses add up")
+	require.Equal(t, 2, progress.RequestCount)
 
-	require.Len(t, progress, 2)
-	require.Equal(t, "10.0.0.1", progress[0].Source)
-	require.Equal(t, int64(7), progress[0].BytesServed)
-	require.Equal(t, int64(7), progress[0].BytesCovered)
-	require.Equal(t, "10.0.0.2", progress[1].Source)
-	require.Equal(t, int64(4), progress[1].BytesServed)
-	require.Equal(t, int64(4), progress[1].BytesCovered)
-
-	require.Empty(t, tracker.GetByImage(ctx, provisioning.SeedImageID{CacheID: "unread", FingerprintID: "fingerprint"}))
+	_, ok = tracker.Get(ctx, "deployment-never-seen")
+	require.False(t, ok)
 }
 
 func TestTracker_evictionAfterIdlePeriod(t *testing.T) {
@@ -193,7 +180,7 @@ func TestTracker_evictionAfterIdlePeriod(t *testing.T) {
 		seedprogress.WithNow(func() time.Time { return now }),
 	)
 
-	image := tracker.Track(ctx, testImageID, testSource, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
+	image := tracker.Track(ctx, testDeploymentID, provisioning.SeedImageInfo{Size: int64(len(content))}, nopReadSeekCloser{strings.NewReader(content)})
 
 	_, err := io.ReadAll(image)
 	require.NoError(t, err)
@@ -201,13 +188,13 @@ func TestTracker_evictionAfterIdlePeriod(t *testing.T) {
 
 	now = now.Add(time.Hour)
 
-	progress, ok := tracker.Get(ctx, testImageID, testSource)
+	progress, ok := tracker.Get(ctx, testDeploymentID)
 	require.True(t, ok)
 	require.Equal(t, time.Hour, progress.IdleFor(now))
 
 	now = now.Add(time.Second)
 
-	_, ok = tracker.Get(ctx, testImageID, testSource)
+	_, ok = tracker.Get(ctx, testDeploymentID)
 	require.False(t, ok)
 }
 

--- a/internal/provisioning/repo/middleware/server_repo_prometheus_gen.go
+++ b/internal/provisioning/repo/middleware/server_repo_prometheus_gen.go
@@ -94,6 +94,20 @@ func (_d ServerRepoWithPrometheus) GetAllNames(ctx context.Context) (strings []s
 	return _d.base.GetAllNames(ctx)
 }
 
+// GetAllNamesWithActiveDeployment implements provisioning.ServerRepo.
+func (_d ServerRepoWithPrometheus) GetAllNamesWithActiveDeployment(ctx context.Context) (strings []string, err error) {
+	_since := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+
+		serverRepoDurationSummaryVec.WithLabelValues(_d.instanceName, "GetAllNamesWithActiveDeployment", result).Observe(time.Since(_since).Seconds())
+	}()
+	return _d.base.GetAllNamesWithActiveDeployment(ctx)
+}
+
 // GetAllNamesWithFilter implements provisioning.ServerRepo.
 func (_d ServerRepoWithPrometheus) GetAllNamesWithFilter(ctx context.Context, filter provisioning.ServerFilter) (strings []string, err error) {
 	_since := time.Now()

--- a/internal/provisioning/repo/middleware/server_repo_slog_gen.go
+++ b/internal/provisioning/repo/middleware/server_repo_slog_gen.go
@@ -176,6 +176,40 @@ func (_d ServerRepoWithSlog) GetAllNames(ctx context.Context) (strings []string,
 	return _d._base.GetAllNames(ctx)
 }
 
+// GetAllNamesWithActiveDeployment implements provisioning.ServerRepo.
+func (_d ServerRepoWithSlog) GetAllNamesWithActiveDeployment(ctx context.Context) (strings []string, err error) {
+	log := slog.With()
+	if slog.Default().Enabled(ctx, logger.LevelTrace) {
+		log = log.With(
+			slog.Any("ctx", ctx),
+		)
+	}
+	log.DebugContext(ctx, "=> calling GetAllNamesWithActiveDeployment")
+	defer func() {
+		log := slog.With()
+		if slog.Default().Enabled(ctx, logger.LevelTrace) {
+			log = slog.With(
+				slog.Any("strings", strings),
+				slog.Any("err", err),
+			)
+		} else {
+			if err != nil {
+				log = slog.With("err", err)
+			}
+		}
+		if err != nil {
+			if _d._isInformativeErrFunc(err) {
+				log.DebugContext(ctx, "<= method GetAllNamesWithActiveDeployment returned an informative error")
+			} else {
+				log.ErrorContext(ctx, "<= method GetAllNamesWithActiveDeployment returned an error")
+			}
+		} else {
+			log.DebugContext(ctx, "<= method GetAllNamesWithActiveDeployment finished")
+		}
+	}()
+	return _d._base.GetAllNamesWithActiveDeployment(ctx)
+}
+
 // GetAllNamesWithFilter implements provisioning.ServerRepo.
 func (_d ServerRepoWithSlog) GetAllNamesWithFilter(ctx context.Context, filter provisioning.ServerFilter) (strings []string, err error) {
 	log := slog.With()

--- a/internal/provisioning/repo/mock/server_repo_mock_gen.go
+++ b/internal/provisioning/repo/mock/server_repo_mock_gen.go
@@ -33,6 +33,9 @@ var _ provisioning.ServerRepo = &ServerRepoMock{}
 //			GetAllNamesFunc: func(ctx context.Context) ([]string, error) {
 //				panic("mock out the GetAllNames method")
 //			},
+//			GetAllNamesWithActiveDeploymentFunc: func(ctx context.Context) ([]string, error) {
+//				panic("mock out the GetAllNamesWithActiveDeployment method")
+//			},
 //			GetAllNamesWithFilterFunc: func(ctx context.Context, filter provisioning.ServerFilter) ([]string, error) {
 //				panic("mock out the GetAllNamesWithFilter method")
 //			},
@@ -75,6 +78,9 @@ type ServerRepoMock struct {
 
 	// GetAllNamesFunc mocks the GetAllNames method.
 	GetAllNamesFunc func(ctx context.Context) ([]string, error)
+
+	// GetAllNamesWithActiveDeploymentFunc mocks the GetAllNamesWithActiveDeployment method.
+	GetAllNamesWithActiveDeploymentFunc func(ctx context.Context) ([]string, error)
 
 	// GetAllNamesWithFilterFunc mocks the GetAllNamesWithFilter method.
 	GetAllNamesWithFilterFunc func(ctx context.Context, filter provisioning.ServerFilter) ([]string, error)
@@ -123,6 +129,11 @@ type ServerRepoMock struct {
 		}
 		// GetAllNames holds details about calls to the GetAllNames method.
 		GetAllNames []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+		}
+		// GetAllNamesWithActiveDeployment holds details about calls to the GetAllNamesWithActiveDeployment method.
+		GetAllNamesWithActiveDeployment []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
@@ -185,18 +196,19 @@ type ServerRepoMock struct {
 			Server provisioning.Server
 		}
 	}
-	lockCreate                sync.RWMutex
-	lockDeleteByName          sync.RWMutex
-	lockGetAll                sync.RWMutex
-	lockGetAllNames           sync.RWMutex
-	lockGetAllNamesWithFilter sync.RWMutex
-	lockGetAllWithFilter      sync.RWMutex
-	lockGetByCertificate      sync.RWMutex
-	lockGetByMachineID        sync.RWMutex
-	lockGetByName             sync.RWMutex
-	lockGetBySystemUUID       sync.RWMutex
-	lockRename                sync.RWMutex
-	lockUpdate                sync.RWMutex
+	lockCreate                          sync.RWMutex
+	lockDeleteByName                    sync.RWMutex
+	lockGetAll                          sync.RWMutex
+	lockGetAllNames                     sync.RWMutex
+	lockGetAllNamesWithActiveDeployment sync.RWMutex
+	lockGetAllNamesWithFilter           sync.RWMutex
+	lockGetAllWithFilter                sync.RWMutex
+	lockGetByCertificate                sync.RWMutex
+	lockGetByMachineID                  sync.RWMutex
+	lockGetByName                       sync.RWMutex
+	lockGetBySystemUUID                 sync.RWMutex
+	lockRename                          sync.RWMutex
+	lockUpdate                          sync.RWMutex
 }
 
 // Create calls CreateFunc.
@@ -332,6 +344,38 @@ func (mock *ServerRepoMock) GetAllNamesCalls() []struct {
 	mock.lockGetAllNames.RLock()
 	calls = mock.calls.GetAllNames
 	mock.lockGetAllNames.RUnlock()
+	return calls
+}
+
+// GetAllNamesWithActiveDeployment calls GetAllNamesWithActiveDeploymentFunc.
+func (mock *ServerRepoMock) GetAllNamesWithActiveDeployment(ctx context.Context) ([]string, error) {
+	if mock.GetAllNamesWithActiveDeploymentFunc == nil {
+		panic("ServerRepoMock.GetAllNamesWithActiveDeploymentFunc: method is nil but ServerRepo.GetAllNamesWithActiveDeployment was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockGetAllNamesWithActiveDeployment.Lock()
+	mock.calls.GetAllNamesWithActiveDeployment = append(mock.calls.GetAllNamesWithActiveDeployment, callInfo)
+	mock.lockGetAllNamesWithActiveDeployment.Unlock()
+	return mock.GetAllNamesWithActiveDeploymentFunc(ctx)
+}
+
+// GetAllNamesWithActiveDeploymentCalls gets all the calls that were made to GetAllNamesWithActiveDeployment.
+// Check the length with:
+//
+//	len(mockedServerRepo.GetAllNamesWithActiveDeploymentCalls())
+func (mock *ServerRepoMock) GetAllNamesWithActiveDeploymentCalls() []struct {
+	Ctx context.Context
+} {
+	var calls []struct {
+		Ctx context.Context
+	}
+	mock.lockGetAllNamesWithActiveDeployment.RLock()
+	calls = mock.calls.GetAllNamesWithActiveDeployment
+	mock.lockGetAllNamesWithActiveDeployment.RUnlock()
 	return calls
 }
 

--- a/internal/provisioning/repo/sqlite/server.go
+++ b/internal/provisioning/repo/sqlite/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	incustls "github.com/lxc/incus/v7/shared/tls"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/FuturFusion/operations-center/internal/provisioning/repo/sqlite/entities"
 	"github.com/FuturFusion/operations-center/internal/sql/sqlite"
 	"github.com/FuturFusion/operations-center/internal/sql/transaction"
+	"github.com/FuturFusion/operations-center/shared/api"
 )
 
 type server struct {
@@ -73,6 +75,53 @@ func (s server) GetAllNames(ctx context.Context) ([]string, error) {
 
 func (s server) GetAllNamesWithFilter(ctx context.Context, filter provisioning.ServerFilter) ([]string, error) {
 	return entities.GetServerNames(ctx, transaction.GetDBTX(ctx, s.db), filter)
+}
+
+// serverNamesWithActiveDeploymentStmt selects the servers, that still have an
+// automated deployment to advance, based on the deployment state (and not
+// the server state).
+var serverNamesWithActiveDeploymentStmt = fmt.Sprintf(`
+SELECT servers.name
+  FROM servers
+  WHERE json_extract(servers.status_internal, '$.deployment.state') IS NOT NULL
+    AND json_extract(servers.status_internal, '$.deployment.state') NOT IN (%s)
+  ORDER BY servers.name
+`, strings.TrimSuffix(strings.Repeat("?, ", len(api.ServerDeploymentTerminalStates())), ", "))
+
+func (s server) GetAllNamesWithActiveDeployment(ctx context.Context) ([]string, error) {
+	terminalStates := api.ServerDeploymentTerminalStates()
+
+	args := make([]any, 0, len(terminalStates))
+	for _, state := range terminalStates {
+		args = append(args, state.String())
+	}
+
+	rows, err := transaction.GetDBTX(ctx, s.db).QueryContext(ctx, serverNamesWithActiveDeploymentStmt, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get the names of the servers with an active deployment: %w", err)
+	}
+
+	defer func() { _ = rows.Close() }()
+
+	var names []string
+
+	for rows.Next() {
+		var name string
+
+		err = rows.Scan(&name)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get the names of the servers with an active deployment: %w", err)
+		}
+
+		names = append(names, name)
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get the names of the servers with an active deployment: %w", err)
+	}
+
+	return names, nil
 }
 
 func (s server) GetByName(ctx context.Context, name string) (*provisioning.Server, error) {

--- a/internal/provisioning/repo/sqlite/server_test.go
+++ b/internal/provisioning/repo/sqlite/server_test.go
@@ -361,6 +361,81 @@ func TestServerDatabaseActions(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestServerDatabaseActions_namesWithActiveDeployment asserts, that the servers
+// with a deployment to advance are found from the deployment record alone: a
+// server, that has registered itself, owns its status again while its deployment
+// is still finalizing, so no status tells them apart.
+func TestServerDatabaseActions_namesWithActiveDeployment(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	db, err := dbdriver.Open(tmpDir)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = db.Close()
+		require.NoError(t, err)
+	})
+
+	_, err = dbschema.Ensure(ctx, db, tmpDir)
+	require.NoError(t, err)
+
+	tx := transaction.Enable(db)
+	entities.PreparedStmts, err = entities.PrepareStmts(tx, false)
+	require.NoError(t, err)
+
+	server := sqlite.NewServer(tx)
+
+	withDeployment := func(name string, status api.ServerStatus, state api.ServerDeploymentState) provisioning.Server {
+		srv := provisioning.Server{
+			Name:    name,
+			Status:  status,
+			Channel: "stable",
+		}
+
+		if state != "" {
+			srv.StatusInternal.Deployment = &provisioning.ServerDeployment{
+				State:   state,
+				Request: provisioning.ServerDeploymentRequest{ImageType: api.ImageTypeISO},
+			}
+		}
+
+		return srv
+	}
+
+	servers := []provisioning.Server{
+		withDeployment("deploying", api.ServerStatusDeploying, api.ServerDeploymentStateWaitInstall),
+		withDeployment("registering", api.ServerStatusPending, api.ServerDeploymentStateWaitRegistration),
+		withDeployment("ready", api.ServerStatusReady, api.ServerDeploymentStateCleanup),
+		withDeployment("completed", api.ServerStatusReady, api.ServerDeploymentStateCompleted),
+		withDeployment("failed", api.ServerStatusUnregistered, api.ServerDeploymentStateFailed),
+		withDeployment("cancelled", api.ServerStatusUnregistered, api.ServerDeploymentStateCancelled),
+		withDeployment("never deployed", api.ServerStatusUnregistered, ""),
+	}
+
+	for _, srv := range servers {
+		_, err = server.Create(ctx, srv)
+		require.NoError(t, err)
+	}
+
+	names, err := server.GetAllNamesWithActiveDeployment(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"deploying", "ready", "registering"}, names)
+
+	// A deployment, that reaches a terminal state, is not picked up anymore.
+	done, err := server.GetByName(ctx, "ready")
+	require.NoError(t, err)
+
+	done.StatusInternal.Deployment.State = api.ServerDeploymentStateCompleted
+
+	err = server.Update(ctx, *done)
+	require.NoError(t, err)
+
+	names, err = server.GetAllNamesWithActiveDeployment(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"deploying", "registering"}, names)
+}
+
 func TestServerDatabaseActions_preRegisteredWithoutCertificate(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/provisioning/seed_image_progress_model.go
+++ b/internal/provisioning/seed_image_progress_model.go
@@ -1,26 +1,13 @@
 package provisioning
 
 import (
-	"net"
-	"net/netip"
 	"time"
 )
 
-// SeedImageID addresses one prepared seed image, the way the URL a BMC streams
-// it from does.
-type SeedImageID struct {
-	CacheID       string
-	FingerprintID string
-}
-
-func (i SeedImageID) String() string {
-	return i.CacheID + "/" + i.FingerprintID
-}
-
-// SeedImageProgress reports how much of a seed image one source has read.
+// SeedImageProgress reports how much of its installation media one deployment
+// has read.
 type SeedImageProgress struct {
-	ImageID      SeedImageID
-	Source       string
+	DeploymentID string
 	Size         int64
 	BytesServed  int64
 	BytesCovered int64
@@ -37,22 +24,4 @@ func (p SeedImageProgress) IdleFor(now time.Time) time.Duration {
 	}
 
 	return now.Sub(p.LastRead)
-}
-
-// SeedImageSource returns the canonical form of the address an image is read
-// from, as it is used to tell the readers of an image apart.
-func SeedImageSource(addr string) string {
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		host = addr
-	}
-
-	// Normalize the host, so that an address recorded here can be compared to
-	// the host of a configured BMC endpoint.
-	ip, err := netip.ParseAddr(host)
-	if err != nil {
-		return host
-	}
-
-	return ip.Unmap().String()
 }

--- a/internal/provisioning/seed_image_progress_ports.go
+++ b/internal/provisioning/seed_image_progress_ports.go
@@ -5,23 +5,18 @@ import (
 	"io"
 )
 
-// SeedImageProgressPort records how much of a seed image the sources reading it
-// have read.
+// SeedImageProgressPort records how much of its installation media a deployment
+// has read.
 type SeedImageProgressPort interface {
 	// Track wraps content, so that the reads served from it are recorded as
-	// progress of source reading the image described by info and identified by
-	// imageID.
-	Track(ctx context.Context, imageID SeedImageID, source string, info SeedImageInfo, content io.ReadSeekCloser) io.ReadSeekCloser
+	// progress of the deployment named by deploymentID.
+	Track(ctx context.Context, deploymentID string, info SeedImageInfo, content io.ReadSeekCloser) io.ReadSeekCloser
 
-	// Get returns the progress recorded for imageID being read by source and
-	// reports whether anything has been recorded at all.
-	Get(ctx context.Context, imageID SeedImageID, source string) (SeedImageProgress, bool)
+	// Get returns the progress recorded for the deployment and reports whether
+	// anything has been recorded at all.
+	Get(ctx context.Context, deploymentID string) (SeedImageProgress, bool)
 
-	// GetByImage returns the progress recorded for imageID by every source,
-	// that has read it, ordered by source.
-	GetByImage(ctx context.Context, imageID SeedImageID) []SeedImageProgress
-
-	// Reset drops what has been recorded for imageID, no matter which source
-	// read it.
-	Reset(ctx context.Context, imageID SeedImageID)
+	// Reset drops what has been recorded for the deployment, leaving every other
+	// deployment, including the ones reading the very same image, alone.
+	Reset(ctx context.Context, deploymentID string)
 }

--- a/internal/provisioning/server/server_deployment.go
+++ b/internal/provisioning/server/server_deployment.go
@@ -1268,7 +1268,7 @@ var bmcWaitConditions = map[api.ServerDeploymentState]func(*provisioning.ServerD
 	api.ServerDeploymentStateWaitPowerOffBIOSDeferred:      deploymentPowerIsOff,
 	api.ServerDeploymentStateWaitPowerOffSecureBoot:        deploymentPowerIsOff,
 	api.ServerDeploymentStateWaitPowerOffSecureBootSettled: deploymentPowerIsOff,
-	api.ServerDeploymentStateWaitCancel:                    deploymentPowerIsOff,
+	api.ServerDeploymentStateWaitCancel:                    deploymentCancelSettled,
 	api.ServerDeploymentStateWaitMediaCleared:              deploymentNoMediaInserted,
 	api.ServerDeploymentStateWaitMediaAttached:             deploymentMediaHoldsImage,
 	api.ServerDeploymentStateWaitMediaDetached:             deploymentMediaEjected,
@@ -1276,6 +1276,12 @@ var bmcWaitConditions = map[api.ServerDeploymentState]func(*provisioning.ServerD
 
 func deploymentPowerIsOff(_ *provisioning.ServerDeployment, data api.BMCData) bool {
 	return data.ServerPowerState == bmcPowerStateOff
+}
+
+// deploymentCancelSettled tells, whether the clean up of a cancelled deployment
+// has come through.
+func deploymentCancelSettled(deployment *provisioning.ServerDeployment, data api.BMCData) bool {
+	return deploymentPowerIsOff(deployment, data) && deploymentNoMediaInserted(deployment, data)
 }
 
 func deploymentNoMediaInserted(_ *provisioning.ServerDeployment, data api.BMCData) bool {

--- a/internal/provisioning/server/server_deployment.go
+++ b/internal/provisioning/server/server_deployment.go
@@ -1066,7 +1066,13 @@ func (s *serverService) runDeploymentAction(ctx context.Context, log *slog.Logge
 // attachDeploymentMedia generates the installation media, attaches it and
 // registers it as the boot device for the next boot.
 func (s *serverService) attachDeploymentMedia(ctx context.Context, server provisioning.Server) (func(*provisioning.ServerDeployment), error) {
-	request := server.StatusInternal.Deployment.Request
+	deployment := server.StatusInternal.Deployment
+	request := deployment.Request
+
+	deploymentID := deployment.ImageDeploymentID
+	if deploymentID == "" {
+		deploymentID = provisioning.NewSeedImageDeploymentID()
+	}
 
 	if s.seedImageProgress != nil {
 		s.seedImageProgress.Reset(ctx, deploymentID)
@@ -1531,11 +1537,18 @@ func (s *serverService) checkDeploymentInstalled(ctx context.Context, log *slog.
 		bytesRead = progress.BytesCovered
 	}
 
+	// The installer having been running is what tells the reboot at the end of
+	// the first stage apart from the one the firmware performs to pick up, what
+	// has been staged for it, since the latter comes within the POST cycles of
+	// the very boot, that is supposed to start the installer.
+	osObserved := deployment.InstallOSObserved || deploymentInstallOSObserved(deployment, current.BMCData)
+
 	var mutate func(*provisioning.ServerDeployment)
-	if bytesRead != deployment.MediaBytesRead {
+	if bytesRead != deployment.MediaBytesRead || osObserved != deployment.InstallOSObserved {
 		mutate = func(deployment *provisioning.ServerDeployment) {
 			deployment.MediaBytesRead = bytesRead
 			deployment.MediaSize = progress.Size
+			deployment.InstallOSObserved = osObserved
 		}
 	}
 
@@ -1545,9 +1558,9 @@ func (s *serverService) checkDeploymentInstalled(ctx context.Context, log *slog.
 		// The firmware reboots the server on its own, once it has applied the
 		// staged BIOS attributes or picked the enrolled secure boot certificates
 		// up, both of which happen on the very boot, that is supposed to start
-		// the installer. Such a reboot re-anchors the detection instead of ending
-		// the wait.
-		if !deploymentInstallRebootEndsTheWait(now, deployment, progress, progressKnown) {
+		// the installer, before it ever gets to run. Such a reboot re-anchors the
+		// detection instead of ending the wait.
+		if !deploymentInstallRebootTellsTheInstallation(now, deployment, osObserved) {
 			log.InfoContext(
 				ctx, "Server rebooted before the installation could have completed, waiting for the installation",
 				slog.Bool("media_progress_known", progressKnown),
@@ -1570,6 +1583,7 @@ func (s *serverService) checkDeploymentInstalled(ctx context.Context, log *slog.
 
 		log.InfoContext(
 			ctx, "Installation completed, the BMC reports a reboot of the server",
+			slog.Bool("os_observed", osObserved),
 			slog.Bool("media_read_out", progressKnown && deploymentMediaReadOut(progress)),
 			slog.Int64("bytes_covered", progress.BytesCovered),
 			slog.Duration("installing_for", now.Sub(deployment.StateEnteredAt)),
@@ -1578,10 +1592,13 @@ func (s *serverService) checkDeploymentInstalled(ctx context.Context, log *slog.
 		return true, mutate, nil
 	}
 
-	couldBeDone := deploymentInstallCouldBeDone(now, deployment)
-
 	// 3. The BMC has read enough of the installation media and stopped reading.
-	if couldBeDone && progressKnown && deploymentMediaReadOut(progress) && deploymentMediaIdle(now, progress) {
+	//    Only a deployment, whose server does not reboot on its own, is told by
+	//    the read progress: a BMC, that caches the media instead of handing every
+	//    read through to the installer, reads it out while the server boots and
+	//    then goes quiet, which is indistinguishable from an installation, that
+	//    has been read out and is done.
+	if !deployment.ForceReboot && deploymentInstallCouldBeDone(now, deployment) && progressKnown && deploymentMediaReadOut(progress) && deploymentMediaIdle(now, progress) {
 		log.InfoContext(ctx, "Installation completed, the installation media has been read and is idle", slog.Int64("bytes_covered", progress.BytesCovered))
 
 		return true, mutate, nil
@@ -1630,14 +1647,29 @@ func deploymentInstallCouldBeDone(now time.Time, deployment *provisioning.Server
 	return now.Sub(deployment.StateEnteredAt) >= config.ServerDeploymentMinInstallDuration
 }
 
-// deploymentInstallRebootEndsTheWait reports, whether a reboot the BMC observed
-// can be taken as the end of the first stage of the installation.
-func deploymentInstallRebootEndsTheWait(now time.Time, deployment *provisioning.ServerDeployment, progress provisioning.SeedImageProgress, progressKnown bool) bool {
-	if progressKnown && deploymentMediaReadOut(progress) {
+// deploymentInstallRebootTellsTheInstallation reports, whether a reboot the BMC
+// observed can be taken as the end of the first stage of the installation.
+func deploymentInstallRebootTellsTheInstallation(now time.Time, deployment *provisioning.ServerDeployment, osObserved bool) bool {
+	if osObserved {
 		return true
 	}
 
-	return deploymentInstallCouldBeDone(now, deployment)
+	return now.Sub(deployment.StateEnteredAt) >= config.ServerDeploymentInstallRebootFallbackDelay
+}
+
+// deploymentInstallOSObserved reports, whether the BMC has the server past the
+// hand over to the operating system, which the installer, and only a boot, that
+// got as far as starting it, reaches. A state, that was already reported when
+// the install wait was anchored, belongs to an earlier boot and says nothing
+// about this one.
+func deploymentInstallOSObserved(deployment *provisioning.ServerDeployment, current api.BMCData) bool {
+	progress := current.ServerBootProgress
+
+	if !api.BMCBootProgressHandedOverToOS(progress.LastState) {
+		return false
+	}
+
+	return !progress.LastStateTime.Before(deployment.InstallSnapshot.Taken)
 }
 
 // deploymentMediaReadOut reports, whether enough of the installation media has

--- a/internal/provisioning/server/server_deployment.go
+++ b/internal/provisioning/server/server_deployment.go
@@ -715,7 +715,7 @@ func (s *serverService) CancelDeploymentByName(ctx context.Context, name string)
 // DeploymentControlLoop advances the automated deployment of every server
 // matching the filter and that has one in progress.
 func (s *serverService) DeploymentControlLoop(ctx context.Context, serverNameFilter *string) error {
-	servers, err := s.deploymentCandidates(ctx, serverNameFilter)
+	names, err := s.deploymentCandidates(ctx, serverNameFilter)
 	if err != nil {
 		return fmt.Errorf("Failed to get servers for the deployment control loop: %w", err)
 	}
@@ -731,13 +731,13 @@ func (s *serverService) DeploymentControlLoop(ctx context.Context, serverNameFil
 
 	slots := make(chan struct{}, config.ServerDeploymentControlLoopConcurrency)
 
-	for _, server := range servers {
+	for _, name := range names {
 		slots <- struct{}{}
 
 		wg.Go(func() {
 			defer func() { <-slots }()
 
-			err := s.runDeployment(ctx, server.Name)
+			err := s.runDeployment(ctx, name)
 			if err == nil {
 				return
 			}
@@ -745,7 +745,7 @@ func (s *serverService) DeploymentControlLoop(ctx context.Context, serverNameFil
 			errsMu.Lock()
 			defer errsMu.Unlock()
 
-			errs = append(errs, fmt.Errorf("Failed to advance the deployment of server %q: %w", server.Name, err))
+			errs = append(errs, fmt.Errorf("Failed to advance the deployment of server %q: %w", name, err))
 		})
 	}
 
@@ -754,58 +754,27 @@ func (s *serverService) DeploymentControlLoop(ctx context.Context, serverNameFil
 	return errors.Join(errs...)
 }
 
-// deploymentCandidates returns the servers, that have a deployment in progress.
-func (s *serverService) deploymentCandidates(ctx context.Context, serverNameFilter *string) (provisioning.Servers, error) {
-	if serverNameFilter != nil {
-		server, err := s.repo.GetByName(ctx, *serverNameFilter)
-		if err != nil {
-			if errors.Is(err, domain.ErrNotFound) {
-				return nil, nil
-			}
+// deploymentCandidates returns the names of the servers, that have a deployment
+// in progress.
+func (s *serverService) deploymentCandidates(ctx context.Context, serverNameFilter *string) ([]string, error) {
+	if serverNameFilter == nil {
+		return s.repo.GetAllNamesWithActiveDeployment(ctx)
+	}
 
-			return nil, err
-		}
-
-		if !server.StatusInternal.Deployment.IsActive() {
+	server, err := s.repo.GetByName(ctx, *serverNameFilter)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
 			return nil, nil
 		}
 
-		return provisioning.Servers{*server}, nil
+		return nil, err
 	}
 
-	filters := []provisioning.ServerFilter{
-		{
-			Status: new(api.ServerStatusDeploying),
-		},
-		{
-			Status:       new(api.ServerStatusPending),
-			StatusDetail: new(api.ServerStatusDetailPendingRegistering),
-		},
+	if !server.StatusInternal.Deployment.IsActive() {
+		return nil, nil
 	}
 
-	var candidates provisioning.Servers
-
-	seen := map[string]struct{}{}
-
-	for _, filter := range filters {
-		servers, err := s.repo.GetAllWithFilter(ctx, filter)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, server := range servers {
-			_, ok := seen[server.Name]
-			if ok || !server.StatusInternal.Deployment.IsActive() {
-				continue
-			}
-
-			seen[server.Name] = struct{}{}
-
-			candidates = append(candidates, server)
-		}
-	}
-
-	return candidates, nil
+	return []string{server.Name}, nil
 }
 
 // runDeployment advances the deployment of a single server as far as it gets

--- a/internal/provisioning/server/server_deployment.go
+++ b/internal/provisioning/server/server_deployment.go
@@ -294,6 +294,21 @@ func (e deploymentRetryFromError) Unwrap() error {
 	return e.err
 }
 
+// deploymentFatalError ends the deployment right away, instead of being retried.
+// It is what a wait state reports, when it observes, that the condition it is
+// waiting for can never be met.
+type deploymentFatalError struct {
+	err error
+}
+
+func (e deploymentFatalError) Error() string {
+	return e.err.Error()
+}
+
+func (e deploymentFatalError) Unwrap() error {
+	return e.err
+}
+
 // deploymentNextState returns the state, the deployment enters after the step it
 // just completed, passing by a BIOS pass with nothing left to apply and the
 // secure boot enrollment, if it was requested to be skipped. The skips chain,
@@ -569,7 +584,7 @@ func (s *serverService) DeployByName(ctx context.Context, name string, request p
 		}
 
 		if request.VirtualMediaID == "" {
-			request.VirtualMediaID, err = selectVirtualMediaID(server.BMCData, request.ImageType)
+			request.VirtualMediaID, err = selectVirtualMediaID(server.BMCData, request.ImageType, !forceReboot)
 			if err != nil {
 				return fmt.Errorf("Failed to select a virtual media device of server %q: %w", name, err)
 			}
@@ -585,6 +600,10 @@ func (s *serverService) DeployByName(ctx context.Context, name string, request p
 					request.VirtualMediaID, name, request.ImageType, strings.Join(media.MediaTypes, ", "), domain.ErrOperationNotPermitted,
 				)
 			}
+		}
+
+		if !forceReboot && virtualMediaUploads(server.BMCData.VirtualMedia[request.VirtualMediaID]) {
+			return deploymentUploadedMediaError(name, request.VirtualMediaID)
 		}
 
 		resolution, err := s.resolveBIOSProfile(ctx, *server)
@@ -927,6 +946,11 @@ func (s *serverService) deploymentWait(ctx context.Context, log *slog.Logger, se
 
 	met, mutate, err := s.checkBoundedDeploymentWait(ctx, log, server, definition)
 	if err != nil {
+		fatal, ok := errors.AsType[deploymentFatalError](err)
+		if ok {
+			return false, s.failDeployment(ctx, server.Name, fatal)
+		}
+
 		// Failing to observe the condition is not failing the step, it is simply
 		// repeated on the next tick until the state times out.
 		log.WarnContext(ctx, "Failed to evaluate the deployment wait condition", logger.Err(err))
@@ -1298,7 +1322,6 @@ var bmcWaitConditions = map[api.ServerDeploymentState]func(*provisioning.ServerD
 	api.ServerDeploymentStateWaitPowerOffSecureBootSettled: deploymentPowerIsOff,
 	api.ServerDeploymentStateWaitCancel:                    deploymentCancelSettled,
 	api.ServerDeploymentStateWaitMediaCleared:              deploymentNoMediaInserted,
-	api.ServerDeploymentStateWaitMediaAttached:             deploymentMediaHoldsImage,
 	api.ServerDeploymentStateWaitMediaDetached:             deploymentMediaEjected,
 }
 
@@ -1351,6 +1374,9 @@ func (s *serverService) checkDeploymentWait(ctx context.Context, log *slog.Logge
 	}
 
 	switch deployment.State {
+	case api.ServerDeploymentStateWaitMediaAttached:
+		return s.checkDeploymentMediaAttached(ctx, server)
+
 	case api.ServerDeploymentStateWaitSecureBootSettled:
 		return s.checkDeploymentSecureBootSettled(ctx, log, server)
 
@@ -1368,6 +1394,22 @@ func (s *serverService) checkDeploymentWait(ctx context.Context, log *slog.Logge
 	}
 
 	return false, nil, fmt.Errorf("Deployment state %q is not a wait", deployment.State)
+}
+
+func (s *serverService) checkDeploymentMediaAttached(ctx context.Context, server provisioning.Server) (bool, func(*provisioning.ServerDeployment), error) {
+	deployment := server.StatusInternal.Deployment
+
+	current, err := s.deploymentBMCData(ctx, server)
+	if err != nil {
+		return false, nil, err
+	}
+
+	media, ok := current.BMCData.VirtualMedia[deployment.Request.VirtualMediaID]
+	if ok && !deployment.ForceReboot && virtualMediaUploads(media) {
+		return false, nil, deploymentFatalError{err: deploymentUploadedMediaError(server.Name, deployment.Request.VirtualMediaID)}
+	}
+
+	return deploymentMediaHoldsImage(deployment, current.BMCData), nil, nil
 }
 
 // checkDeploymentRebooted tells, whether the server has come back up after the
@@ -1601,7 +1643,7 @@ func (s *serverService) deploymentMediaProgress(ctx context.Context, server prov
 	}
 
 	media, ok := server.BMCData.VirtualMedia[deployment.Request.VirtualMediaID]
-	if ok && strings.EqualFold(media.TransferMethod, virtualMediaTransferMethodUpload) {
+	if ok && virtualMediaUploads(media) {
 		return provisioning.SeedImageProgress{}, false
 	}
 
@@ -1884,6 +1926,19 @@ var virtualMediaTypesByImageType = map[api.ImageType][]string{
 
 var virtualMediaServicePrecedence = []string{"system", "manager"}
 
+// virtualMediaUploads reports, whether a virtual media device pulls the image in
+// before the server boots, instead of streaming.
+func virtualMediaUploads(media api.BMCVirtualMedia) bool {
+	return strings.EqualFold(media.TransferMethod, virtualMediaTransferMethodUpload)
+}
+
+func deploymentUploadedMediaError(name string, virtualMediaID string) error {
+	return fmt.Errorf(
+		`Virtual media device %q of server %q uploads the installation media instead of streaming it, so its read progress can not tell, when the installation is done. Use a token seed, that sets "force_reboot", or a virtual media device, that streams: %w`,
+		virtualMediaID, name, domain.ErrOperationNotPermitted,
+	)
+}
+
 // virtualMediaAdvertisesImageType reports, whether a virtual media device says
 // itself, that it can hold an image of the given type.
 func virtualMediaAdvertisesImageType(media api.BMCVirtualMedia, imageType api.ImageType) bool {
@@ -1909,16 +1964,44 @@ func virtualMediaSupportsImageType(media api.BMCVirtualMedia, imageType api.Imag
 // attached to, preferring a device advertising support for the requested image
 // type over one advertising nothing and, among equally suitable devices, one
 // offered by the system over one offered by the manager.
-func selectVirtualMediaID(data api.BMCData, imageType api.ImageType) (string, error) {
+//
+// A deployment, that has only the read progress of the installation media to
+// tell the installation by, needs a device, that streams it.
+func selectVirtualMediaID(data api.BMCData, imageType api.ImageType, requireStreaming bool) (string, error) {
 	if len(data.VirtualMedia) == 0 {
 		return "", fmt.Errorf("The BMC reports no virtual media device: %w", domain.ErrNotFound)
 	}
 
 	ids := virtualMediaIDsByPreference(data)
 
+	if requireStreaming {
+		streaming := slices.DeleteFunc(slices.Clone(ids), func(id string) bool {
+			return virtualMediaUploads(data.VirtualMedia[id])
+		})
+
+		id, ok := selectVirtualMediaIDFrom(data, streaming, imageType)
+		if ok {
+			return id, nil
+		}
+	}
+
+	id, ok := selectVirtualMediaIDFrom(data, ids, imageType)
+	if ok {
+		return id, nil
+	}
+
+	return "", fmt.Errorf(
+		"No virtual media device of the BMC accepts a %q image, it reports %s: %w",
+		imageType, describeVirtualMediaTypes(data), domain.ErrOperationNotPermitted,
+	)
+}
+
+// selectVirtualMediaIDFrom picks the device holding an image of the given type
+// out of ids, which the caller has already brought into the order of preference.
+func selectVirtualMediaIDFrom(data api.BMCData, ids []string, imageType api.ImageType) (string, bool) {
 	for _, id := range ids {
 		if virtualMediaAdvertisesImageType(data.VirtualMedia[id], imageType) {
-			return id, nil
+			return id, true
 		}
 	}
 
@@ -1926,14 +2009,11 @@ func selectVirtualMediaID(data api.BMCData, imageType api.ImageType) (string, er
 	// device, that does not say, what it takes.
 	for _, id := range ids {
 		if len(data.VirtualMedia[id].MediaTypes) == 0 {
-			return id, nil
+			return id, true
 		}
 	}
 
-	return "", fmt.Errorf(
-		"No virtual media device of the BMC accepts a %q image, it reports %s: %w",
-		imageType, describeVirtualMediaTypes(data), domain.ErrOperationNotPermitted,
-	)
+	return "", false
 }
 
 // virtualMediaIDsByPreference returns the IDs of all virtual media devices, the

--- a/internal/provisioning/server/server_deployment.go
+++ b/internal/provisioning/server/server_deployment.go
@@ -1068,6 +1068,10 @@ func (s *serverService) runDeploymentAction(ctx context.Context, log *slog.Logge
 func (s *serverService) attachDeploymentMedia(ctx context.Context, server provisioning.Server) (func(*provisioning.ServerDeployment), error) {
 	request := server.StatusInternal.Deployment.Request
 
+	if s.seedImageProgress != nil {
+		s.seedImageProgress.Reset(ctx, deploymentID)
+	}
+
 	attached, err := s.bmcAttachMediaByName(ctx, server.Name, api.ServerBMCAttachMedia{
 		TokenUUID:      request.TokenUUID.String(),
 		Seed:           request.Seed,
@@ -1076,41 +1080,29 @@ func (s *serverService) attachDeploymentMedia(ctx context.Context, server provis
 		Channel:        request.Channel,
 		VirtualMediaID: request.VirtualMediaID,
 		SetBootDevice:  true,
-	}, false)
+	}, deploymentID, false)
 	if err != nil {
 		return nil, err
 	}
 
-	imageID := provisioning.SeedImageID{
-		CacheID:       provisioning.SeedImageCacheID(request.TokenUUID, request.Seed, request.ImageType, request.Architecture, request.Channel),
-		FingerprintID: attached.fingerprintID,
-	}
-
-	s.resetDeploymentMediaProgress(ctx, imageID)
-
 	return func(deployment *provisioning.ServerDeployment) {
 		deployment.MediaURL = attached.imageURL
-		deployment.ImageCacheID = imageID.CacheID
-		deployment.ImageFingerprintID = imageID.FingerprintID
+		deployment.ImageDeploymentID = deploymentID
 		deployment.MediaBytesRead = -1
 		deployment.MediaSize = 0
 	}, nil
 }
 
-func (s *serverService) resetDeploymentMediaProgress(ctx context.Context, imageID provisioning.SeedImageID) {
-	if s.seedImageProgress == nil || imageID.FingerprintID == "" {
-		return
+// cleanupDeploymentMedia drops the read progress recorded for the installation
+// media of this deployment and ejects it.
+func (s *serverService) cleanupDeploymentMedia(ctx context.Context, server provisioning.Server) error {
+	deployment := server.StatusInternal.Deployment
+
+	if s.seedImageProgress != nil && deployment.ImageDeploymentID != "" {
+		s.seedImageProgress.Reset(ctx, deployment.ImageDeploymentID)
 	}
 
-	s.seedImageProgress.Reset(ctx, imageID)
-}
-
-// cleanupDeploymentMedia drops the read progress recorded for the installation
-// media and ejects it.
-func (s *serverService) cleanupDeploymentMedia(ctx context.Context, server provisioning.Server) error {
-	s.resetDeploymentMediaProgress(ctx, server.StatusInternal.Deployment.SeedImageID())
-
-	return s.detachDeploymentMedia(ctx, server, server.StatusInternal.Deployment.Request.VirtualMediaID)
+	return s.detachDeploymentMedia(ctx, server, deployment.Request.VirtualMediaID)
 }
 
 // detachAllDeploymentMedia ejects the media of every virtual media device, that
@@ -1607,7 +1599,7 @@ func (s *serverService) checkDeploymentInstalled(ctx context.Context, log *slog.
 func (s *serverService) deploymentMediaProgress(ctx context.Context, server provisioning.Server) (provisioning.SeedImageProgress, bool) {
 	deployment := server.StatusInternal.Deployment
 
-	if s.seedImageProgress == nil || deployment.ImageFingerprintID == "" {
+	if s.seedImageProgress == nil || deployment.ImageDeploymentID == "" {
 		return provisioning.SeedImageProgress{}, false
 	}
 
@@ -1616,46 +1608,18 @@ func (s *serverService) deploymentMediaProgress(ctx context.Context, server prov
 		return provisioning.SeedImageProgress{}, false
 	}
 
-	source := server.BMCSource()
-
-	if source != "" {
-		progress, ok := s.seedImageProgress.Get(ctx, deployment.SeedImageID(), source)
-		if ok {
-			return progress, true
-		}
-	}
-
-	// A BMC does not necessarily read the installation media from the address,
-	// its Redfish API is reached at.
-	recorded := s.seedImageProgress.GetByImage(ctx, deployment.SeedImageID())
-	if len(recorded) == 1 {
+	progress, ok := s.seedImageProgress.Get(ctx, deployment.ImageDeploymentID)
+	if !ok {
 		slog.DebugContext(
-			ctx, "The BMC reads the installation media from another address than its Redfish API is reached at",
+			ctx, "The BMC has not read anything of the installation media yet",
 			slog.String("name", server.Name),
-			slog.String("image_id", deployment.SeedImageID().String()),
-			slog.String("bmc_source", source),
-			slog.String("media_source", recorded[0].Source),
+			slog.String("deployment_id", deployment.ImageDeploymentID),
 		)
 
-		return recorded[0], true
+		return provisioning.SeedImageProgress{}, false
 	}
 
-	if slog.Default().Enabled(ctx, slog.LevelDebug) {
-		sources := make([]string, 0, len(recorded))
-		for _, progress := range recorded {
-			sources = append(sources, fmt.Sprintf("%s=%d", progress.Source, progress.BytesCovered))
-		}
-
-		slog.DebugContext(
-			ctx, "No read progress of the installation media can be attributed to the server",
-			slog.String("name", server.Name),
-			slog.String("image_id", deployment.SeedImageID().String()),
-			slog.String("bmc_source", source),
-			slog.String("recorded_sources", strings.Join(sources, " ")),
-		)
-	}
-
-	return provisioning.SeedImageProgress{}, false
+	return progress, true
 }
 
 // deploymentInstallCouldBeDone reports, whether the first stage of the

--- a/internal/provisioning/server/server_deployment.go
+++ b/internal/provisioning/server/server_deployment.go
@@ -53,6 +53,12 @@ type deploymentStateDefinition struct {
 	// timeout, which bounds how long a wait may stay unsatisfied, it keeps an
 	// unresponsive BMC from parking the control loop.
 	callTimeout time.Duration
+
+	// prepare records, that the action of the state is about to run, and is
+	// persisted before it does. It belongs to a step, whose side effect can not
+	// be told apart from a no-op once it has been performed, so a re-issued
+	// attempt has to learn from the record instead of from the BMC.
+	prepare func(*provisioning.ServerDeployment)
 }
 
 func (d deploymentStateDefinition) callTimeoutOrDefault() time.Duration {
@@ -163,6 +169,9 @@ var deploymentStates = map[api.ServerDeploymentState]deploymentStateDefinition{
 		detail:      api.ServerStatusDetailDeployingConfiguringBIOS,
 		next:        api.ServerDeploymentStateClearMedia,
 		callTimeout: config.ServerDeploymentSecureBootCallTimeout,
+		prepare: func(deployment *provisioning.ServerDeployment) {
+			deployment.SecureBootAttempted = true
+		},
 	},
 	api.ServerDeploymentStateClearMedia: {
 		kind:   deploymentStateKindAction,
@@ -885,6 +894,16 @@ func (s *serverService) deploymentAction(ctx context.Context, log *slog.Logger, 
 		}
 	}
 
+	// Record, that the action is about to be performed, before it is, so a
+	// re-issued attempt knows about the side effect of the one before it, which
+	// the BMC does not report anymore.
+	if definition.prepare != nil {
+		err := s.updateDeployment(ctx, server.Name, definition.prepare)
+		if err != nil {
+			return false, err
+		}
+	}
+
 	log.InfoContext(ctx, "Deployment action triggered", slog.Int("retries", deployment.Retries))
 
 	mutate, err := s.runBoundedDeploymentAction(ctx, log, server, definition)
@@ -1005,13 +1024,15 @@ func (s *serverService) runDeploymentAction(ctx context.Context, log *slog.Logge
 		return s.verifyDeploymentBIOSAttributes(ctx, log, server)
 
 	case api.ServerDeploymentStateSecureBoot:
+		attempted := deployment.SecureBootAttempted
+
 		enrolled, err := s.applySecureBootCertificatesByName(ctx, server.Name, deployment.SecureBoot)
 		if err != nil {
 			return nil, err
 		}
 
 		return func(deployment *provisioning.ServerDeployment) {
-			deployment.SecureBootPending = enrolled
+			deployment.SecureBootPending = enrolled || attempted
 		}, nil
 
 	case api.ServerDeploymentStateClearMedia:

--- a/internal/provisioning/server/server_deployment.go
+++ b/internal/provisioning/server/server_deployment.go
@@ -569,14 +569,21 @@ func (s *serverService) DeployByName(ctx context.Context, name string, request p
 		}
 
 		if request.VirtualMediaID == "" {
-			request.VirtualMediaID, err = selectVirtualMediaID(server.BMCData)
+			request.VirtualMediaID, err = selectVirtualMediaID(server.BMCData, request.ImageType)
 			if err != nil {
 				return fmt.Errorf("Failed to select a virtual media device of server %q: %w", name, err)
 			}
 		} else {
-			_, ok := server.BMCData.VirtualMedia[request.VirtualMediaID]
+			media, ok := server.BMCData.VirtualMedia[request.VirtualMediaID]
 			if !ok {
 				return fmt.Errorf("Server %q has no virtual media device %q, the BMC reports %s: %w", name, request.VirtualMediaID, describeVirtualMedia(server.BMCData), domain.ErrOperationNotPermitted)
+			}
+
+			if !virtualMediaSupportsImageType(media, request.ImageType) {
+				return fmt.Errorf(
+					"Virtual media device %q of server %q does not accept a %q image, it supports %s: %w",
+					request.VirtualMediaID, name, request.ImageType, strings.Join(media.MediaTypes, ", "), domain.ErrOperationNotPermitted,
+				)
 			}
 		}
 
@@ -1866,15 +1873,43 @@ const (
 	virtualMediaTransferMethodUpload = string(schemas.UploadTransferMethod)
 )
 
-var virtualMediaOpticalTypes = []string{string(schemas.CDVirtualMediaType), string(schemas.DVDVirtualMediaType)}
+// virtualMediaTypesByImageType holds the virtual media types able to hold an
+// image of a given type. It mirrors, what the BMC adapter derives from the
+// extension of the media URL, so a device, that the attachment would reject, is
+// not picked in the first place.
+var virtualMediaTypesByImageType = map[api.ImageType][]string{
+	api.ImageTypeISO: {string(schemas.CDVirtualMediaType), string(schemas.DVDVirtualMediaType)},
+	api.ImageTypeRaw: {string(schemas.USBStickVirtualMediaType), string(schemas.FloppyVirtualMediaType)},
+}
 
 var virtualMediaServicePrecedence = []string{"system", "manager"}
 
+// virtualMediaAdvertisesImageType reports, whether a virtual media device says
+// itself, that it can hold an image of the given type.
+func virtualMediaAdvertisesImageType(media api.BMCVirtualMedia, imageType api.ImageType) bool {
+	wanted := virtualMediaTypesByImageType[imageType]
+
+	return slices.ContainsFunc(media.MediaTypes, func(mediaType string) bool {
+		return slices.Contains(wanted, mediaType)
+	})
+}
+
+// virtualMediaSupportsImageType reports, whether a virtual media device can hold
+// an image of the given type. A device, that advertises no media type at all,
+// leaves the decision to the BMC.
+func virtualMediaSupportsImageType(media api.BMCVirtualMedia, imageType api.ImageType) bool {
+	if len(media.MediaTypes) == 0 || len(virtualMediaTypesByImageType[imageType]) == 0 {
+		return true
+	}
+
+	return virtualMediaAdvertisesImageType(media, imageType)
+}
+
 // selectVirtualMediaID picks the virtual media device the installation media is
-// attached to, preferring a device advertising CD or DVD support and, among
-// equally suitable devices, one offered by the system over one offered by the
-// manager.
-func selectVirtualMediaID(data api.BMCData) (string, error) {
+// attached to, preferring a device advertising support for the requested image
+// type over one advertising nothing and, among equally suitable devices, one
+// offered by the system over one offered by the manager.
+func selectVirtualMediaID(data api.BMCData, imageType api.ImageType) (string, error) {
 	if len(data.VirtualMedia) == 0 {
 		return "", fmt.Errorf("The BMC reports no virtual media device: %w", domain.ErrNotFound)
 	}
@@ -1882,14 +1917,23 @@ func selectVirtualMediaID(data api.BMCData) (string, error) {
 	ids := virtualMediaIDsByPreference(data)
 
 	for _, id := range ids {
-		for _, mediaType := range data.VirtualMedia[id].MediaTypes {
-			if slices.Contains(virtualMediaOpticalTypes, mediaType) {
-				return id, nil
-			}
+		if virtualMediaAdvertisesImageType(data.VirtualMedia[id], imageType) {
+			return id, nil
 		}
 	}
 
-	return ids[0], nil
+	// Nothing advertises the media type the image needs, so fall back to a
+	// device, that does not say, what it takes.
+	for _, id := range ids {
+		if len(data.VirtualMedia[id].MediaTypes) == 0 {
+			return id, nil
+		}
+	}
+
+	return "", fmt.Errorf(
+		"No virtual media device of the BMC accepts a %q image, it reports %s: %w",
+		imageType, describeVirtualMediaTypes(data), domain.ErrOperationNotPermitted,
+	)
 }
 
 // virtualMediaIDsByPreference returns the IDs of all virtual media devices, the
@@ -1923,4 +1967,25 @@ func describeVirtualMedia(data api.BMCData) string {
 	}
 
 	return strings.Join(slices.Sorted(maps.Keys(data.VirtualMedia)), ", ")
+}
+
+// describeVirtualMediaTypes names every virtual media device along with the
+// media types it advertises, so an operator can tell, which device to ask for.
+func describeVirtualMediaTypes(data api.BMCData) string {
+	if len(data.VirtualMedia) == 0 {
+		return "no virtual media device"
+	}
+
+	descriptions := make([]string, 0, len(data.VirtualMedia))
+
+	for _, id := range slices.Sorted(maps.Keys(data.VirtualMedia)) {
+		mediaTypes := "no media type"
+		if len(data.VirtualMedia[id].MediaTypes) > 0 {
+			mediaTypes = strings.Join(data.VirtualMedia[id].MediaTypes, ", ")
+		}
+
+		descriptions = append(descriptions, fmt.Sprintf("%s (%s)", id, mediaTypes))
+	}
+
+	return strings.Join(descriptions, ", ")
 }

--- a/internal/provisioning/server/server_deployment_concurrency_test.go
+++ b/internal/provisioning/server/server_deployment_concurrency_test.go
@@ -14,7 +14,6 @@ import (
 	adapterMock "github.com/FuturFusion/operations-center/internal/provisioning/adapter/mock"
 	repoMock "github.com/FuturFusion/operations-center/internal/provisioning/repo/mock"
 	provisioningServer "github.com/FuturFusion/operations-center/internal/provisioning/server"
-	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/shared/api"
 )
@@ -96,18 +95,8 @@ func deploymentBlockedTestRepo(store *deploymentServerStore) *repoMock.ServerRep
 		GetByNameFunc: func(ctx context.Context, name string) (*provisioning.Server, error) {
 			return store.get(name)
 		},
-		GetAllWithFilterFunc: func(ctx context.Context, filter provisioning.ServerFilter) (provisioning.Servers, error) {
-			var matching provisioning.Servers
-
-			for _, server := range store.all() {
-				if ptr.From(filter.Status) != server.Status {
-					continue
-				}
-
-				matching = append(matching, server)
-			}
-
-			return matching, nil
+		GetAllNamesWithActiveDeploymentFunc: func(ctx context.Context) ([]string, error) {
+			return store.namesWithActiveDeployment(), nil
 		},
 		UpdateFunc: func(ctx context.Context, in provisioning.Server) error {
 			store.put(in)

--- a/internal/provisioning/server/server_deployment_control_loop_test.go
+++ b/internal/provisioning/server/server_deployment_control_loop_test.go
@@ -348,7 +348,10 @@ func TestServerService_DeploymentControlLoopDrivesDeploymentToATerminalState(t *
 			resolution:  deploymentTestResolution(),
 			trackMedia:  true,
 			worldOptions: []func(*bmcWorld){
-				func(w *bmcWorld) { w.installDuration = config.ServerDeploymentMinInstallDuration / 2 },
+				func(w *bmcWorld) {
+					w.installDuration = config.ServerDeploymentMinInstallDuration / 2
+					w.bootsMediaAgain = true
+				},
 			},
 
 			wantStates:       deploymentStatesHappyPath(),
@@ -362,11 +365,25 @@ func TestServerService_DeploymentControlLoopDrivesDeploymentToATerminalState(t *
 			},
 		},
 		{
+			name:        "success - the BMC caches the installation media instead of streaming it",
+			forceReboot: true,
+			resolution:  deploymentTestResolution(),
+			trackMedia:  true,
+			worldOptions: []func(*bmcWorld){
+				func(w *bmcWorld) { w.cachesMedia = true },
+			},
+
+			wantStates:       deploymentStatesHappyPath(),
+			wantStatus:       api.ServerStatusPending,
+			wantStatusDetail: api.ServerStatusDetailPendingRegistering,
+			assertLog:        log.NotContains("Installation completed, the installation media has been read and is idle"),
+		},
+		{
 			name:        "success - the firmware reboots before the installer even started",
 			forceReboot: true,
 			resolution:  deploymentTestResolution(),
 			worldOptions: []func(*bmcWorld){
-				func(w *bmcWorld) { w.rebootsEarly = true },
+				func(w *bmcWorld) { w.rebootsEarly = true; w.postDuration = worldEarlyRebootDelay + worldBootDuration },
 			},
 
 			wantStates:       deploymentStatesHappyPath(),

--- a/internal/provisioning/server/server_deployment_control_loop_test.go
+++ b/internal/provisioning/server/server_deployment_control_loop_test.go
@@ -212,7 +212,15 @@ func TestServerService_DeploymentControlLoopDrivesDeploymentToATerminalState(t *
 			assertWorld: func(t *testing.T, world *bmcWorld) {
 				t.Helper()
 
-				require.Equal(t, 2, world.mediaResets, "the read progress is dropped when the media is attached and again when it is cleaned up")
+				require.Equal(t, 2, world.mediaResets, "the read progress is dropped when the media is attached and again when the deployment is cleaned up")
+
+				// A server, that does not reboot on its own, is installed and
+				// waiting for the media to go, so the idle period is the whole
+				// latency of the only signal telling the deployment about it.
+				require.LessOrEqual(
+					t, world.mediaEjectedAfter(), deploymentMaxMediaEjectDelay,
+					"the media is ejected right after the installer stopped reading it",
+				)
 			},
 		},
 		{
@@ -229,7 +237,7 @@ func TestServerService_DeploymentControlLoopDrivesDeploymentToATerminalState(t *
 			wantStates:       deploymentStatesHappyPath(),
 			wantStatus:       api.ServerStatusPending,
 			wantStatusDetail: api.ServerStatusDetailPendingRegistering,
-			assertLog:        log.Contains("The BMC reads the installation media from another address"),
+			assertLog:        log.Contains("Installation completed, the installation media has been read and is idle"),
 		},
 		{
 			name:        "success - the BMC uploads the installation media instead of streaming it",

--- a/internal/provisioning/server/server_deployment_control_loop_test.go
+++ b/internal/provisioning/server/server_deployment_control_loop_test.go
@@ -760,6 +760,95 @@ func TestServerService_DeploymentControlLoopSurvivesAServiceRestart(t *testing.T
 	require.Equal(t, api.ServerStatusPending, server.Status)
 }
 
+// TestServerService_DeploymentControlLoopKeepsTheSecureBootSettleBootAcrossARetry
+// drives the deployment through the enrollment of the secure boot certificates
+// and then rewinds it into the enrollment, the way a crash between the write and
+// the transition, that records it, leaves the deployment behind. The BMC reports
+// the key databases as applied by then, so the re-issued enrollment writes
+// nothing, while the firmware still has the certificates to pick up: the settle
+// boot has to run regardless.
+func TestServerService_DeploymentControlLoopKeepsTheSecureBootSettleBootAcrossARetry(t *testing.T) {
+	ctx := t.Context()
+
+	w := setupDeploymentWorld(t, ctx, deploymentWorldConfig{
+		forceReboot: true,
+		resolution:  deploymentTestResolution(),
+	})
+
+	err := w.service.DeployByName(ctx, worldServerName, deploymentTestRequest(w.tokenUUID))
+	require.NoError(t, err)
+
+	for range deploymentDriveIterations {
+		if w.world.callCount("ApplySecureBootCertificates") > 0 {
+			break
+		}
+
+		server, err := w.repo.GetByName(ctx, worldServerName)
+		require.NoError(t, err)
+
+		before := server.StatusInternal.Deployment.State
+
+		require.NoError(t, w.world.settle(ctx))
+		require.NoError(t, w.service.DeploymentControlLoop(ctx, nil))
+
+		after, err := w.repo.GetByName(ctx, worldServerName)
+		require.NoError(t, err)
+
+		advance := deploymentTick
+		if after.StatusInternal.Deployment.State == before {
+			advance = deploymentIdleTick
+		}
+
+		w.clock.advance(advance)
+	}
+
+	require.Equal(t, 1, w.world.callCount("ApplySecureBootCertificates"), "the enrollment has run once")
+
+	crashed, err := w.repo.GetByName(ctx, worldServerName)
+	require.NoError(t, err)
+
+	deployment := crashed.StatusInternal.Deployment
+	require.True(t, deployment.SecureBootAttempted, "the attempt is recorded before the enrollment writes anything")
+
+	// Everything the enrollment produced is gone, only what was persisted before
+	// it ran is left, and the deployment is back in the trigger state.
+	deployment.State = api.ServerDeploymentStateSecureBoot
+	deployment.SecureBootPending = false
+
+	require.NoError(t, w.repo.Update(ctx, *crashed))
+
+	// The key databases hold the certificates now, so the enrollment leaves them
+	// untouched and reports, that it wrote nothing.
+	w.world.mu.Lock()
+	w.world.secureBootEnrolls = false
+	w.world.mu.Unlock()
+
+	server := driveDeployment(t, ctx, w, false)
+
+	require.Equal(t, 2, w.world.callCount("ApplySecureBootCertificates"), "the enrollment is re-issued")
+
+	states := deploymentStateSequence(server)
+
+	retried := slices.Index(states, api.ServerDeploymentStateSecureBoot)
+	require.NotEqual(t, -1, retried)
+
+	retried = slices.Index(states[retried+1:], api.ServerDeploymentStateSecureBoot) + retried + 1
+
+	require.Equal(
+		t,
+		slices.Concat(
+			deploymentStatesMediaCleared,
+			deploymentStatesSecureBootSettle,
+			deploymentStatesInstall,
+			deploymentStatesFinalize,
+		),
+		states[retried+1:],
+		"the re-issued enrollment keeps the settle boot, since an earlier attempt may have written the key databases",
+	)
+
+	require.Equal(t, api.ServerStatusPending, server.Status)
+}
+
 // TestServerService_DeploymentControlLoopLeavesAFailedDeploymentAlone asserts,
 // that a failed deployment is not cleaned up, so an operator can look at the
 // server the way the deployment left it.

--- a/internal/provisioning/server/server_deployment_control_loop_test.go
+++ b/internal/provisioning/server/server_deployment_control_loop_test.go
@@ -601,6 +601,38 @@ func TestServerService_DeploymentControlLoopDrivesDeploymentToATerminalState(t *
 				require.False(t, world.isPoweredOn(), "a cancelled deployment leaves the server powered off")
 			},
 		},
+		{
+			name:        "cancelled - the BMC completes the ejection after the power off",
+			forceReboot: true,
+			resolution:  deploymentTestResolution(),
+			cancelAt:    api.ServerDeploymentStateWaitInstall,
+			worldOptions: []func(*bmcWorld){
+				func(w *bmcWorld) { w.ejectDelay = worldEjectDelay },
+			},
+
+			wantStates: slices.Concat(
+				deploymentStatesPreparing,
+				deploymentStatesBIOSPass,
+				deploymentStatesBIOSDeferredPass,
+				deploymentStatesSecureBootOff,
+				deploymentStatesSecureBoot,
+				deploymentStatesMediaCleared,
+				deploymentStatesSecureBootSettle,
+				deploymentStatesInstall,
+				deploymentStatesCancel,
+			),
+			wantStatus:       api.ServerStatusUnregistered,
+			wantStatusDetail: api.ServerStatusDetailUnregisteredDeploymentCancelled,
+			assertWorld: func(t *testing.T, world *bmcWorld) {
+				t.Helper()
+
+				require.Empty(
+					t, world.mediaInserted(),
+					"a cancelled deployment waits for the ejection it issued, instead of completing on the power state alone",
+				)
+				require.False(t, world.isPoweredOn(), "a cancelled deployment leaves the server powered off")
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/provisioning/server/server_deployment_control_loop_test.go
+++ b/internal/provisioning/server/server_deployment_control_loop_test.go
@@ -245,6 +245,38 @@ func TestServerService_DeploymentControlLoopDrivesDeploymentToATerminalState(t *
 			wantStatusDetail: api.ServerStatusDetailPendingRegistering,
 		},
 		{
+			name:       "failed - the BMC uploads the installation media, while only its read progress could tell",
+			resolution: deploymentTestResolution(),
+			trackMedia: true,
+			worldOptions: []func(*bmcWorld){
+				func(w *bmcWorld) { w.uploadTransfer = true },
+			},
+			request: func(request *provisioning.ServerDeploymentRequest) {
+				request.Force = true
+			},
+
+			wantStates: slices.Concat(
+				deploymentStatesPreparing,
+				deploymentStatesBIOSPass,
+				deploymentStatesBIOSDeferredPass,
+				deploymentStatesSecureBootOff,
+				deploymentStatesSecureBoot,
+				deploymentStatesMediaCleared,
+				deploymentStatesSecureBootSettle,
+				deploymentStatesInstall[:2],
+				[]api.ServerDeploymentState{api.ServerDeploymentStateFailed},
+			),
+			wantStatus:       api.ServerStatusUnregistered,
+			wantStatusDetail: api.ServerStatusDetailUnregisteredDeploymentFailed,
+			wantFailedState:  api.ServerDeploymentStateWaitMediaAttached,
+			wantLastError:    "uploads the installation media instead of streaming it",
+			assertWorld: func(t *testing.T, world *bmcWorld) {
+				t.Helper()
+
+				require.Equal(t, []string{"system:1"}, world.mediaInserted(), "the failed deployment leaves the installation media attached, the way every failure does")
+			},
+		},
+		{
 			name:        "success - the BMC reports no boot progress",
 			forceReboot: true,
 			resolution:  deploymentTestResolution(),

--- a/internal/provisioning/server/server_deployment_internal_test.go
+++ b/internal/provisioning/server/server_deployment_internal_test.go
@@ -791,20 +791,31 @@ func Test_bmcWaitConditions(t *testing.T) {
 
 func Test_selectVirtualMediaID(t *testing.T) {
 	tests := []struct {
-		name string
-		data api.BMCData
+		name      string
+		data      api.BMCData
+		imageType api.ImageType
 
 		want      string
 		assertErr require.ErrorAssertionFunc
 	}{
 		{
-			name: "the only device",
+			name: "the only device takes the image",
 			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
 				"manager:1": {ID: "manager:1", MediaTypes: []string{"USBStick"}},
 			}},
+			imageType: api.ImageTypeRaw,
 
 			want:      "manager:1",
 			assertErr: require.NoError,
+		},
+		{
+			name: "the only device does not take the image",
+			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
+				"manager:1": {ID: "manager:1", MediaTypes: []string{"USBStick"}},
+			}},
+			imageType: api.ImageTypeISO,
+
+			assertErr: errassert.OperationNotPermittedErrorContains(`manager:1 (USBStick)`),
 		},
 		{
 			name: "the only optical device",
@@ -812,13 +823,26 @@ func Test_selectVirtualMediaID(t *testing.T) {
 				"manager:1": {ID: "manager:1", MediaTypes: []string{"USBStick"}},
 				"system:1":  {ID: "system:1", MediaTypes: []string{"CD", "DVD"}},
 			}},
+			imageType: api.ImageTypeISO,
 
 			want:      "system:1",
 			assertErr: require.NoError,
 		},
 		{
-			name: "no device at all",
-			data: api.BMCData{},
+			name: "the same devices, but a raw image needs the USB one",
+			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
+				"manager:1": {ID: "manager:1", MediaTypes: []string{"USBStick"}},
+				"system:1":  {ID: "system:1", MediaTypes: []string{"CD", "DVD"}},
+			}},
+			imageType: api.ImageTypeRaw,
+
+			want:      "manager:1",
+			assertErr: require.NoError,
+		},
+		{
+			name:      "no device at all",
+			data:      api.BMCData{},
+			imageType: api.ImageTypeISO,
 
 			assertErr: errassert.NotFoundError,
 		},
@@ -828,18 +852,20 @@ func Test_selectVirtualMediaID(t *testing.T) {
 				"system:1": {ID: "system:1", MediaTypes: []string{"CD"}},
 				"system:2": {ID: "system:2", MediaTypes: []string{"DVD"}},
 			}},
+			imageType: api.ImageTypeISO,
 
 			want:      "system:1",
 			assertErr: require.NoError,
 		},
 		{
-			name: "several devices, none of them optical",
+			name: "the device saying nothing wins over the one saying it does not take the image",
 			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
 				"manager:1": {ID: "manager:1", MediaTypes: []string{"USBStick"}},
 				"manager:2": {ID: "manager:2"},
 			}},
+			imageType: api.ImageTypeISO,
 
-			want:      "manager:1",
+			want:      "manager:2",
 			assertErr: require.NoError,
 		},
 		{
@@ -848,6 +874,7 @@ func Test_selectVirtualMediaID(t *testing.T) {
 				"manager:1": {ID: "manager:1", MediaTypes: []string{"CD", "DVD"}},
 				"system:2":  {ID: "system:2", MediaTypes: []string{"CD", "DVD"}},
 			}},
+			imageType: api.ImageTypeISO,
 
 			want:      "system:2",
 			assertErr: require.NoError,
@@ -858,25 +885,38 @@ func Test_selectVirtualMediaID(t *testing.T) {
 				"manager:1": {ID: "manager:1", MediaTypes: []string{"CD", "DVD"}},
 				"system:1":  {ID: "system:1", MediaTypes: []string{"USBStick"}},
 			}},
+			imageType: api.ImageTypeISO,
 
 			want:      "manager:1",
 			assertErr: require.NoError,
 		},
 		{
-			name: "no optical device at all, the one of the system wins",
+			name: "no device advertises anything, the one of the system wins",
+			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
+				"manager:1": {ID: "manager:1"},
+				"system:1":  {ID: "system:1"},
+			}},
+			imageType: api.ImageTypeISO,
+
+			want:      "system:1",
+			assertErr: require.NoError,
+		},
+		{
+			name: "a device advertising the media type wins over one advertising nothing",
 			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
 				"manager:1": {ID: "manager:1", MediaTypes: []string{"USBStick"}},
 				"system:1":  {ID: "system:1"},
 			}},
+			imageType: api.ImageTypeRaw,
 
-			want:      "system:1",
+			want:      "manager:1",
 			assertErr: require.NoError,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := selectVirtualMediaID(tc.data)
+			got, err := selectVirtualMediaID(tc.data, tc.imageType)
 
 			tc.assertErr(t, err)
 			require.Equal(t, tc.want, got)

--- a/internal/provisioning/server/server_deployment_internal_test.go
+++ b/internal/provisioning/server/server_deployment_internal_test.go
@@ -735,24 +735,6 @@ func Test_bmcWaitConditions(t *testing.T) {
 			want: false,
 		},
 		{
-			name:  "the media holds the image",
-			state: api.ServerDeploymentStateWaitMediaAttached,
-			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
-				"system:1": {ID: "system:1", Inserted: true, Image: "https://oc.example.com:8443/one.iso"},
-			}},
-
-			want: true,
-		},
-		{
-			name:  "the media holds another image",
-			state: api.ServerDeploymentStateWaitMediaAttached,
-			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
-				"system:1": {ID: "system:1", Inserted: true, Image: "https://oc.example.com:8443/other.iso"},
-			}},
-
-			want: false,
-		},
-		{
 			name:  "the media is ejected",
 			state: api.ServerDeploymentStateWaitMediaDetached,
 			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
@@ -789,11 +771,63 @@ func Test_bmcWaitConditions(t *testing.T) {
 	}
 }
 
+func Test_deploymentMediaHoldsImage(t *testing.T) {
+	deployment := provisioning.ServerDeployment{
+		Request:  provisioning.ServerDeploymentRequest{VirtualMediaID: "system:1"},
+		MediaURL: "https://oc.example.com:8443/one.iso",
+	}
+
+	tests := []struct {
+		name string
+		data api.BMCData
+
+		want bool
+	}{
+		{
+			name: "the media holds the image",
+			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
+				"system:1": {ID: "system:1", Inserted: true, Image: "https://oc.example.com:8443/one.iso"},
+			}},
+
+			want: true,
+		},
+		{
+			name: "the media holds another image",
+			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
+				"system:1": {ID: "system:1", Inserted: true, Image: "https://oc.example.com:8443/other.iso"},
+			}},
+
+			want: false,
+		},
+		{
+			name: "nothing is inserted",
+			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
+				"system:1": {ID: "system:1"},
+			}},
+
+			want: false,
+		},
+		{
+			name: "the media device is gone",
+			data: api.BMCData{},
+
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, deploymentMediaHoldsImage(&deployment, tc.data))
+		})
+	}
+}
+
 func Test_selectVirtualMediaID(t *testing.T) {
 	tests := []struct {
-		name      string
-		data      api.BMCData
-		imageType api.ImageType
+		name             string
+		data             api.BMCData
+		imageType        api.ImageType
+		requireStreaming bool
 
 		want      string
 		assertErr require.ErrorAssertionFunc
@@ -912,11 +946,46 @@ func Test_selectVirtualMediaID(t *testing.T) {
 			want:      "manager:1",
 			assertErr: require.NoError,
 		},
+		{
+			name: "a streaming device wins over an uploading one, when the read progress is needed",
+			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
+				"manager:1": {ID: "manager:1", MediaTypes: []string{"CD", "DVD"}},
+				"system:1":  {ID: "system:1", MediaTypes: []string{"CD", "DVD"}, TransferMethod: "Upload"},
+			}},
+			imageType:        api.ImageTypeISO,
+			requireStreaming: true,
+
+			want:      "manager:1",
+			assertErr: require.NoError,
+		},
+		{
+			name: "the uploading device of the system is preferred, when the read progress is not needed",
+			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
+				"manager:1": {ID: "manager:1", MediaTypes: []string{"CD", "DVD"}},
+				"system:1":  {ID: "system:1", MediaTypes: []string{"CD", "DVD"}, TransferMethod: "Upload"},
+			}},
+			imageType: api.ImageTypeISO,
+
+			want:      "system:1",
+			assertErr: require.NoError,
+		},
+		{
+			name: "an uploading device is picked, when it is the only one taking the image",
+			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{
+				"manager:1": {ID: "manager:1", MediaTypes: []string{"USBStick"}},
+				"system:1":  {ID: "system:1", MediaTypes: []string{"CD", "DVD"}, TransferMethod: "Upload"},
+			}},
+			imageType:        api.ImageTypeISO,
+			requireStreaming: true,
+
+			want:      "system:1",
+			assertErr: require.NoError,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := selectVirtualMediaID(tc.data, tc.imageType)
+			got, err := selectVirtualMediaID(tc.data, tc.imageType, tc.requireStreaming)
 
 			tc.assertErr(t, err)
 			require.Equal(t, tc.want, got)
@@ -973,6 +1042,20 @@ func Test_deploymentRetryFromError(t *testing.T) {
 
 	_, ok = errors.AsType[deploymentRetryFromError](boom.Error)
 	require.False(t, ok, "a plain error carries no state to go back to")
+}
+
+func Test_deploymentFatalError(t *testing.T) {
+	err := error(deploymentFatalError{err: boom.Error})
+
+	require.Equal(t, boom.Error.Error(), err.Error(), "the sentinel reports the message of the error it carries")
+	require.ErrorIs(t, err, boom.Error, "the wrapped error stays inspectable")
+	require.False(t, domain.IsRetryableError(err), "a fatal error is never retried")
+
+	_, ok := errors.AsType[deploymentFatalError](fmt.Errorf("wrapped: %w", err))
+	require.True(t, ok, "the sentinel is found through another wrapping")
+
+	_, ok = errors.AsType[deploymentFatalError](boom.Error)
+	require.False(t, ok, "a plain error does not end the deployment")
 }
 
 // Test_deploymentStates asserts the invariants of the deployment state machine,

--- a/internal/provisioning/server/server_deployment_internal_test.go
+++ b/internal/provisioning/server/server_deployment_internal_test.go
@@ -693,6 +693,30 @@ func Test_bmcWaitConditions(t *testing.T) {
 			want: false,
 		},
 		{
+			name:  "the cancellation has powered the server off and ejected the media",
+			state: api.ServerDeploymentStateWaitCancel,
+			data: api.BMCData{
+				ServerPowerState: bmcPowerStateOff,
+				VirtualMedia: map[string]api.BMCVirtualMedia{
+					"system:1": {ID: "system:1"},
+				},
+			},
+
+			want: true,
+		},
+		{
+			name:  "the cancellation has powered the server off, but the media is still inserted",
+			state: api.ServerDeploymentStateWaitCancel,
+			data: api.BMCData{
+				ServerPowerState: bmcPowerStateOff,
+				VirtualMedia: map[string]api.BMCVirtualMedia{
+					"system:1": {ID: "system:1", Inserted: true, Image: "https://oc.example.com:8443/one.iso"},
+				},
+			},
+
+			want: false,
+		},
+		{
 			name:  "no media is inserted",
 			state: api.ServerDeploymentStateWaitMediaCleared,
 			data: api.BMCData{VirtualMedia: map[string]api.BMCVirtualMedia{

--- a/internal/provisioning/server/server_deployment_internal_test.go
+++ b/internal/provisioning/server/server_deployment_internal_test.go
@@ -200,68 +200,51 @@ func Test_deploymentStates_callTimeoutIsAlwaysPositive(t *testing.T) {
 	}
 }
 
-func Test_deploymentInstallRebootEndsTheWait(t *testing.T) {
-	readOut := provisioning.SeedImageProgress{
-		Size:         4 * config.ServerDeploymentMediaMinBytesRead,
-		BytesCovered: config.ServerDeploymentMediaMinBytesRead,
-	}
-
-	barelyRead := provisioning.SeedImageProgress{
-		Size:         4 * config.ServerDeploymentMediaMinBytesRead,
-		BytesCovered: config.ServerDeploymentMediaMinBytesRead - 1,
-	}
+func Test_deploymentInstallOSObserved(t *testing.T) {
+	anchored := deploymentTestNow
 
 	tests := []struct {
-		name          string
-		installingFor time.Duration
-		progress      provisioning.SeedImageProgress
-		progressKnown bool
+		name     string
+		snapshot provisioning.ServerDeploymentBMCSnapshot
+		current  api.BMCData
 
 		want bool
 	}{
 		{
-			name:          "media read out before the installation could be done",
-			installingFor: time.Minute,
-			progress:      readOut,
-			progressKnown: true,
-
-			want: true,
-		},
-		{
-			name:          "media barely read before the installation could be done",
-			installingFor: time.Minute,
-			progress:      barelyRead,
-			progressKnown: true,
+			name:     "the BMC reports no boot progress",
+			snapshot: provisioning.ServerDeploymentBMCSnapshot{Taken: anchored},
+			current:  api.BMCData{},
 
 			want: false,
 		},
 		{
-			name:          "read progress can not be told before the installation could be done",
-			installingFor: time.Minute,
-			progress:      readOut,
-			progressKnown: false,
+			name:     "the firmware is still running the power on self test",
+			snapshot: provisioning.ServerDeploymentBMCSnapshot{Taken: anchored},
+			current:  api.BMCData{ServerBootProgress: api.BMCBootProgress{LastState: "MemoryInitializationStarted", LastStateTime: anchored.Add(time.Minute)}},
 
 			want: false,
 		},
 		{
-			name:          "read progress can not be told once the installation could be done",
-			installingFor: config.ServerDeploymentMinInstallDuration,
-			progress:      provisioning.SeedImageProgress{},
-			progressKnown: false,
+			name:     "the installer is running",
+			snapshot: provisioning.ServerDeploymentBMCSnapshot{Taken: anchored},
+			current:  api.BMCData{ServerBootProgress: api.BMCBootProgress{LastState: "OSRunning", LastStateTime: anchored.Add(time.Minute)}},
 
 			want: true,
+		},
+		{
+			name:     "a BMC, that kept the state of the boot before the install wait",
+			snapshot: provisioning.ServerDeploymentBMCSnapshot{Taken: anchored},
+			current:  api.BMCData{ServerBootProgress: api.BMCBootProgress{LastState: "OSRunning", LastStateTime: anchored.Add(-time.Hour)}},
+
+			want: false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			deployment := &provisioning.ServerDeployment{
-				StateEnteredAt: deploymentTestNow,
-			}
+			deployment := &provisioning.ServerDeployment{InstallSnapshot: tc.snapshot}
 
-			got := deploymentInstallRebootEndsTheWait(deploymentTestNow.Add(tc.installingFor), deployment, tc.progress, tc.progressKnown)
-
-			require.Equal(t, tc.want, got)
+			require.Equal(t, tc.want, deploymentInstallOSObserved(deployment, tc.current), "only a boot, that ran the installer, may let a reboot end the install wait")
 		})
 	}
 }

--- a/internal/provisioning/server/server_deployment_internal_test.go
+++ b/internal/provisioning/server/server_deployment_internal_test.go
@@ -943,6 +943,10 @@ func Test_deploymentStates(t *testing.T) {
 			var unmarshalled api.ServerDeploymentState
 			require.NoError(t, unmarshalled.UnmarshalText([]byte(state)), "state %q is not a known deployment state", state)
 
+			if definition.kind != deploymentStateKindAction {
+				require.Nil(t, definition.prepare, "state %q is not an action, but prepares one", state)
+			}
+
 			if definition.kind == deploymentStateKindTerminal {
 				require.True(t, state.IsTerminal(), "terminal state %q does not report itself as terminal", state)
 				require.Empty(t, definition.next, "terminal state %q leads somewhere", state)
@@ -974,6 +978,21 @@ func Test_deploymentStates(t *testing.T) {
 			require.Equal(t, deploymentStateKindAction, deploymentStates[definition.fallback].kind, "wait state %q falls back to %q, which is not an action", state, definition.fallback)
 		})
 	}
+}
+
+// Test_deploymentStatesSecureBootRecordsItsAttempt asserts, that the enrollment
+// of the secure boot certificates records, that it is about to run. The record
+// is what tells a re-issued enrollment, that an earlier attempt may have written
+// the key databases already, which the BMC does not report anymore.
+func Test_deploymentStatesSecureBootRecordsItsAttempt(t *testing.T) {
+	prepare := deploymentStates[api.ServerDeploymentStateSecureBoot].prepare
+	require.NotNil(t, prepare, "the enrollment does not record its attempt")
+
+	var deployment provisioning.ServerDeployment
+
+	prepare(&deployment)
+
+	require.True(t, deployment.SecureBootAttempted)
 }
 
 func Test_deploymentStatesAreAllReachable(t *testing.T) {

--- a/internal/provisioning/server/server_deployment_test.go
+++ b/internal/provisioning/server/server_deployment_test.go
@@ -132,9 +132,10 @@ func deploymentTestBMCData(virtualMedia ...api.BMCVirtualMedia) api.BMCData {
 }
 
 var (
-	deploymentTestOpticalMedia = api.BMCVirtualMedia{ID: "system:1", MediaTypes: []string{"CD", "DVD"}}
-	deploymentTestUSBMedia     = api.BMCVirtualMedia{ID: "manager:1", MediaTypes: []string{"USBStick"}}
-	deploymentTestUntypedMedia = api.BMCVirtualMedia{ID: "manager:2"}
+	deploymentTestOpticalMedia   = api.BMCVirtualMedia{ID: "system:1", MediaTypes: []string{"CD", "DVD"}}
+	deploymentTestUSBMedia       = api.BMCVirtualMedia{ID: "manager:1", MediaTypes: []string{"USBStick"}}
+	deploymentTestUntypedMedia   = api.BMCVirtualMedia{ID: "manager:2"}
+	deploymentTestUploadingMedia = api.BMCVirtualMedia{ID: "system:1", MediaTypes: []string{"CD", "DVD"}, TransferMethod: "Upload"}
 )
 
 func TestServerService_DeployByName(t *testing.T) {
@@ -416,6 +417,82 @@ func TestServerService_DeployByName(t *testing.T) {
 					VirtualMediaID: "system:1",
 					Force:          true,
 				},
+				MediaBytesRead: -1,
+				StartedAt:      deploymentTestDate,
+				StateEnteredAt: deploymentTestDate,
+				History:        []api.ServerDeploymentStep{},
+			},
+			wantStatus: api.ServerStatusDeploying,
+			assertErr:  require.NoError,
+		},
+		{
+			name:                    "success - a seed without force reboot picks the streaming device",
+			nameArg:                 "one",
+			requestArg:              provisioning.ServerDeploymentRequest{TokenUUID: tokenUUID, Seed: "default", ImageType: api.ImageTypeISO, Architecture: images.UpdateFileArchitecture64BitX86, Force: true},
+			operationsCenterAddress: deploymentTestOperationsCenterAddress,
+			server:                  new(deploymentTestServer("one")),
+			bmcGetData: deploymentTestBMCData(
+				deploymentTestUploadingMedia,
+				api.BMCVirtualMedia{ID: "manager:1", MediaTypes: []string{"CD", "DVD"}},
+			),
+			tokenSvcGetByUUID:   validToken,
+			tokenSvcGetSeed:     &provisioning.TokenSeed{Token: tokenUUID, Name: "default", Public: true},
+			withBIOSProfilePort: true,
+			biosProfileResolve:  &provisioning.BIOSProfileResolution{},
+
+			wantDeployment: &provisioning.ServerDeployment{
+				State: api.ServerDeploymentStateRefreshBMCData,
+				Request: provisioning.ServerDeploymentRequest{
+					TokenUUID:      tokenUUID,
+					Seed:           "default",
+					ImageType:      api.ImageTypeISO,
+					Architecture:   images.UpdateFileArchitecture64BitX86,
+					VirtualMediaID: "manager:1",
+					Force:          true,
+				},
+				MediaBytesRead: -1,
+				StartedAt:      deploymentTestDate,
+				StateEnteredAt: deploymentTestDate,
+				History:        []api.ServerDeploymentStep{},
+			},
+			wantStatus: api.ServerStatusDeploying,
+			assertErr:  require.NoError,
+		},
+		{
+			name:                    "error - a seed without force reboot on a device, that uploads the media",
+			nameArg:                 "one",
+			requestArg:              provisioning.ServerDeploymentRequest{TokenUUID: tokenUUID, Seed: "default", ImageType: api.ImageTypeISO, Architecture: images.UpdateFileArchitecture64BitX86, Force: true},
+			operationsCenterAddress: deploymentTestOperationsCenterAddress,
+			server:                  new(deploymentTestServer("one")),
+			bmcGetData:              deploymentTestBMCData(deploymentTestUploadingMedia),
+			tokenSvcGetByUUID:       validToken,
+			tokenSvcGetSeed:         &provisioning.TokenSeed{Token: tokenUUID, Name: "default", Public: true},
+
+			wantStatus: api.ServerStatusUnregistered,
+			assertErr:  errassert.OperationNotPermittedErrorContains("uploads the installation media instead of streaming it"),
+		},
+		{
+			name:                    "success - a seed with force reboot takes the device, that uploads the media",
+			nameArg:                 "one",
+			requestArg:              validRequest,
+			operationsCenterAddress: deploymentTestOperationsCenterAddress,
+			server:                  new(deploymentTestServer("one")),
+			bmcGetData:              deploymentTestBMCData(deploymentTestUploadingMedia),
+			tokenSvcGetByUUID:       validToken,
+			tokenSvcGetSeed:         validSeed,
+			withBIOSProfilePort:     true,
+			biosProfileResolve:      &provisioning.BIOSProfileResolution{},
+
+			wantDeployment: &provisioning.ServerDeployment{
+				State: api.ServerDeploymentStateRefreshBMCData,
+				Request: provisioning.ServerDeploymentRequest{
+					TokenUUID:      tokenUUID,
+					Seed:           "default",
+					ImageType:      api.ImageTypeISO,
+					Architecture:   images.UpdateFileArchitecture64BitX86,
+					VirtualMediaID: "system:1",
+				},
+				ForceReboot:    true,
 				MediaBytesRead: -1,
 				StartedAt:      deploymentTestDate,
 				StateEnteredAt: deploymentTestDate,

--- a/internal/provisioning/server/server_deployment_test.go
+++ b/internal/provisioning/server/server_deployment_test.go
@@ -22,7 +22,6 @@ import (
 	svcMock "github.com/FuturFusion/operations-center/internal/provisioning/mock"
 	repoMock "github.com/FuturFusion/operations-center/internal/provisioning/repo/mock"
 	provisioningServer "github.com/FuturFusion/operations-center/internal/provisioning/server"
-	"github.com/FuturFusion/operations-center/internal/util/ptr"
 	"github.com/FuturFusion/operations-center/internal/util/testing/boom"
 	"github.com/FuturFusion/operations-center/internal/util/testing/errassert"
 	"github.com/FuturFusion/operations-center/internal/util/testing/queue"
@@ -91,16 +90,21 @@ func (s *deploymentServerStore) put(server provisioning.Server) {
 	s.servers[server.Name] = cloneDeploymentServer(server)
 }
 
-func (s *deploymentServerStore) all() provisioning.Servers {
+func (s *deploymentServerStore) namesWithActiveDeployment() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	servers := make(provisioning.Servers, 0, len(s.servers))
+	var names []string
+
 	for _, name := range slices.Sorted(maps.Keys(s.servers)) {
-		servers = append(servers, cloneDeploymentServer(s.servers[name]))
+		if !s.servers[name].StatusInternal.Deployment.IsActive() {
+			continue
+		}
+
+		names = append(names, name)
 	}
 
-	return servers
+	return names
 }
 
 func deploymentTestServer(name string) provisioning.Server {
@@ -1063,6 +1067,14 @@ func TestServerService_DeploymentControlLoopCandidates(t *testing.T) {
 		return server
 	}
 
+	ready := func(name string) provisioning.Server {
+		server := deploying(name)
+		server.Status = api.ServerStatusReady
+		server.StatusDetail = api.ServerStatusDetailNone
+
+		return server
+	}
+
 	tests := []struct {
 		name              string
 		serverNameFilter  *string
@@ -1084,6 +1096,13 @@ func TestServerService_DeploymentControlLoopCandidates(t *testing.T) {
 			servers: []provisioning.Server{deploying("one"), registering("two")},
 
 			wantAdvanced: []string{"one", "two"},
+			assertErr:    require.NoError,
+		},
+		{
+			name:    "success - a server, that has registered and turned ready, is still advanced",
+			servers: []provisioning.Server{ready("one")},
+
+			wantAdvanced: []string{"one"},
 			assertErr:    require.NoError,
 		},
 		{
@@ -1132,7 +1151,7 @@ func TestServerService_DeploymentControlLoopCandidates(t *testing.T) {
 			assertErr: boom.ErrorIs,
 		},
 		{
-			name:           "error - repo.GetAllWithFilter",
+			name:           "error - repo.GetAllNamesWithActiveDeployment",
 			servers:        []provisioning.Server{deploying("one")},
 			repoGetAllErrs: queue.Errs{boom.Error},
 
@@ -1170,7 +1189,7 @@ func TestServerService_DeploymentControlLoopCandidates(t *testing.T) {
 
 					return server, nil
 				},
-				GetAllWithFilterFunc: func(ctx context.Context, filter provisioning.ServerFilter) (provisioning.Servers, error) {
+				GetAllNamesWithActiveDeploymentFunc: func(ctx context.Context) ([]string, error) {
 					recordMu.Lock()
 					defer recordMu.Unlock()
 
@@ -1179,21 +1198,7 @@ func TestServerService_DeploymentControlLoopCandidates(t *testing.T) {
 						return nil, err
 					}
 
-					var matching provisioning.Servers
-
-					for _, server := range store.all() {
-						if ptr.From(filter.Status) != server.Status {
-							continue
-						}
-
-						if filter.StatusDetail != nil && ptr.From(filter.StatusDetail) != server.StatusDetail {
-							continue
-						}
-
-						matching = append(matching, server)
-					}
-
-					return matching, nil
+					return store.namesWithActiveDeployment(), nil
 				},
 				UpdateFunc: func(ctx context.Context, in provisioning.Server) error {
 					store.put(in)

--- a/internal/provisioning/server/server_deployment_test.go
+++ b/internal/provisioning/server/server_deployment_test.go
@@ -134,6 +134,7 @@ func deploymentTestBMCData(virtualMedia ...api.BMCVirtualMedia) api.BMCData {
 var (
 	deploymentTestOpticalMedia = api.BMCVirtualMedia{ID: "system:1", MediaTypes: []string{"CD", "DVD"}}
 	deploymentTestUSBMedia     = api.BMCVirtualMedia{ID: "manager:1", MediaTypes: []string{"USBStick"}}
+	deploymentTestUntypedMedia = api.BMCVirtualMedia{ID: "manager:2"}
 )
 
 func TestServerService_DeployByName(t *testing.T) {
@@ -264,7 +265,42 @@ func TestServerService_DeployByName(t *testing.T) {
 				Seed:           "default",
 				ImageType:      api.ImageTypeISO,
 				Architecture:   images.UpdateFileArchitecture64BitX86,
-				VirtualMediaID: "manager:1",
+				VirtualMediaID: "manager:2",
+			},
+			operationsCenterAddress: deploymentTestOperationsCenterAddress,
+			server:                  new(deploymentTestServer("one")),
+			bmcGetData:              deploymentTestBMCData(deploymentTestUntypedMedia, deploymentTestOpticalMedia),
+			tokenSvcGetByUUID:       validToken,
+			tokenSvcGetSeed:         validSeed,
+			withBIOSProfilePort:     true,
+			biosProfileResolve:      &provisioning.BIOSProfileResolution{},
+
+			wantDeployment: &provisioning.ServerDeployment{
+				State: api.ServerDeploymentStateRefreshBMCData,
+				Request: provisioning.ServerDeploymentRequest{
+					TokenUUID:      tokenUUID,
+					Seed:           "default",
+					ImageType:      api.ImageTypeISO,
+					Architecture:   images.UpdateFileArchitecture64BitX86,
+					VirtualMediaID: "manager:2",
+				},
+				ForceReboot:    true,
+				MediaBytesRead: -1,
+				StartedAt:      deploymentTestDate,
+				StateEnteredAt: deploymentTestDate,
+				History:        []api.ServerDeploymentStep{},
+			},
+			wantStatus: api.ServerStatusDeploying,
+			assertErr:  require.NoError,
+		},
+		{
+			name:    "success - a raw image is attached to the USB device, not the optical one",
+			nameArg: "one",
+			requestArg: provisioning.ServerDeploymentRequest{
+				TokenUUID:    tokenUUID,
+				Seed:         "default",
+				ImageType:    api.ImageTypeRaw,
+				Architecture: images.UpdateFileArchitecture64BitX86,
 			},
 			operationsCenterAddress: deploymentTestOperationsCenterAddress,
 			server:                  new(deploymentTestServer("one")),
@@ -279,7 +315,7 @@ func TestServerService_DeployByName(t *testing.T) {
 				Request: provisioning.ServerDeploymentRequest{
 					TokenUUID:      tokenUUID,
 					Seed:           "default",
-					ImageType:      api.ImageTypeISO,
+					ImageType:      api.ImageTypeRaw,
 					Architecture:   images.UpdateFileArchitecture64BitX86,
 					VirtualMediaID: "manager:1",
 				},
@@ -291,6 +327,38 @@ func TestServerService_DeployByName(t *testing.T) {
 			},
 			wantStatus: api.ServerStatusDeploying,
 			assertErr:  require.NoError,
+		},
+		{
+			name:    "error - the explicitly requested virtual media device does not take the image",
+			nameArg: "one",
+			requestArg: provisioning.ServerDeploymentRequest{
+				TokenUUID:      tokenUUID,
+				Seed:           "default",
+				ImageType:      api.ImageTypeISO,
+				Architecture:   images.UpdateFileArchitecture64BitX86,
+				VirtualMediaID: "manager:1",
+			},
+			operationsCenterAddress: deploymentTestOperationsCenterAddress,
+			server:                  new(deploymentTestServer("one")),
+			bmcGetData:              deploymentTestBMCData(deploymentTestUSBMedia, deploymentTestOpticalMedia),
+			tokenSvcGetByUUID:       validToken,
+			tokenSvcGetSeed:         validSeed,
+
+			wantStatus: api.ServerStatusUnregistered,
+			assertErr:  errassert.OperationNotPermittedErrorContains(`does not accept a "iso" image, it supports USBStick`),
+		},
+		{
+			name:                    "error - no virtual media device takes the image",
+			nameArg:                 "one",
+			requestArg:              validRequest,
+			operationsCenterAddress: deploymentTestOperationsCenterAddress,
+			server:                  new(deploymentTestServer("one")),
+			bmcGetData:              deploymentTestBMCData(deploymentTestUSBMedia),
+			tokenSvcGetByUUID:       validToken,
+			tokenSvcGetSeed:         validSeed,
+
+			wantStatus: api.ServerStatusUnregistered,
+			assertErr:  errassert.OperationNotPermittedErrorContains(`No virtual media device of the BMC accepts a "iso" image, it reports manager:1 (USBStick)`),
 		},
 		{
 			name:                    "success - the first matching virtual media device is selected",

--- a/internal/provisioning/server/server_deployment_test_world_test.go
+++ b/internal/provisioning/server/server_deployment_test_world_test.go
@@ -51,6 +51,11 @@ const (
 	// spending a tick per simulated second.
 	deploymentIdleTick = time.Minute
 
+	// deploymentMaxMediaEjectDelay is how long a server, that has installed and
+	// waits for its media to go before it reboots, may be left waiting. It bounds
+	// the media idle period plus the granularity, at which the fake advances.
+	deploymentMaxMediaEjectDelay = 3 * time.Minute
+
 	deploymentDriveIterations = 400
 )
 
@@ -145,6 +150,9 @@ type bmcWorld struct {
 	// The knobs, that let a row model a BMC or a server behaving differently.
 	dropsMediaOnBoot    bool
 	installDuration     time.Duration
+	postDuration        time.Duration
+	bootGeneration      int
+	bootsMediaAgain     bool
 	ignorePowerOffs     int
 	biosApplyDrops      int
 	secureBootEnrolls   bool
@@ -152,6 +160,8 @@ type bmcWorld struct {
 	noLastResetTime     bool
 	uploadTransfer      bool
 	installViaMediaRead bool
+	cachesMedia         bool
+	mediaEjectDelay     time.Duration
 	mediaFromOtherHost  bool
 	registers           bool
 	registrationDelay   time.Duration
@@ -212,6 +222,13 @@ func (w *bmcWorld) detachedSinceInstall() []string {
 	defer w.mu.Unlock()
 
 	return slices.Clone(w.detachedIDs)
+}
+
+func (w *bmcWorld) mediaEjectedAfter() time.Duration {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.mediaEjectDelay
 }
 
 func (w *bmcWorld) mediaInserted() []string {
@@ -290,15 +307,34 @@ func (w *bmcWorld) bootNow() {
 
 	w.lastResetTime = now
 	w.bootProgress = api.BMCBootProgress{LastState: worldBootProgressEarly, LastStateTime: now}
+	w.bootGeneration++
 
-	w.schedule(worldBootDuration, "boot progress reaches the operating system", func(ctx context.Context, w *bmcWorld) error {
+	postDuration := w.postDurationOrDefault()
+
+	generation := w.bootGeneration
+
+	w.schedule(postDuration, "boot progress reaches the operating system", func(ctx context.Context, w *bmcWorld) error {
 		w.mu.Lock()
 		defer w.mu.Unlock()
+
+		if w.bootGeneration != generation {
+			return nil
+		}
 
 		w.bootProgress = api.BMCBootProgress{LastState: worldBootProgressLate, LastStateTime: w.clock.Now()}
 
 		return nil
 	})
+}
+
+// postDurationOrDefault returns how long the server takes from a reset to the
+// hand over to the operating system. It has to be called with the lock held.
+func (w *bmcWorld) postDurationOrDefault() time.Duration {
+	if w.postDuration == 0 {
+		return worldBootDuration
+	}
+
+	return w.postDuration
 }
 
 // startInstall models booting the installation media: the installer reads the
@@ -330,6 +366,20 @@ func (w *bmcWorld) startInstall() {
 		return
 	}
 
+	// A BMC, that caches the installation media instead of streaming it to the
+	// installer, has read it out while the server boots and stays quiet for the
+	// rest of the installation.
+	if w.cachesMedia {
+		w.schedule(worldMediaReadDuration, "installation media has been read", func(ctx context.Context, w *bmcWorld) error {
+			w.mu.Lock()
+			defer w.mu.Unlock()
+
+			w.recordMediaProgress()
+
+			return nil
+		})
+	}
+
 	// A firmware, that still has something to pick up, reboots the server within
 	// the first POST cycles, long before the installation could be done.
 	if w.rebootsEarly {
@@ -352,8 +402,34 @@ func (w *bmcWorld) startInstall() {
 		w.mu.Lock()
 		defer w.mu.Unlock()
 
-		w.recordMediaProgress()
+		if !w.cachesMedia {
+			w.recordMediaProgress()
+		}
+
 		w.bootNow()
+
+		// A server, that does not fall back to the installed system on its own,
+		// boots the installation media again, where the installer refuses to run
+		// a second time, so the server never registers. Ejecting the media has
+		// the POST of that boot to come through.
+		if w.bootsMediaAgain {
+			w.schedule(w.postDurationOrDefault(), "server picked its boot device", func(ctx context.Context, w *bmcWorld) error {
+				w.mu.Lock()
+				defer w.mu.Unlock()
+
+				media, ok := w.virtualMedia[w.bootDevice]
+				if ok && media.Inserted {
+					return nil
+				}
+
+				w.scheduleRegistration()
+
+				return nil
+			})
+
+			return nil
+		}
+
 		w.scheduleRegistration()
 
 		return nil

--- a/internal/provisioning/server/server_deployment_test_world_test.go
+++ b/internal/provisioning/server/server_deployment_test_world_test.go
@@ -6,9 +6,11 @@ import (
 	"crypto/tls"
 	"io"
 	"maps"
+	"net/url"
 	"os"
 	"path"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -129,10 +131,10 @@ type bmcWorld struct {
 
 	secureBootPending bool
 
-	mediaProgress   map[string]provisioning.SeedImageProgress
-	mediaReadStart  time.Time
-	mediaProgressID provisioning.SeedImageID
-	mediaResets     int
+	mediaProgress     map[string]provisioning.SeedImageProgress
+	mediaReadStart    time.Time
+	mediaDeploymentID string
+	mediaResets       int
 
 	register func(ctx context.Context) error
 
@@ -375,18 +377,12 @@ func (w *bmcWorld) scheduleRegistration() {
 
 // recordMediaProgress has to be called with the lock held.
 func (w *bmcWorld) recordMediaProgress() {
-	if w.mediaProgressID.FingerprintID == "" {
+	if w.mediaDeploymentID == "" {
 		return
 	}
 
-	source := provisioning.SeedImageSource(worldBMCHost)
-	if w.mediaFromOtherHost {
-		source = provisioning.SeedImageSource("192.168.1.101")
-	}
-
-	w.mediaProgress[source] = provisioning.SeedImageProgress{
-		ImageID:      w.mediaProgressID,
-		Source:       source,
+	w.mediaProgress[w.mediaDeploymentID] = provisioning.SeedImageProgress{
+		DeploymentID: w.mediaDeploymentID,
 		Size:         worldMediaSize,
 		BytesServed:  worldMediaSize,
 		BytesCovered: worldMediaSize,
@@ -618,6 +614,8 @@ func deploymentBMCClient(t *testing.T, world *bmcWorld) *adapterMock.BMCServerCl
 				world.bootDevice = virtualMediaID
 			}
 
+			world.mediaDeploymentID = deploymentIDFromMediaURL(t, mediaURL)
+
 			return monitor(world), nil
 		},
 
@@ -690,40 +688,38 @@ func deploymentBMCClient(t *testing.T, world *bmcWorld) *adapterMock.BMCServerCl
 	}
 }
 
+func deploymentIDFromMediaURL(t *testing.T, mediaURL string) string {
+	t.Helper()
+
+	parsed, err := url.Parse(mediaURL)
+	require.NoError(t, err)
+
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+
+	i := slices.Index(segments, "deployment")
+	require.NotEqual(t, -1, i, "the media URL names no deployment: %s", mediaURL)
+	require.Less(t, i+1, len(segments), "the media URL names no deployment: %s", mediaURL)
+
+	return segments[i+1]
+}
+
 func deploymentSeedImageProgressPort(world *bmcWorld) *adapterMock.SeedImageProgressPortMock {
 	return &adapterMock.SeedImageProgressPortMock{
-		GetFunc: func(ctx context.Context, imageID provisioning.SeedImageID, source string) (provisioning.SeedImageProgress, bool) {
+		GetFunc: func(ctx context.Context, deploymentID string) (provisioning.SeedImageProgress, bool) {
 			world.mu.Lock()
 			defer world.mu.Unlock()
 
-			progress, ok := world.mediaProgress[source]
-			if !ok || progress.ImageID != imageID {
-				return provisioning.SeedImageProgress{}, false
-			}
+			progress, ok := world.mediaProgress[deploymentID]
 
-			return progress, true
+			return progress, ok
 		},
-		GetByImageFunc: func(ctx context.Context, imageID provisioning.SeedImageID) []provisioning.SeedImageProgress {
-			world.mu.Lock()
-			defer world.mu.Unlock()
-
-			var recorded []provisioning.SeedImageProgress
-
-			for _, source := range slices.Sorted(maps.Keys(world.mediaProgress)) {
-				if world.mediaProgress[source].ImageID == imageID {
-					recorded = append(recorded, world.mediaProgress[source])
-				}
-			}
-
-			return recorded
-		},
-		ResetFunc: func(ctx context.Context, imageID provisioning.SeedImageID) {
+		ResetFunc: func(ctx context.Context, deploymentID string) {
 			world.mu.Lock()
 			defer world.mu.Unlock()
 
 			world.mediaResets++
-			world.mediaProgressID = imageID
-			world.mediaProgress = map[string]provisioning.SeedImageProgress{}
+
+			delete(world.mediaProgress, deploymentID)
 		},
 	}
 }

--- a/internal/provisioning/server/server_deployment_test_world_test.go
+++ b/internal/provisioning/server/server_deployment_test_world_test.go
@@ -63,6 +63,7 @@ const (
 	worldEarlyRebootDelay    = 4 * time.Minute
 	worldMediaReadDuration   = 5 * time.Minute
 	worldRegistrationDelay   = 2 * time.Minute
+	worldEjectDelay          = 30 * time.Second
 	worldMediaSize           = 4 * config.ServerDeploymentMediaMinBytesRead
 )
 
@@ -159,6 +160,7 @@ type bmcWorld struct {
 	awaitingPowerOn     bool
 	powerOffErrs        queue.Errs
 	attachMediaErrs     queue.Errs
+	ejectDelay          time.Duration
 }
 
 func newBMCWorld(t *testing.T, clock *testClock, opts ...func(*bmcWorld)) *bmcWorld {
@@ -626,14 +628,34 @@ func deploymentBMCClient(t *testing.T, world *bmcWorld) *adapterMock.BMCServerCl
 			world.calls["DetachMedia"]++
 			world.detachedIDs = append(world.detachedIDs, virtualMediaID)
 
-			media := world.virtualMedia[virtualMediaID]
-			media.Inserted = false
-			media.Image = ""
-			media.ImageName = ""
-			world.virtualMedia[virtualMediaID] = media
+			lastRead := world.mediaProgress[world.mediaDeploymentID].LastRead
+			if !lastRead.IsZero() {
+				world.mediaEjectDelay = world.clock.Now().Sub(lastRead)
+			}
 
-			if world.bootDevice == virtualMediaID {
-				world.bootDevice = ""
+			eject := func(w *bmcWorld) {
+				media := w.virtualMedia[virtualMediaID]
+				media.Inserted = false
+				media.Image = ""
+				media.ImageName = ""
+				w.virtualMedia[virtualMediaID] = media
+
+				if w.bootDevice == virtualMediaID {
+					w.bootDevice = ""
+				}
+			}
+
+			if world.ejectDelay > 0 {
+				world.schedule(world.ejectDelay, "media of "+virtualMediaID+" ejected", func(ctx context.Context, w *bmcWorld) error {
+					w.mu.Lock()
+					defer w.mu.Unlock()
+
+					eject(w)
+
+					return nil
+				})
+			} else {
+				eject(world)
 			}
 
 			// A server, that does not reboot on its own when the first stage of

--- a/internal/provisioning/server/server_service.go
+++ b/internal/provisioning/server/server_service.go
@@ -2893,7 +2893,7 @@ func (s *serverService) BMCDumpByName(ctx context.Context, name string, addition
 }
 
 func (s *serverService) BMCAttachMediaByName(ctx context.Context, name string, media api.ServerBMCAttachMedia) error {
-	_, err := s.bmcAttachMediaByName(ctx, name, media, true)
+	_, err := s.bmcAttachMediaByName(ctx, name, media, "", true)
 
 	return err
 }
@@ -2905,7 +2905,7 @@ type bmcAttachedMedia struct {
 }
 
 // bmcAttachMediaByName skips awaiting the task monitor in the background, if wait is false.
-func (s *serverService) bmcAttachMediaByName(ctx context.Context, name string, media api.ServerBMCAttachMedia, wait bool) (bmcAttachedMedia, error) {
+func (s *serverService) bmcAttachMediaByName(ctx context.Context, name string, media api.ServerBMCAttachMedia, deploymentID string, wait bool) (bmcAttachedMedia, error) {
 	if name == "" {
 		return bmcAttachedMedia{}, fmt.Errorf("Server name cannot be empty: %w", domain.ErrOperationNotPermitted)
 	}
@@ -2973,7 +2973,7 @@ func (s *serverService) bmcAttachMediaByName(ctx context.Context, name string, m
 
 	segments := append(
 		[]string{"1.0", "provisioning", "tokens", tokenUUID.String(), "seeds", seed.Name},
-		api.TokenSeedPreparedImagePathSegments(imageType, architecture, media.Channel, fingerprintID)...,
+		api.TokenSeedPreparedImagePathSegments(imageType, architecture, media.Channel, deploymentID, fingerprintID)...,
 	)
 
 	imageURL := baseURL.JoinPath(segments...)

--- a/internal/provisioning/server_deployment_model.go
+++ b/internal/provisioning/server_deployment_model.go
@@ -158,6 +158,13 @@ type ServerDeployment struct {
 	// given a boot to pick them up, before the installation is started.
 	SecureBootPending bool `json:"secure_boot_pending"`
 
+	// SecureBootAttempted records, that the enrollment of the secure boot
+	// certificates has been issued at least once. It is persisted before the
+	// enrollment runs, since the BMC reports the key databases as applied
+	// afterwards, so a re-issued enrollment can not tell an earlier attempt,
+	// that wrote them, apart from a server, that held them all along.
+	SecureBootAttempted bool `json:"secure_boot_attempted"`
+
 	// MediaURL is the installation media, as it is handed to the BMC, while
 	// ImageCacheID and ImageFingerprintID address the generated media, so the
 	// read progress recorded for it can be looked up.

--- a/internal/provisioning/server_deployment_model.go
+++ b/internal/provisioning/server_deployment_model.go
@@ -1,7 +1,6 @@
 package provisioning
 
 import (
-	"net/url"
 	"slices"
 	"time"
 
@@ -166,11 +165,9 @@ type ServerDeployment struct {
 	SecureBootAttempted bool `json:"secure_boot_attempted"`
 
 	// MediaURL is the installation media, as it is handed to the BMC, while
-	// ImageCacheID and ImageFingerprintID address the generated media, so the
-	// read progress recorded for it can be looked up.
-	MediaURL           string `json:"media_url"`
-	ImageCacheID       string `json:"image_cache_id"`
-	ImageFingerprintID string `json:"image_fingerprint_id"`
+	// ImageDeploymentID names this deployment reading the generated media.
+	MediaURL          string `json:"media_url"`
+	ImageDeploymentID string `json:"image_deployment_id"`
 
 	// BIOSTaskMonitor holds the URI of the BMC task monitor of the application
 	// of the BIOS attributes. It is kept, since the server is powered on before
@@ -246,31 +243,6 @@ func (d *ServerDeployment) transition(now time.Time, state api.ServerDeploymentS
 	if state.IsTerminal() {
 		d.FinishedAt = now
 	}
-}
-
-// SeedImageID returns the identity of the generated installation media of the
-// deployment. It is only set once the media has been attached.
-func (d ServerDeployment) SeedImageID() SeedImageID {
-	return SeedImageID{
-		CacheID:       d.ImageCacheID,
-		FingerprintID: d.ImageFingerprintID,
-	}
-}
-
-// BMCSource returns the address, the BMC of the server is expected to read the
-// installation media from.
-func (s Server) BMCSource() string {
-	endpoint := s.BMCConfig.Endpoint
-	if endpoint == "" {
-		return ""
-	}
-
-	endpointURL, err := url.Parse(endpoint)
-	if err != nil || endpointURL.Host == "" {
-		return SeedImageSource(endpoint)
-	}
-
-	return SeedImageSource(endpointURL.Host)
 }
 
 func (d ServerDeployment) ToAPI() *api.ServerDeploymentStatus {

--- a/internal/provisioning/server_deployment_model.go
+++ b/internal/provisioning/server_deployment_model.go
@@ -184,6 +184,13 @@ type ServerDeployment struct {
 	MediaBytesRead int64 `json:"media_bytes_read"`
 	MediaSize      int64 `json:"media_size"`
 
+	// InstallOSObserved records, that the BMC has reported the server past the
+	// hand over to the operating system since the install wait was anchored, so
+	// the installer has been running. It is what tells the reboot at the end of
+	// the first stage apart from the one the firmware performs within the POST
+	// cycles of the boot, that is supposed to start the installer.
+	InstallOSObserved bool `json:"install_os_observed"`
+
 	// SecureBootSnapshot and InstallSnapshot hold the reboot relevant BMC
 	// properties, as they were observed on the boot, that lets the firmware pick
 	// the enrolled certificates up, respectively on entering the install wait.

--- a/internal/provisioning/server_deployment_model_test.go
+++ b/internal/provisioning/server_deployment_model_test.go
@@ -169,46 +169,6 @@ func TestServerDeployment_EnterState(t *testing.T) {
 	require.Equal(t, entered.Add(3*time.Minute), deployment.FinishedAt)
 }
 
-func TestServer_BMCSource(t *testing.T) {
-	tests := []struct {
-		name     string
-		endpoint string
-
-		want string
-	}{
-		{
-			name:     "host and port",
-			endpoint: "https://192.168.1.10:443",
-			want:     "192.168.1.10",
-		},
-		{
-			name:     "host only",
-			endpoint: "https://bmc.local",
-			want:     "bmc.local",
-		},
-		{
-			name:     "IPv6",
-			endpoint: "https://[2001:db8::1]:8443",
-			want:     "2001:db8::1",
-		},
-		{
-			name:     "no endpoint",
-			endpoint: "",
-			want:     "",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			server := provisioning.Server{
-				BMCConfig: api.BMCConfig{Endpoint: tc.endpoint},
-			}
-
-			require.Equal(t, tc.want, server.BMCSource())
-		})
-	}
-}
-
 func TestServerDeploymentBMCSnapshot(t *testing.T) {
 	taken := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
 	reset := taken.Add(-time.Hour)

--- a/internal/provisioning/server_expr_gen.go
+++ b/internal/provisioning/server_expr_gen.go
@@ -488,8 +488,7 @@ type ExprServerDeployment struct {
 	SecureBootPending      bool                            `json:"secure_boot_pending" expr:"secure_boot_pending"`
 	SecureBootAttempted    bool                            `json:"secure_boot_attempted" expr:"secure_boot_attempted"`
 	MediaURL               string                          `json:"media_url" expr:"media_url"`
-	ImageCacheID           string                          `json:"image_cache_id" expr:"image_cache_id"`
-	ImageFingerprintID     string                          `json:"image_fingerprint_id" expr:"image_fingerprint_id"`
+	ImageDeploymentID      string                          `json:"image_deployment_id" expr:"image_deployment_id"`
 	BIOSTaskMonitor        string                          `json:"bios_task_monitor" expr:"bios_task_monitor"`
 	FallbackAttempts       int                             `json:"fallback_attempts" expr:"fallback_attempts"`
 	MediaBytesRead         int64                           `json:"media_bytes_read" expr:"media_bytes_read"`
@@ -1103,8 +1102,7 @@ func ToExprServerDeployment(s ServerDeployment) ExprServerDeployment {
 		SecureBootPending:      s.SecureBootPending,
 		SecureBootAttempted:    s.SecureBootAttempted,
 		MediaURL:               s.MediaURL,
-		ImageCacheID:           s.ImageCacheID,
-		ImageFingerprintID:     s.ImageFingerprintID,
+		ImageDeploymentID:      s.ImageDeploymentID,
 		BIOSTaskMonitor:        s.BIOSTaskMonitor,
 		FallbackAttempts:       s.FallbackAttempts,
 		MediaBytesRead:         s.MediaBytesRead,

--- a/internal/provisioning/server_expr_gen.go
+++ b/internal/provisioning/server_expr_gen.go
@@ -486,6 +486,7 @@ type ExprServerDeployment struct {
 	BIOSPending            bool                            `json:"bios_pending" expr:"bios_pending"`
 	BIOSDeferredPending    bool                            `json:"bios_deferred_pending" expr:"bios_deferred_pending"`
 	SecureBootPending      bool                            `json:"secure_boot_pending" expr:"secure_boot_pending"`
+	SecureBootAttempted    bool                            `json:"secure_boot_attempted" expr:"secure_boot_attempted"`
 	MediaURL               string                          `json:"media_url" expr:"media_url"`
 	ImageCacheID           string                          `json:"image_cache_id" expr:"image_cache_id"`
 	ImageFingerprintID     string                          `json:"image_fingerprint_id" expr:"image_fingerprint_id"`
@@ -1100,6 +1101,7 @@ func ToExprServerDeployment(s ServerDeployment) ExprServerDeployment {
 		BIOSPending:            s.BIOSPending,
 		BIOSDeferredPending:    s.BIOSDeferredPending,
 		SecureBootPending:      s.SecureBootPending,
+		SecureBootAttempted:    s.SecureBootAttempted,
 		MediaURL:               s.MediaURL,
 		ImageCacheID:           s.ImageCacheID,
 		ImageFingerprintID:     s.ImageFingerprintID,

--- a/internal/provisioning/server_expr_gen.go
+++ b/internal/provisioning/server_expr_gen.go
@@ -493,6 +493,7 @@ type ExprServerDeployment struct {
 	FallbackAttempts       int                             `json:"fallback_attempts" expr:"fallback_attempts"`
 	MediaBytesRead         int64                           `json:"media_bytes_read" expr:"media_bytes_read"`
 	MediaSize              int64                           `json:"media_size" expr:"media_size"`
+	InstallOSObserved      bool                            `json:"install_os_observed" expr:"install_os_observed"`
 	SecureBootSnapshot     ExprServerDeploymentBMCSnapshot `json:"secure_boot_snapshot" expr:"secure_boot_snapshot"`
 	InstallSnapshot        ExprServerDeploymentBMCSnapshot `json:"install_snapshot" expr:"install_snapshot"`
 	Retries                int                             `json:"retries" expr:"retries"`
@@ -1107,6 +1108,7 @@ func ToExprServerDeployment(s ServerDeployment) ExprServerDeployment {
 		FallbackAttempts:       s.FallbackAttempts,
 		MediaBytesRead:         s.MediaBytesRead,
 		MediaSize:              s.MediaSize,
+		InstallOSObserved:      s.InstallOSObserved,
 		SecureBootSnapshot:     ToExprServerDeploymentBMCSnapshot(s.SecureBootSnapshot),
 		InstallSnapshot:        ToExprServerDeploymentBMCSnapshot(s.InstallSnapshot),
 		Retries:                s.Retries,

--- a/internal/provisioning/server_ports.go
+++ b/internal/provisioning/server_ports.go
@@ -80,6 +80,7 @@ type ServerRepo interface {
 	GetAllWithFilter(ctx context.Context, filter ServerFilter) (Servers, error)
 	GetAllNames(ctx context.Context) ([]string, error)
 	GetAllNamesWithFilter(ctx context.Context, filter ServerFilter) ([]string, error)
+	GetAllNamesWithActiveDeployment(ctx context.Context) ([]string, error)
 	GetByName(ctx context.Context, name string) (*Server, error)
 	GetByCertificate(ctx context.Context, certificatePEM string) (*Server, error)
 	GetBySystemUUID(ctx context.Context, systemUUID string) (*Server, error)

--- a/internal/provisioning/token_model.go
+++ b/internal/provisioning/token_model.go
@@ -182,6 +182,16 @@ func SeedImageCacheID(id uuid.UUID, name string, imageType api.ImageType, archit
 	return base64.RawURLEncoding.EncodeToString(sum[:])[:SeedImageCacheIDLength]
 }
 
+// NewSeedImageDeploymentID returns an ID, that tells one deployment reading a
+// generated image apart from every other reader of the very same image. It is
+// taken once per deployment, so a re-issued attachment addresses the media by
+// the very same URL.
+func NewSeedImageDeploymentID() string {
+	sum := sha256.Sum256([]byte(uuid.New().String()))
+
+	return base64.RawURLEncoding.EncodeToString(sum[:])[:SeedImageCacheIDLength]
+}
+
 // SeedImageFingerprintID returns the ID of a pre-seeded image generated from
 // the given fingerprint.
 //

--- a/internal/util/testing/log/match.go
+++ b/internal/util/testing/log/match.go
@@ -70,6 +70,14 @@ func Contains(want string) func(t TestifyT, logBuf *bytes.Buffer) {
 	}
 }
 
+func NotContains(unwanted string) func(t TestifyT, logBuf *bytes.Buffer) {
+	return func(t TestifyT, logBuf *bytes.Buffer) {
+		t.Helper()
+
+		require.NotContains(t, logBuf.String(), unwanted)
+	}
+}
+
 func Match(expr string) func(t TestifyT, logBuf *bytes.Buffer) {
 	return func(t TestifyT, logBuf *bytes.Buffer) {
 		t.Helper()

--- a/shared/api/provisioning_server_bmc.go
+++ b/shared/api/provisioning_server_bmc.go
@@ -175,6 +175,16 @@ var bmcBootProgressOrder = []string{
 // only reached once the firmware handed over to the operating system.
 const bmcBootProgressLateState = "OSBootStarted"
 
+// BMCBootProgressHandedOverToOS reports, if a boot progress state is one, that
+// is only reached once the firmware handed over to the operating system. A state
+// carrying no ordering information is not one of them.
+func BMCBootProgressHandedOverToOS(state string) bool {
+	index := slices.Index(bmcBootProgressOrder, state)
+	lateIndex := slices.Index(bmcBootProgressOrder, bmcBootProgressLateState)
+
+	return index >= 0 && index >= lateIndex
+}
+
 // BMCHasRebootedSince reports, if the server has rebooted since the given time,
 // by comparing a previous BMC data snapshot with the current one. Since neither
 // of the required properties is supported by every BMC, the outcome is

--- a/shared/api/provisioning_server_bmc_test.go
+++ b/shared/api/provisioning_server_bmc_test.go
@@ -9,6 +9,28 @@ import (
 	"github.com/FuturFusion/operations-center/shared/api"
 )
 
+func TestBMCBootProgressHandedOverToOS(t *testing.T) {
+	tests := []struct {
+		name  string
+		state string
+
+		want bool
+	}{
+		{name: "no state reported", state: "", want: false},
+		{name: "the firmware is still initializing", state: "PrimaryProcessorInitializationStarted", want: false},
+		{name: "the last state before the hand over", state: "SetupEntered", want: false},
+		{name: "the operating system is being started", state: "OSBootStarted", want: true},
+		{name: "the operating system is running", state: "OSRunning", want: true},
+		{name: "a state carrying no ordering information", state: "OEM", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, api.BMCBootProgressHandedOverToOS(tc.state), "only a boot, that got as far as starting the operating system, has run the installer")
+		})
+	}
+}
+
 func TestBMCHasRebootedSince(t *testing.T) {
 	since := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
 

--- a/shared/api/provisioning_server_deployment.go
+++ b/shared/api/provisioning_server_deployment.go
@@ -48,7 +48,9 @@ type ServerDeploymentPost struct {
 	// Force requests, that a token seed, which does not reboot the server upon
 	// completion of the installation ("force_reboot"), is accepted. The
 	// deployment then relies on the read progress of the installation media
-	// alone to tell, when the first stage of the installation is done.
+	// alone to tell, when the first stage of the installation is done, so it
+	// needs a virtual media device, that streams the media rather than uploading
+	// it before the server boots.
 	// Example: false
 	Force bool `json:"force" yaml:"force"`
 

--- a/shared/api/provisioning_server_deployment.go
+++ b/shared/api/provisioning_server_deployment.go
@@ -38,9 +38,10 @@ type ServerDeploymentPost struct {
 
 	// VirtualMediaID identifies the virtual media device the installation media
 	// is attached to, using the "<service>:<bmc-id>" notation (e.g. "system:1").
-	// Optional, the first virtual media device advertising CD or DVD support is
-	// picked automatically, if it is left empty, the ones offered by the system
-	// taking precedence over the ones offered by the manager.
+	// Optional, the first virtual media device advertising support for the
+	// requested image type is picked automatically, if it is left empty (CD or
+	// DVD for an ISO image, USB stick or floppy for a raw one), the ones offered
+	// by the system taking precedence over the ones offered by the manager.
 	// Example: system:1
 	VirtualMediaID string `json:"virtual_media_id" yaml:"virtual_media_id"`
 

--- a/shared/api/provisioning_server_deployment.go
+++ b/shared/api/provisioning_server_deployment.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"slices"
 	"time"
 )
 
@@ -255,14 +256,23 @@ func (s ServerDeploymentState) String() string {
 	return string(s)
 }
 
+// serverDeploymentTerminalStates are the states, in which no further step is
+// performed for a deployment.
+var serverDeploymentTerminalStates = []ServerDeploymentState{
+	ServerDeploymentStateCompleted,
+	ServerDeploymentStateFailed,
+	ServerDeploymentStateCancelled,
+}
+
+// ServerDeploymentTerminalStates returns the states, in which no further step is
+// performed for a deployment.
+func ServerDeploymentTerminalStates() []ServerDeploymentState {
+	return slices.Clone(serverDeploymentTerminalStates)
+}
+
 // IsTerminal reports, if no further step is performed for a deployment in this state.
 func (s ServerDeploymentState) IsTerminal() bool {
-	switch s {
-	case ServerDeploymentStateCompleted, ServerDeploymentStateFailed, ServerDeploymentStateCancelled:
-		return true
-	}
-
-	return false
+	return slices.Contains(serverDeploymentTerminalStates, s)
 }
 
 // MarshalText implements the encoding.TextMarshaler interface.

--- a/shared/api/provisioning_token.go
+++ b/shared/api/provisioning_token.go
@@ -112,23 +112,33 @@ func (i ImageType) UpdateFileType() images.UpdateFileType {
 // media extension, for the sake of BMC firmware that validates the format of
 // the virtual media Image URI.
 func TokenSeedImagePathSegments(imageType ImageType, architecture images.UpdateFileArchitecture, channel string) []string {
-	return tokenSeedImagePathSegments(imageType, architecture, channel, "file")
+	return tokenSeedImagePathSegments(imageType, architecture, channel, "", "file")
 }
 
 // TokenSeedPreparedImagePathSegments returns the path segments addressing one
 // already generated pre-seeded image of a token seed, e.g.
 // "architecture/x86_64/channel/stable/type/iso/a1B2c3D4e5F6.iso".
-func TokenSeedPreparedImagePathSegments(imageType ImageType, architecture images.UpdateFileArchitecture, channel string, fingerprintID string) []string {
-	return tokenSeedImagePathSegments(imageType, architecture, channel, fingerprintID)
+//
+// A non empty deploymentID adds a "deployment/<id>" pair, e.g.
+// "architecture/x86_64/deployment/f6E5d4C3b2A1/type/iso/a1B2c3D4e5F6.iso". It
+// does not address anything, the very same image is served with and without it.
+// It only lets the server tell the deployment reading the image apart from every
+// other reader of the same bytes.
+func TokenSeedPreparedImagePathSegments(imageType ImageType, architecture images.UpdateFileArchitecture, channel string, deploymentID string, fingerprintID string) []string {
+	return tokenSeedImagePathSegments(imageType, architecture, channel, deploymentID, fingerprintID)
 }
 
-func tokenSeedImagePathSegments(imageType ImageType, architecture images.UpdateFileArchitecture, channel string, filename string) []string {
+func tokenSeedImagePathSegments(imageType ImageType, architecture images.UpdateFileArchitecture, channel string, deploymentID string, filename string) []string {
 	segments := []string{
 		"architecture", architecture.String(),
 	}
 
 	if channel != "" {
 		segments = append(segments, "channel", url.PathEscape(channel))
+	}
+
+	if deploymentID != "" {
+		segments = append(segments, "deployment", url.PathEscape(deploymentID))
 	}
 
 	segments = append(

--- a/shared/api/provisioning_token_test.go
+++ b/shared/api/provisioning_token_test.go
@@ -62,3 +62,52 @@ func TestTokenSeedImagePathSegments(t *testing.T) {
 		})
 	}
 }
+
+func TestTokenSeedPreparedImagePathSegments(t *testing.T) {
+	tests := []struct {
+		name string
+
+		imageType    api.ImageType
+		architecture images.UpdateFileArchitecture
+		channel      string
+		deploymentID string
+
+		wantPath string
+	}{
+		{
+			name: "without a deployment",
+
+			imageType:    api.ImageTypeISO,
+			architecture: images.UpdateFileArchitecture64BitX86,
+
+			wantPath: "architecture/x86_64/type/iso/a1B2c3D4e5F6.iso",
+		},
+		{
+			name: "with a deployment",
+
+			imageType:    api.ImageTypeISO,
+			architecture: images.UpdateFileArchitecture64BitX86,
+			channel:      "stable",
+			deploymentID: "f6E5d4C3b2A1",
+
+			wantPath: "architecture/x86_64/channel/stable/deployment/f6E5d4C3b2A1/type/iso/a1B2c3D4e5F6.iso",
+		},
+		{
+			name: "a raw image of a deployment",
+
+			imageType:    api.ImageTypeRaw,
+			architecture: images.UpdateFileArchitecture64BitARM,
+			deploymentID: "f6E5d4C3b2A1",
+
+			wantPath: "architecture/aarch64/deployment/f6E5d4C3b2A1/type/raw/a1B2c3D4e5F6.raw",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			segments := api.TokenSeedPreparedImagePathSegments(tc.imageType, tc.architecture, tc.channel, tc.deploymentID, "a1B2c3D4e5F6")
+
+			require.Equal(t, tc.wantPath, path.Join(segments...))
+		})
+	}
+}


### PR DESCRIPTION
Fixes:

* Wait for media ejection before completing cancellation
* Preserve secure-boot changes across action retries
* Choose media slots based on the requested image type
* Reject force mode for uploaded virtual media
* Resume active deployments after registration
* Isolate progress resets per deployment
* Improvements for end of first installation phase detection
